### PR TITLE
Add markdown support for list text custom fields

### DIFF
--- a/.agents/skills/plugins-guide/SKILL.md
+++ b/.agents/skills/plugins-guide/SKILL.md
@@ -237,7 +237,19 @@ Avoid custom fallbacks like `--text-primary` or `prefers-color-scheme` blocks.
 
 ---
 
-## 11. Panel Context for Chat Input
+## 11. Shared Dialog Styling Duplication
+
+Some dialogs are rendered by shared web-client controllers but styled in multiple plugin bundles.
+For example, list metadata dialog styles live in both:
+- `packages/plugins/official/lists/web/styles.css`
+- `packages/plugins/official/notes/web/styles.css`
+
+When adjusting `.list-metadata-*` rules (or similar shared dialog styles), update both files to keep
+Lists and Notes consistent.
+
+---
+
+## 12. Panel Context for Chat Input
 
 Panels can provide context that is injected into user chat messages and shown in the
 context preview above the input. Use the panel context key and include selection data.
@@ -272,7 +284,7 @@ services.notifyContextAvailabilityChange();
 
 ---
 
-## 12. Recommended Panel Lifecycle
+## 13. Recommended Panel Lifecycle
 
 On mount:
 - fetch instances via HTTP

--- a/docs/design/custom-field-markdown.md
+++ b/docs/design/custom-field-markdown.md
@@ -1,0 +1,39 @@
+# Custom field markdown rendering
+
+## Summary
+Add an optional `markdown` flag on text custom fields. When enabled, list rows render that field as markdown and show the same overflow preview popup used by notes.
+
+## Goals
+- Let list creators mark text custom fields as markdown-capable.
+- Render markdown in list rows for those fields.
+- Reuse the existing notes overflow popup behavior.
+
+## Non-goals
+- No new markdown editing UI beyond the existing text inputs.
+- No changes to sorting/search semantics for custom fields.
+
+## Data model
+- Extend `ListCustomFieldDefinition` with optional `markdown?: boolean`.
+- Persist this flag in list metadata (server store already passes through custom fields).
+- Parse/normalize the flag in the lists web client.
+
+## UI changes
+- In the list metadata dialog, show a "Render as markdown" checkbox when `type === 'text'`.
+- Hide/disable the checkbox for non-text types. When type changes away from text, clear the flag.
+
+## Rendering changes
+- In `ListPanelTableController`, detect `field.type === 'text' && field.markdown === true`.
+- Render markdown using `applyMarkdownToElement` in the cell (similar to notes).
+- Reuse the notes overflow logic (fade + hover trigger + popup) with the same popup UI.
+- Keep `formatCustomFieldValue` for search indexing/visibility decisions (use raw text).
+
+## Styles
+- Add styles for the markdown checkbox row in list metadata dialog.
+- If new classes are introduced for custom markdown cells, extend the existing notes styles to cover them; otherwise reuse the notes classes directly.
+
+## Tests
+- Update list metadata dialog tests to assert markdown flag persists in `customFields` payload.
+- Add a list panel table test verifying markdown rendering in a custom text field (e.g., heading becomes `<h1>`).
+
+## Open questions
+- Should the markdown checkbox be exposed for multi-line text fields only (if we add them later)?

--- a/packages/plugins/official/lists/server/types.ts
+++ b/packages/plugins/official/lists/server/types.ts
@@ -59,6 +59,10 @@ export interface ListCustomFieldDefinition {
    * For select fields, the list of allowed option values.
    */
   options?: string[];
+  /**
+   * For text fields, whether values should render as markdown.
+   */
+  markdown?: boolean;
 }
 
 export interface ListsData {

--- a/packages/plugins/official/lists/web/index.ts
+++ b/packages/plugins/official/lists/web/index.ts
@@ -331,7 +331,14 @@ function parseCustomFields(value: unknown): ListCustomFieldDefinition[] | undefi
         options = undefined;
       }
     }
-    result.push({ key, label, type: type as ListCustomFieldDefinition['type'], options });
+    const markdown = type === 'text' && obj['markdown'] === true;
+    result.push({
+      key,
+      label,
+      type: type as ListCustomFieldDefinition['type'],
+      options,
+      ...(markdown ? { markdown: true } : {}),
+    });
   }
   return result.length > 0 ? result : undefined;
 }

--- a/packages/plugins/official/lists/web/styles.css
+++ b/packages/plugins/official/lists/web/styles.css
@@ -3029,6 +3029,21 @@ button.list-item-menu-checkbox {
   width: 100%;
 }
 
+.list-metadata-custom-field-markdown {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.list-metadata-custom-field-markdown-label {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  cursor: pointer;
+}
+
 .list-metadata-custom-field-actions {
   display: flex;
   justify-content: flex-end;

--- a/packages/plugins/official/notes/web/styles.css
+++ b/packages/plugins/official/notes/web/styles.css
@@ -2929,6 +2929,21 @@ button.list-item-menu-checkbox {
   width: 100%;
 }
 
+.list-metadata-custom-field-markdown {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.list-metadata-custom-field-markdown-label {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  cursor: pointer;
+}
+
 .list-metadata-custom-field-actions {
   display: flex;
   justify-content: flex-end;

--- a/packages/web-client/src/controllers/listCustomFields.ts
+++ b/packages/web-client/src/controllers/listCustomFields.ts
@@ -12,4 +12,5 @@ export interface ListCustomFieldDefinition {
   label: string;
   type: ListCustomFieldType;
   options?: string[];
+  markdown?: boolean;
 }

--- a/packages/web-client/src/controllers/listItemEditorDialog.ts
+++ b/packages/web-client/src/controllers/listItemEditorDialog.ts
@@ -63,7 +63,7 @@ export class ListItemEditorDialog {
 
     const fieldInputs: Array<{
       definition: ListCustomFieldDefinition;
-      input: HTMLInputElement | HTMLSelectElement;
+      input: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
     }> = [];
 
     for (const def of normalized) {
@@ -82,7 +82,7 @@ export class ListItemEditorDialog {
       const fieldLabel = document.createElement('label');
       fieldLabel.textContent = label;
 
-      let input: HTMLInputElement | HTMLSelectElement;
+      let input: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
       const type = def.type;
 
       if (type === 'checkbox') {
@@ -125,6 +125,11 @@ export class ListItemEditorDialog {
           }
         }
         input = select;
+      } else if (type === 'text' && def.markdown === true) {
+        const textarea = document.createElement('textarea');
+        textarea.className = 'list-item-form-textarea';
+        textarea.rows = 3;
+        input = textarea;
       } else {
         input = document.createElement('input');
         input.type = 'text';

--- a/packages/web-client/src/controllers/listMetadataDialog.test.ts
+++ b/packages/web-client/src/controllers/listMetadataDialog.test.ts
@@ -205,6 +205,76 @@ describe('ListMetadataDialog tag chips', () => {
     ]);
   });
 
+  it('includes markdown flag for text custom fields', async () => {
+    const dialogManager = new DialogManager();
+    const getAllKnownTags = vi.fn(() => []);
+    const createList = vi.fn(async () => true);
+
+    const controller = new ListMetadataDialog({
+      dialogManager,
+      getAllKnownTags,
+      createList,
+      updateList: vi.fn(async () => true),
+      deleteList: vi.fn(async () => true),
+    });
+
+    controller.open('create');
+
+    const nameInput = document.querySelector<HTMLInputElement>(
+      '.list-metadata-dialog input.list-item-form-input',
+    );
+    expect(nameInput).not.toBeNull();
+    if (!nameInput) return;
+    nameInput.value = 'Markdown Fields';
+
+    const addButton = document.querySelector<HTMLButtonElement>(
+      '.list-metadata-custom-field-add-button',
+    );
+    expect(addButton).not.toBeNull();
+    addButton?.click();
+
+    const row = document.querySelector<HTMLElement>('.list-metadata-custom-field-row');
+    expect(row).not.toBeNull();
+    if (!row) return;
+
+    const labelInput = row.querySelector<HTMLInputElement>(
+      '.list-metadata-custom-field-label-input',
+    );
+    const keyInput = row.querySelector<HTMLInputElement>('.list-metadata-custom-field-key-input');
+    const markdownInput = row.querySelector<HTMLInputElement>(
+      '.list-metadata-custom-field-markdown-input',
+    );
+
+    expect(labelInput).not.toBeNull();
+    expect(keyInput).not.toBeNull();
+    expect(markdownInput).not.toBeNull();
+    if (!labelInput || !keyInput || !markdownInput) return;
+
+    labelInput.value = 'Details';
+    keyInput.value = 'details';
+    markdownInput.checked = true;
+
+    const form = document.querySelector<HTMLFormElement>('.list-metadata-dialog form');
+    expect(form).not.toBeNull();
+    form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    await flushPromises();
+
+    expect(createList).toHaveBeenCalledTimes(1);
+    const calls = createList.mock.calls as ListMetadataDialogPayload[][];
+    const payload = calls[0]?.[0];
+    expect(payload).toBeDefined();
+    if (!payload) return;
+
+    expect(payload.customFields).toEqual([
+      {
+        key: 'details',
+        label: 'Details',
+        type: 'text',
+        markdown: true,
+      },
+    ]);
+  });
+
   it('includes the selected instance when instance options are provided', async () => {
     const dialogManager = new DialogManager();
     const getAllKnownTags = vi.fn(() => []);

--- a/packages/web-client/src/controllers/listMetadataDialog.ts
+++ b/packages/web-client/src/controllers/listMetadataDialog.ts
@@ -85,6 +85,21 @@ export class ListMetadataDialog {
       optionsWrapper.style.display = isSelect ? '' : 'none';
     };
 
+    const ensureMarkdownVisibility = (row: HTMLElement, type: ListCustomFieldType): void => {
+      const markdownWrapper = row.querySelector<HTMLElement>(
+        '.list-metadata-custom-field-markdown',
+      );
+      if (!markdownWrapper) return;
+      const markdownInput = markdownWrapper.querySelector<HTMLInputElement>(
+        '.list-metadata-custom-field-markdown-input',
+      );
+      const isText = type === 'text';
+      markdownWrapper.style.display = isText ? '' : 'none';
+      if (!isText && markdownInput) {
+        markdownInput.checked = false;
+      }
+    };
+
     const addFieldRow = (field?: ListCustomFieldDefinition): void => {
       const row = document.createElement('div');
       row.className = 'list-metadata-custom-field-row';
@@ -153,6 +168,19 @@ export class ListMetadataDialog {
       optionsWrapper.appendChild(optionsLabel);
       row.appendChild(optionsWrapper);
 
+      const markdownWrapper = document.createElement('div');
+      markdownWrapper.className = 'list-metadata-custom-field-markdown';
+      const markdownLabel = document.createElement('label');
+      markdownLabel.className = 'list-metadata-custom-field-markdown-label';
+      const markdownInput = document.createElement('input');
+      markdownInput.type = 'checkbox';
+      markdownInput.className = 'list-item-form-checkbox list-metadata-custom-field-markdown-input';
+      markdownInput.checked = field?.markdown === true;
+      markdownLabel.appendChild(markdownInput);
+      markdownLabel.appendChild(document.createTextNode('Render as markdown'));
+      markdownWrapper.appendChild(markdownLabel);
+      row.appendChild(markdownWrapper);
+
       const actions = document.createElement('div');
       actions.className = 'list-metadata-custom-field-actions';
       const removeButton = document.createElement('button');
@@ -172,9 +200,11 @@ export class ListMetadataDialog {
 
       typeSelect.addEventListener('change', () => {
         ensureOptionsVisibility(row, typeSelect.value as ListCustomFieldType);
+        ensureMarkdownVisibility(row, typeSelect.value as ListCustomFieldType);
       });
 
       ensureOptionsVisibility(row, typeSelect.value as ListCustomFieldType);
+      ensureMarkdownVisibility(row, typeSelect.value as ListCustomFieldType);
 
       list.appendChild(row);
       fieldRows.push(row);
@@ -212,6 +242,9 @@ export class ListMetadataDialog {
         );
         const optionsInput = row.querySelector<HTMLInputElement>(
           '.list-metadata-custom-field-options-input',
+        );
+        const markdownInput = row.querySelector<HTMLInputElement>(
+          '.list-metadata-custom-field-markdown-input',
         );
 
         if (!labelInput || !keyInput || !typeSelect || !optionsInput) {
@@ -287,11 +320,14 @@ export class ListMetadataDialog {
           }
         }
 
+        const markdown = type === 'text' && markdownInput?.checked === true;
+
         result.push({
           key,
           label: rawLabel,
           type,
           ...(options ? { options } : {}),
+          ...(markdown ? { markdown: true } : {}),
         });
       }
 

--- a/packages/web-client/src/controllers/listPanelTableController.test.ts
+++ b/packages/web-client/src/controllers/listPanelTableController.test.ts
@@ -772,6 +772,47 @@ describe('ListPanelTableController notes column', () => {
     expect(cells[2]?.textContent).toBe('High');
     expect(cells[3]?.textContent).toBe('✓');
   });
+
+  it('renders markdown in custom text fields when enabled', () => {
+    const controller = new ListPanelTableController({
+      icons: { moreVertical: '', pin: '' },
+      renderTags: () => null,
+      recentUserItemUpdates,
+      userUpdateTimeoutMs: 1000,
+      getSelectedItemCount: () => 0,
+      showListItemMenu: vi.fn(),
+      updateListItem: vi.fn(async () => true),
+    });
+
+    const { tbody } = controller.renderTable({
+      listId,
+      sortedItems: [
+        {
+          id: 'item1',
+          title: 'Item 1',
+          customFields: { details: '# Heading' },
+        },
+      ],
+      showUrlColumn: false,
+      showNotesColumn: false,
+      showTagsColumn: false,
+      showAddedColumn: false,
+      customFields: [{ key: 'details', label: 'Details', type: 'text', markdown: true }],
+      showAllColumns: false,
+      rerender: () => {},
+    });
+
+    const row = tbody.querySelector<HTMLTableRowElement>('.list-item-row');
+    expect(row).not.toBeNull();
+    if (!row) return;
+
+    const cells = Array.from(row.querySelectorAll<HTMLTableCellElement>('td'));
+    // checkbox, title, details
+    const detailsCell = cells[2];
+    expect(detailsCell).toBeDefined();
+    if (!detailsCell) return;
+    expect(detailsCell.querySelector('h1')).not.toBeNull();
+  });
 });
 
 describe('ListPanelTableController column preferences', () => {


### PR DESCRIPTION
## Summary
- add a markdown flag to list custom field definitions and surface it in the list metadata dialog
- render markdown text custom fields in list rows with the notes-style overflow popup
- use a multiline textarea for markdown custom fields in the list item editor
- update parsing/types/styles/tests and note shared dialog styling duplication in plugins guide

## Testing
- `npm run format` (fails: Prettier warnings in many existing files)
- `npm run lint` (fails: unused vars in existing files, e.g. `packages/agent-server/src/chatProcessor.ts`, `packages/agent-server/src/chatRunCore.ts`, `packages/agent-server/src/history/historyProvider.ts`, `packages/plugins/official/artifacts/server/index.ts`)
- `npm run build`
- `npm run test` (fails: `packages/coding-executor/src/localExecutor.test.ts` and `packages/agent-server/src/plugins/coding/localExecutor.test.ts` expected truncation)
