### PR TITLE
Add bang shell command feature (!command)

### DIFF
--- a/.plans/bang-shell-command/PLAN.md
+++ b/.plans/bang-shell-command/PLAN.md
@@ -1,0 +1,186 @@
+# PLAN
+
+## Goal
+Add a user-input shortcut for shell execution in assistant sessions:
+- when a direct user message starts with `!`, treat the rest of the line (after trimming spaces immediately after `!`) as a shell command
+- execute it on the server in the session working directory when available, otherwise fall back to the server process cwd
+- persist the outcome in transcript history as tool events that replay after reload but are **excluded from LLM prompt/history**
+- stream output in real-time using the existing tool execution pipeline
+- render the result in chat as a dedicated terminal-style bubble with a terminal icon, `Terminal` heading, and markdown-rendered fenced code block output
+
+## Agreed product decisions
+- Show **only** the terminal result bubble; do **not** render the original `!command` as a normal user bubble.
+- Support bang execution in:
+  - websocket/manual chat input
+  - `sessions.message` / API path
+- Present output as a **single combined** code block (in the final result; streaming shows incremental output).
+- Include the executed command in the bubble (for example `$ git status`).
+- If `core.workingDir` is missing, **fall back to the server process cwd**.
+- Non-zero exit codes should render as an **error-style** terminal bubble.
+- Use the existing tool execution pipeline (streaming, broadcast, persistence) rather than `custom_message`.
+- Suppress bang-command tool events from LLM replay by filtering on a reserved tool name prefix `_assistant_`.
+- Tool events persist in both EventStore and Pi canonical transcript for full replay support.
+
+## Current findings
+- Direct user text entry reaches the server in two main paths:
+  - websocket chat input: `packages/agent-server/src/ws/chatRunLifecycle.ts` (`handleTextInputWithChatCompletions`)
+  - session operations API: `packages/agent-server/src/sessionMessages.ts` (`startSessionMessage`)
+- LLM-visible history is built from `user_message`, `assistant_done`, `tool_call`, `tool_result`, etc. in:
+  - `packages/agent-server/src/sessionChatMessages.ts`
+  - `packages/agent-server/src/projections/toOpenAIMessages.ts`
+- Existing precedent for LLM replay exclusion: `phase: 'commentary'` on `assistant_done` events is filtered by `isReplayableAssistantText()` in `toOpenAIMessages.ts`
+- Tool execution pipeline already supports:
+  - `tool_call_start` ServerMessage → immediate UI feedback (spinner/pending)
+  - `tool_output_chunk` → transient streaming events (broadcast only, not persisted)
+  - `tool_result` → final result (persisted + broadcast)
+- Chat replay/rendering already supports dedicated special bubbles for tool-like UI patterns:
+  - `voice_speak` / `voice_ask` — detected by tool name, custom bubble with icon
+  - `attachment_send` — same pattern
+  - renderer: `packages/web-client/src/controllers/chatRenderer.ts`
+- The web client already has a terminal icon in `packages/web-client/src/utils/icons.ts`.
+- Pi replay:
+  - Tool events persist through `piSessionWriter.appendAssistantEvent()` and replay via `historyProvider.ts`
+  - LLM suppression happens downstream in `sessionChatMessages.ts` / `toOpenAIMessages.ts`, so persistence and replay are unaffected
+
+## Recommended architecture
+
+### 1) Intercept bang commands before LLM execution
+Add a shared helper in `agent-server` that:
+- detects direct user input beginning with `!`
+- extracts command text with this rule:
+  - first character must be `!`
+  - ignore spaces immediately after `!`
+  - remainder must be non-empty
+- explicitly applies only to direct user entry points, not internal callback/agent-message flows
+- defines edge-case handling for:
+  - `!` → reject / no-op with visible error bubble
+  - `!   ` → reject / no-op with visible error bubble
+  - `!!` → escape: send `!` + rest as a normal chat message to the LLM (e.g., `!!hello` → sends `!hello`)
+  - multiline input → treat everything after the leading bang as the command string
+
+Use that helper from:
+- `packages/agent-server/src/ws/chatRunLifecycle.ts`
+- `packages/agent-server/src/sessionMessages.ts`
+
+This keeps the command out of `processUserMessage()` entirely, so it never enters `state.chatMessages` and never reaches any provider.
+
+### 2) Execute shell command via tool pipeline with streaming
+Use a reserved tool name `_assistant_shell` (prefix `_assistant_` marks it as internal/non-LLM).
+
+Execution flow:
+1. **Emit `tool_call_start`** ServerMessage immediately → client shows spinner
+2. **Spawn shell process** using `child_process.spawn()`:
+   - shell wrapper: `/bin/sh -c` (non-login shell for speed; no `-l` flag)
+   - cwd resolution:
+     - `state.summary.attributes?.core?.workingDir` when present
+     - otherwise `process.cwd()`
+   - capture combined stdout/stderr
+3. **Stream output** via `tool_output_chunk` transient events → client sees live output
+4. **Emit `tool_call` ChatEvent** (persisted) with tool name `_assistant_shell` and args `{ command, cwd }`
+5. **Emit `tool_result` ChatEvent** (persisted) with combined output, exit code, truncation/timeout metadata
+
+Required runtime protections:
+- configurable execution timeout with kill-on-timeout behavior
+- output size limits enforced **during streaming** (not just on the final result) — stop reading from the process and kill it once the limit is hit, to prevent client memory exhaustion from unbounded `tool_output_chunk` events
+- truncation note appended to output when limit is reached
+- cleanup on abort/disconnect where practical
+- clear failure path for spawn/timeout/kill errors
+
+Why dedicated helper instead of reusing coding tool internals:
+- avoids coupling this feature to coding plugin/tool availability
+- avoids tool-call semantics for a user-side control path
+- gives direct control over timeout/truncation/combined-output behavior
+
+### 3) Suppress from LLM replay by tool name prefix
+In both LLM history assembly paths, filter out tool events with tool names starting with `_assistant_`:
+
+**`packages/agent-server/src/sessionChatMessages.ts`** — in `buildChatMessagesFromEvents()`:
+- `tool_call` case: if `payload.toolName.startsWith('_assistant_')`, add `toolCallId` to a `suppressedToolCallIds` Set and skip
+- `tool_result` case: if `payload.toolCallId` is in `suppressedToolCallIds`, skip (do **not** rely on `toolName` here since `ToolResultPayloadSchema` has `toolName` as optional — an orphaned `role: 'tool'` message without a matching call would crash the LLM completion request)
+
+**`packages/agent-server/src/projections/toOpenAIMessages.ts`** — in `toOpenAIMessages()`:
+- Same `suppressedToolCallIds` Set pattern
+
+This follows the precedent set by `isReplayableAssistantText()` filtering `phase: 'commentary'` events, and mirrors the existing `interruptedResponseIds` filtering pattern already used in `buildChatMessagesFromEvents()`.
+
+The `_assistant_` prefix is intentionally generic — future internal tool-like events (e.g., system diagnostics, session management actions) can reuse the same suppression mechanism without additional filtering logic.
+
+### 4) Persist to transcript for replay
+No special handling needed — tool events already flow through:
+- **EventStore**: `eventStore.append()` in `appendAndBroadcastChatEvents()`
+- **Pi canonical transcript**: `piSessionWriter.appendAssistantEvent()` with custom type `assistant.tool_call` / `assistant.tool_result`
+
+Both paths persist `_assistant_shell` events identically to any other tool event. The suppression filter only applies in `sessionChatMessages.ts` / `toOpenAIMessages.ts` when building LLM prompt messages.
+
+On session reload, `historyProvider.ts` projects these events into `ProjectedTranscriptEvent` objects with `chatEventType: 'tool_call'` / `'tool_result'`, which the renderer picks up normally.
+
+### 5) Render as dedicated terminal bubble
+In `packages/web-client/src/controllers/chatRenderer.ts`:
+- detect `_assistant_shell` tool name (same pattern as `VOICE_TOOL_NAMES` / `ATTACHMENT_TOOL_NAME`)
+- exclude `_assistant_shell` from `isGroupableToolCall()` to prevent duplicate rendering as both a grouped tool call and a terminal bubble
+- render a dedicated bubble:
+  - terminal icon from `packages/web-client/src/utils/icons.ts`
+  - heading text: `Terminal`
+  - body: markdown content containing fenced code block with command and output
+  - error styling when exit code is non-zero or execution timed out
+- for streaming: handle `tool_output_chunk` events for `_assistant_shell` with incremental text append (same as existing tool output streaming, just with terminal styling)
+
+### 6) Replay strategy
+Tool events for `_assistant_shell` persist and replay through both storage backends:
+- **EventStore-backed sessions**: standard `tool_call` + `tool_result` events
+- **Pi canonical replay path**: persisted via `appendAssistantEvent()`, projected via `historyProvider.ts`
+
+The LLM suppression is purely at the message-assembly layer, so replay rendering is unaffected.
+
+No special `historyProvider.ts` changes needed unless tests reveal a gap.
+
+## Review feedback incorporated
+Main changes from review rounds:
+- **Switched from `custom_message` to tool pipeline** — gets streaming, spinner, multi-user broadcast for free
+- **LLM suppression via `_assistant_` tool name prefix** — minimal code change, follows existing `commentary` phase pattern
+- **Non-login shell** (`/bin/sh -c` not `/bin/sh -lc`) — avoids profile loading latency and side effects
+- **Timeout / abort / cleanup** handling as required runtime protections
+- **Output truncation** as a required part of the design
+- **Scoped interception** — only direct user entry points, not internal callback/agent-message flows
+- **Pi replay validated by design** — tool events persist normally; suppression is downstream
+
+Gemini review findings incorporated:
+- **`toolCallId` Set for suppression** — `tool_result` events filtered by `toolCallId` membership instead of `toolName` (which is optional on `ToolResultPayload` and could produce orphaned `role: 'tool'` messages that crash LLM completions)
+- **`!!` escape mechanism** — `!!` now sends the remainder as a normal chat message prefixed with `!`, so users can still type literal `!`-prefixed text to the LLM
+- **Exclude from `isGroupableToolCall()`** — prevents `_assistant_shell` from rendering as both a grouped tool call and a terminal bubble
+- **Streaming-phase truncation** — output size limit enforced during `tool_output_chunk` streaming, not just on the final result, to prevent client memory exhaustion
+
+## Files likely to change
+- `packages/agent-server/src/ws/chatRunLifecycle.ts` — bang command interception
+- `packages/agent-server/src/sessionMessages.ts` — bang command interception (API path)
+- `packages/agent-server/src/sessionChatMessages.ts` — `_assistant_` prefix suppression filter
+- `packages/agent-server/src/projections/toOpenAIMessages.ts` — `_assistant_` prefix suppression filter
+- `packages/shared/src/chatEvents.ts` — no schema changes needed (tool name is already a string field)
+- `packages/web-client/src/controllers/chatRenderer.ts` — terminal bubble rendering
+- new helper files:
+  - `packages/agent-server/src/shell/executeSessionShellCommand.ts` — shell spawn, timeout, truncation
+  - `packages/agent-server/src/sessionBangCommands.ts` — bang detection, command extraction, tool event emission
+- tests:
+  - `packages/agent-server/src/__tests__/sessionBangCommands.test.ts`
+  - `packages/agent-server/src/__tests__/shellExecution.test.ts`
+  - `packages/agent-server/src/__tests__/sessionChatMessages.test.ts` (suppression filter)
+  - `packages/web-client/src/controllers/chatRenderer.test.ts` (terminal bubble)
+
+## Acceptance criteria
+- Sending `!pwd` through websocket chat input runs a shell command server-side with live streaming output
+- Sending `!pwd` through `sessions.message` / API also runs the shell command server-side
+- Client sees a spinner/pending state immediately when a bang command is submitted
+- Output streams to the client in real-time as the command produces it
+- Other users watching the same session via websocket see the same streaming output
+- Internal callback / agent-message flows are **not** intercepted
+- Command execution uses `core.workingDir` when present and falls back to server cwd when absent
+- The original `!command` does not enter LLM-visible conversation history and does not render as a normal user bubble
+- `_assistant_shell` tool events are persisted to both EventStore and Pi canonical transcript
+- `_assistant_shell` tool events are excluded from `buildChatMessagesFromEvents()` and `toOpenAIMessages()` output
+- The result renders as a dedicated terminal bubble with terminal icon + `Terminal` heading
+- Bubble body shows the command and combined output in markdown code block format
+- Non-zero exit codes render as an error-style terminal bubble
+- Execution timeout is enforced and timed-out commands render clearly
+- Large output is truncated deterministically and truncation is indicated in the rendered bubble
+- Session reload replays terminal bubbles correctly from both EventStore and Pi transcript
+- Automated tests cover: bang detection/extraction, interception scope, shell execution (timeout, truncation, exit codes), LLM suppression filtering, persistence/replay, and UI rendering

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Added bang shell command feature (`!command`) for executing shell commands directly in chat with real-time streaming output, dedicated terminal bubble rendering, and `_assistant_` prefix LLM suppression. Gated behind `bangCommandEnabled` agent config flag (default: false). ([#94](https://github.com/kcosr/assistant/pull/94))
 - Added template-based agent configuration with `extends` support. Templates are named partial agent configs defined in a top-level `templates` section of `config.json`. Agents and templates can extend one or more templates via `extends` (string or array). Deep merge with null-clearing semantics. ([#93](https://github.com/kcosr/assistant/pull/93))
 - Added `sessionConfig` parameter to the `agents_message` tool, allowing callers to specify `model`, `thinking`, `workingDir`, and `skills` when creating new sessions via agent messaging. ([#93](https://github.com/kcosr/assistant/pull/93))
 - Added skills root normalization relative to config directory (matching existing context files behavior). ([#93](https://github.com/kcosr/assistant/pull/93))
@@ -20,6 +21,7 @@
 
 ### Fixed
 
+- Fixed first streaming `tool_output_chunk` (offset=0) being silently dropped by the renderer's dedup logic, improving incremental output visibility for all tool calls. ([#94](https://github.com/kcosr/assistant/pull/94))
 - Fixed Pi transcript replay and live hydration so canonical replay cursors, projected sequence watermarks, and same-revision live state stay monotonic across reloads/reconnects instead of rewinding, forcing reload loops, or resurfacing already-rendered events. ([#93](https://github.com/kcosr/assistant/pull/93))
 - Fixed Pi refresh/reconnect transcript startup so redundant session-ready reloads no longer trigger overlapping reset-style replay passes for the same session. ([#93](https://github.com/kcosr/assistant/pull/93))
 - Fixed chat user-bubble rendering during replay hydration so refreshes reuse a single unified user bubble per turn instead of transiently showing duplicate user messages while an in-flight turn is rebuilding. ([#93](https://github.com/kcosr/assistant/pull/93))

--- a/packages/agent-server/src/agents.ts
+++ b/packages/agent-server/src/agents.ts
@@ -95,6 +95,12 @@ export interface AgentDefinition {
     callbackBaseUrl: string;
   };
   /**
+   * Whether to enable the bang shell command feature (!command) for this agent.
+   * When true, users can type !<command> in chat to execute shell commands
+   * server-side. Defaults to false when omitted.
+   */
+  bangCommandEnabled?: boolean;
+  /**
    * Optional visibility flag for built-in clients (UI and agents_* tools).
    * When false, the agent is hidden from built-in discovery and delegation.
    * Defaults to true when omitted.

--- a/packages/agent-server/src/bangCommand.test.ts
+++ b/packages/agent-server/src/bangCommand.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectBangCommand,
+  executeShellCommand,
+  ASSISTANT_INTERNAL_TOOL_PREFIX,
+  BANG_SHELL_TOOL_NAME,
+} from './bangCommand';
+
+// ---------------------------------------------------------------------------
+// detectBangCommand
+// ---------------------------------------------------------------------------
+
+describe('detectBangCommand', () => {
+  it('returns none for regular text', () => {
+    const result = detectBangCommand('hello world');
+    expect(result).toEqual({ isBang: false, isEscape: false });
+  });
+
+  it('returns none for empty string', () => {
+    const result = detectBangCommand('');
+    expect(result).toEqual({ isBang: false, isEscape: false });
+  });
+
+  it('detects a simple bang command', () => {
+    const result = detectBangCommand('!pwd');
+    expect(result).toEqual({ isBang: true, command: 'pwd' });
+  });
+
+  it('strips leading whitespace after !', () => {
+    const result = detectBangCommand('!  ls -la');
+    expect(result).toEqual({ isBang: true, command: 'ls -la' });
+  });
+
+  it('returns empty command for bare !', () => {
+    const result = detectBangCommand('!');
+    expect(result).toEqual({ isBang: true, command: '' });
+  });
+
+  it('returns empty command for ! followed by only spaces', () => {
+    const result = detectBangCommand('!   ');
+    expect(result).toEqual({ isBang: true, command: '' });
+  });
+
+  it('treats !! as escape — returns text with single !', () => {
+    const result = detectBangCommand('!!hello');
+    expect(result).toEqual({ isBang: false, isEscape: true, text: '!hello' });
+  });
+
+  it('treats !! alone as escape', () => {
+    const result = detectBangCommand('!!');
+    expect(result).toEqual({ isBang: false, isEscape: true, text: '!' });
+  });
+
+  it('handles multiline bang command', () => {
+    const result = detectBangCommand('!echo hello\necho world');
+    expect(result).toEqual({ isBang: true, command: 'echo hello\necho world' });
+  });
+
+  it('handles bang with complex shell command', () => {
+    const result = detectBangCommand('!git log --oneline -5 | head -3');
+    expect(result).toEqual({ isBang: true, command: 'git log --oneline -5 | head -3' });
+  });
+
+  it('detects bang after a <context .../> line', () => {
+    const result = detectBangCommand('<context panel-id="notes" />\n!pwd');
+    expect(result).toEqual({ isBang: true, command: 'pwd' });
+  });
+
+  it('detects !! escape after a <context .../> line', () => {
+    const result = detectBangCommand('<context type="list" id="123" />\n!!hello');
+    expect(result).toEqual({ isBang: false, isEscape: true, text: '!hello' });
+  });
+
+  it('returns none when context line is followed by normal text', () => {
+    const result = detectBangCommand('<context panel-id="notes" />\nhello world');
+    expect(result).toEqual({ isBang: false, isEscape: false });
+  });
+
+  it('handles context line with attributes and bang', () => {
+    const result = detectBangCommand(
+      '<context type="list" id="abc" name="My List" selection="1,2" />\n!ls -la',
+    );
+    expect(result).toEqual({ isBang: true, command: 'ls -la' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executeShellCommand
+// ---------------------------------------------------------------------------
+
+describe('executeShellCommand', () => {
+  it('executes a simple command and captures output', async () => {
+    const result = await executeShellCommand({
+      command: 'echo hello',
+      cwd: process.cwd(),
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.output.trim()).toBe('hello');
+    expect(result.timedOut).toBe(false);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('captures non-zero exit code', async () => {
+    const result = await executeShellCommand({
+      command: 'exit 42',
+      cwd: process.cwd(),
+    });
+    expect(result.exitCode).toBe(42);
+    expect(result.timedOut).toBe(false);
+  });
+
+  it('captures stderr in output', async () => {
+    const result = await executeShellCommand({
+      command: 'echo err >&2',
+      cwd: process.cwd(),
+    });
+    expect(result.output.trim()).toBe('err');
+  });
+
+  it('calls onChunk with streaming output', async () => {
+    const chunks: string[] = [];
+    await executeShellCommand({
+      command: 'echo hello',
+      cwd: process.cwd(),
+      onChunk: (chunk) => chunks.push(chunk),
+    });
+    expect(chunks.join('').trim()).toBe('hello');
+  });
+
+  it('enforces timeout', async () => {
+    const result = await executeShellCommand({
+      command: 'sleep 10',
+      cwd: process.cwd(),
+      timeoutMs: 200,
+    });
+    expect(result.timedOut).toBe(true);
+  });
+
+  it('enforces output size limit and truncates during streaming', async () => {
+    const chunks: string[] = [];
+    const result = await executeShellCommand({
+      command: 'yes | head -10000',
+      cwd: process.cwd(),
+      maxOutputBytes: 100,
+      onChunk: (chunk) => chunks.push(chunk),
+    });
+    expect(result.truncated).toBe(true);
+    expect(result.output.length).toBeLessThanOrEqual(100);
+  });
+
+  it('respects abort signal', async () => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 100);
+    const result = await executeShellCommand({
+      command: 'sleep 10',
+      cwd: process.cwd(),
+      signal: controller.signal,
+    });
+    // Should complete (killed by abort) rather than hang
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it('uses specified cwd', async () => {
+    const result = await executeShellCommand({
+      command: 'pwd',
+      cwd: '/tmp',
+    });
+    expect(result.output.trim()).toBe('/tmp');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+describe('constants', () => {
+  it('BANG_SHELL_TOOL_NAME starts with ASSISTANT_INTERNAL_TOOL_PREFIX', () => {
+    expect(BANG_SHELL_TOOL_NAME.startsWith(ASSISTANT_INTERNAL_TOOL_PREFIX)).toBe(true);
+  });
+});

--- a/packages/agent-server/src/bangCommand.ts
+++ b/packages/agent-server/src/bangCommand.ts
@@ -1,0 +1,363 @@
+import { randomUUID } from 'node:crypto';
+import { spawn } from 'node:child_process';
+
+import type { SessionHub } from './sessionHub';
+import type { EventStore } from './events';
+import {
+  appendAndBroadcastChatEvents,
+  createChatEventBase,
+  emitToolCallEvent,
+  emitToolOutputChunkEvent,
+  emitToolResultEvent,
+} from './events/chatEventUtils';
+import type { ChatEvent } from '@assistant/shared';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Reserved tool name for bang shell commands. The `_assistant_` prefix marks
+ *  it as internal — events with this prefix are excluded from LLM replay. */
+export const BANG_SHELL_TOOL_NAME = '_assistant_shell';
+
+/** Prefix used to identify internal assistant tool events that should be
+ *  suppressed from LLM message history. */
+export const ASSISTANT_INTERNAL_TOOL_PREFIX = '_assistant_';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_OUTPUT_BYTES = 512 * 1024; // 512 KB
+
+// ---------------------------------------------------------------------------
+// Bang command detection / extraction
+// ---------------------------------------------------------------------------
+
+export interface BangParseResult {
+  /** The raw input was a bang command. */
+  isBang: true;
+  /** The shell command to execute (trimmed). */
+  command: string;
+}
+
+export interface BangEscapeResult {
+  /** The raw input used the `!!` escape — forward to LLM as `!...`. */
+  isBang: false;
+  isEscape: true;
+  /** The text to forward to the LLM (with leading `!` preserved). */
+  text: string;
+}
+
+export interface BangNoneResult {
+  isBang: false;
+  isEscape: false;
+}
+
+export type BangDetectResult = BangParseResult | BangEscapeResult | BangNoneResult;
+
+/** Regex matching the client-prepended `<context ... />` line. */
+const CONTEXT_LINE_RE = /^\s*<context(?:\s[^>]*?)?\s*\/>(?:\r?\n)?/;
+
+/**
+ * Strip a leading `<context ... />` line if present, returning the user's
+ * actual text. The client prepends this metadata line before sending over
+ * the websocket; we need to look past it for bang detection.
+ */
+export function stripLeadingContextLine(text: string): string {
+  const match = text.match(CONTEXT_LINE_RE);
+  return match ? text.slice(match[0].length) : text;
+}
+
+/**
+ * Detect whether trimmed user input is a bang command, a `!!` escape, or
+ * neither.
+ *
+ * The function automatically strips a leading `<context ... />` line (added
+ * by the client) before checking for the bang prefix.
+ *
+ * Rules:
+ * - Input must start with `!` (after any context line).
+ * - `!!...` → escape: returns the remainder prefixed with `!` as normal text.
+ * - `!` or `!   ` (empty after trimming) → treated as bang with empty command
+ *   (caller should reject).
+ * - `!<command>` → bang command with leading whitespace after `!` stripped.
+ */
+export function detectBangCommand(trimmedText: string): BangDetectResult {
+  const userText = stripLeadingContextLine(trimmedText);
+
+  if (!userText.startsWith('!')) {
+    return { isBang: false, isEscape: false };
+  }
+
+  // `!!` escape — send `!` + rest as normal text to LLM
+  if (userText.startsWith('!!')) {
+    return {
+      isBang: false,
+      isEscape: true,
+      text: userText.slice(1), // remove first `!`, keep second
+    };
+  }
+
+  // Strip leading whitespace after `!`
+  const command = userText.slice(1).trimStart();
+
+  return { isBang: true, command };
+}
+
+// ---------------------------------------------------------------------------
+// Shell execution
+// ---------------------------------------------------------------------------
+
+export interface ShellExecutionResult {
+  output: string;
+  exitCode: number | null;
+  timedOut: boolean;
+  truncated: boolean;
+}
+
+export interface ExecuteShellCommandOptions {
+  command: string;
+  cwd: string;
+  timeoutMs?: number;
+  maxOutputBytes?: number;
+  /** Called with each chunk of combined stdout/stderr output. */
+  onChunk?: (chunk: string) => void;
+  signal?: AbortSignal;
+}
+
+/**
+ * Execute a shell command via `/bin/sh -c`, streaming combined stdout/stderr
+ * through the `onChunk` callback. Enforces timeout and output-size limits
+ * during execution (not just on the final result).
+ */
+export function executeShellCommand(
+  options: ExecuteShellCommandOptions,
+): Promise<ShellExecutionResult> {
+  const {
+    command,
+    cwd,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    maxOutputBytes = DEFAULT_MAX_OUTPUT_BYTES,
+    onChunk,
+    signal,
+  } = options;
+
+  return new Promise<ShellExecutionResult>((resolve) => {
+    let output = '';
+    let totalBytes = 0;
+    let truncated = false;
+    let timedOut = false;
+    let killed = false;
+
+    const child = spawn('/bin/sh', ['-c', command], {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+    });
+
+    const kill = () => {
+      if (!killed) {
+        killed = true;
+        child.kill('SIGKILL');
+      }
+    };
+
+    // Timeout
+    const timer = setTimeout(() => {
+      timedOut = true;
+      kill();
+    }, timeoutMs);
+
+    // External abort
+    if (signal) {
+      if (signal.aborted) {
+        kill();
+      } else {
+        signal.addEventListener('abort', () => kill(), { once: true });
+      }
+    }
+
+    const handleData = (data: Buffer) => {
+      if (truncated) return;
+
+      const chunk = data.toString('utf-8');
+      const chunkBytes = data.byteLength;
+
+      if (totalBytes + chunkBytes > maxOutputBytes) {
+        // Take only what fits
+        const remaining = maxOutputBytes - totalBytes;
+        const partial = data.subarray(0, remaining).toString('utf-8');
+        output += partial;
+        totalBytes = maxOutputBytes;
+        truncated = true;
+        onChunk?.(partial);
+        kill();
+        return;
+      }
+
+      output += chunk;
+      totalBytes += chunkBytes;
+      onChunk?.(chunk);
+    };
+
+    child.stdout?.on('data', handleData);
+    child.stderr?.on('data', handleData);
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      resolve({
+        output: output || `Failed to execute command: ${err.message}`,
+        exitCode: null,
+        timedOut: false,
+        truncated,
+      });
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolve({
+        output,
+        exitCode: code,
+        timedOut,
+        truncated,
+      });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Bang command orchestration — emit tool events + execute
+// ---------------------------------------------------------------------------
+
+export interface HandleBangCommandOptions {
+  command: string;
+  sessionId: string;
+  sessionHub: SessionHub;
+  eventStore?: EventStore;
+  /** Session working directory (from core.workingDir), or undefined. */
+  workingDir?: string;
+  timeoutMs?: number;
+  maxOutputBytes?: number;
+}
+
+/**
+ * Full bang command handler: emits tool_call_start, streams output chunks,
+ * then persists tool_call + tool_result events.
+ */
+export async function handleBangCommand(options: HandleBangCommandOptions): Promise<void> {
+  const { command, sessionId, sessionHub, eventStore, workingDir, timeoutMs, maxOutputBytes } =
+    options;
+
+  const cwd = workingDir || process.cwd();
+  const toolCallId = randomUUID() as string;
+  const turnId = randomUUID() as string;
+  const responseId = randomUUID() as string;
+
+  // 1. Emit turn_start + tool_call_start so clients see the spinner immediately
+  const turnStartEvents: ChatEvent[] = [
+    {
+      ...createChatEventBase({ sessionId, turnId }),
+      type: 'turn_start',
+      payload: { trigger: 'user' },
+    },
+  ];
+  await appendAndBroadcastChatEvents(
+    { ...(eventStore ? { eventStore } : {}), sessionHub, sessionId },
+    turnStartEvents,
+  );
+
+  // Broadcast tool_call_start ServerMessage so clients see the spinner immediately
+  sessionHub.broadcastToSession(sessionId, {
+    type: 'tool_call_start',
+    sessionId,
+    callId: toolCallId,
+    toolName: BANG_SHELL_TOOL_NAME,
+    arguments: JSON.stringify({ command, cwd }),
+  });
+
+  // 2. Persist tool_call event BEFORE execution so the renderer creates the
+  //    terminal bubble and can receive streaming tool_output_chunk events.
+  await emitToolCallEvent({
+    ...(eventStore ? { eventStore } : {}),
+    sessionHub,
+    sessionId,
+    turnId,
+    responseId,
+    toolCallId,
+    toolName: BANG_SHELL_TOOL_NAME,
+    args: { command, cwd },
+  });
+
+  // 3. Execute and stream output
+  let chunkOffset = 0;
+  const result = await executeShellCommand({
+    command,
+    cwd,
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    ...(maxOutputBytes !== undefined ? { maxOutputBytes } : {}),
+    onChunk: (chunk) => {
+      emitToolOutputChunkEvent({
+        sessionHub,
+        sessionId,
+        turnId,
+        responseId,
+        toolCallId,
+        toolName: BANG_SHELL_TOOL_NAME,
+        chunk,
+        offset: chunkOffset,
+      });
+      chunkOffset += chunk.length;
+    },
+  });
+
+  // 4. Build rendered markdown for the output only (command is in tool_call args
+  //    and rendered separately by the client in the input block)
+  const outputLines: string[] = [];
+  if (result.output) {
+    outputLines.push('```');
+    outputLines.push(result.output.trimEnd());
+    outputLines.push('```');
+  }
+  if (result.truncated) {
+    outputLines.push('\n*Output truncated (size limit reached)*');
+  }
+  if (result.timedOut) {
+    outputLines.push('\n*Command timed out*');
+  }
+
+  const renderedOutput = outputLines.join('\n');
+
+  const toolError = result.timedOut
+    ? { error: { code: 'timeout', message: 'Command timed out' } }
+    : result.exitCode !== 0 && result.exitCode !== null
+      ? { error: { code: 'non_zero_exit', message: `Exit code: ${result.exitCode}` } }
+      : {};
+
+  await emitToolResultEvent({
+    ...(eventStore ? { eventStore } : {}),
+    sessionHub,
+    sessionId,
+    turnId,
+    responseId,
+    toolCallId,
+    toolName: BANG_SHELL_TOOL_NAME,
+    result: {
+      output: renderedOutput,
+      exitCode: result.exitCode,
+      truncated: result.truncated,
+      timedOut: result.timedOut,
+    },
+    ...toolError,
+  });
+
+  // 5. Close the turn
+  const turnEndEvents: ChatEvent[] = [
+    {
+      ...createChatEventBase({ sessionId, turnId, responseId }),
+      type: 'turn_end',
+      payload: {},
+    },
+  ];
+  await appendAndBroadcastChatEvents(
+    { ...(eventStore ? { eventStore } : {}), sessionHub, sessionId },
+    turnEndEvents,
+  );
+}

--- a/packages/agent-server/src/bangCommand.ts
+++ b/packages/agent-server/src/bangCommand.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
 
 import type { SessionHub } from './sessionHub';
+import type { SessionSummary } from './sessionIndex';
 import type { EventStore } from './events';
 import {
   appendAndBroadcastChatEvents,
@@ -231,6 +232,7 @@ export interface HandleBangCommandOptions {
   command: string;
   sessionId: string;
   sessionHub: SessionHub;
+  summary: SessionSummary;
   eventStore?: EventStore;
   /** Session working directory (from core.workingDir), or undefined. */
   workingDir?: string;
@@ -243,15 +245,38 @@ export interface HandleBangCommandOptions {
  * then persists tool_call + tool_result events.
  */
 export async function handleBangCommand(options: HandleBangCommandOptions): Promise<void> {
-  const { command, sessionId, sessionHub, eventStore, workingDir, timeoutMs, maxOutputBytes } =
-    options;
+  const {
+    command,
+    sessionId,
+    sessionHub,
+    summary,
+    eventStore,
+    workingDir,
+    timeoutMs,
+    maxOutputBytes,
+  } = options;
 
   const cwd = workingDir || process.cwd();
   const toolCallId = randomUUID() as string;
   const turnId = randomUUID() as string;
   const responseId = randomUUID() as string;
 
-  // 1. Emit turn_start + tool_call_start so clients see the spinner immediately
+  // 1. Emit turn_start so clients see the spinner and Pi gets request boundaries
+  //    for turn deletion support.
+  const piSessionWriter = sessionHub.getPiSessionWriter?.();
+  let currentSummary = summary;
+  if (piSessionWriter) {
+    const updatedSummary = await piSessionWriter.appendTurnStart({
+      summary: currentSummary,
+      turnId,
+      trigger: 'user',
+      updateAttributes: (patch) => sessionHub.updateSessionAttributes(sessionId, patch),
+    });
+    if (updatedSummary) {
+      currentSummary = updatedSummary;
+    }
+  }
+
   const turnStartEvents: ChatEvent[] = [
     {
       ...createChatEventBase({ sessionId, turnId }),
@@ -348,7 +373,16 @@ export async function handleBangCommand(options: HandleBangCommandOptions): Prom
     ...toolError,
   });
 
-  // 5. Close the turn
+  // 5. Close the turn — write Pi request boundary for turn deletion support
+  if (piSessionWriter) {
+    await piSessionWriter.appendTurnEnd({
+      summary: currentSummary,
+      turnId,
+      status: 'completed',
+      updateAttributes: (patch) => sessionHub.updateSessionAttributes(sessionId, patch),
+    });
+  }
+
   const turnEndEvents: ChatEvent[] = [
     {
       ...createChatEventBase({ sessionId, turnId, responseId }),

--- a/packages/agent-server/src/config.ts
+++ b/packages/agent-server/src/config.ts
@@ -311,6 +311,7 @@ const RawAgentConfigSchema = z.object({
   capabilityDenylist: GlobPatternListSchema,
   agentAllowlist: GlobPatternListSchema,
   agentDenylist: GlobPatternListSchema,
+  bangCommandEnabled: z.boolean().optional().nullable(),
   uiVisible: z.boolean().optional().nullable(),
   apiExposed: z.boolean().optional().nullable(),
   sessionWorkingDir: SessionWorkingDirConfigSchema.optional(),
@@ -370,6 +371,7 @@ export const AgentConfigSchema = RawAgentConfigSchema.transform((value) => {
     capabilityDenylist,
     agentAllowlist,
     agentDenylist,
+    bangCommandEnabled,
     uiVisible,
     apiExposed,
     sessionWorkingDir,
@@ -607,6 +609,9 @@ export const AgentConfigSchema = RawAgentConfigSchema.transform((value) => {
   if (agentDenylist) {
     extended.agentDenylist = agentDenylist;
   }
+  if (bangCommandEnabled !== undefined && bangCommandEnabled !== null) {
+    extended.bangCommandEnabled = bangCommandEnabled;
+  }
   if (uiVisible !== undefined && uiVisible !== null) {
     extended.uiVisible = uiVisible;
   }
@@ -702,11 +707,7 @@ export const SessionsConfigSchema = z.object({
 export type SessionsConfig = z.infer<typeof SessionsConfigSchema>;
 
 export const AttachmentsConfigSchema = z.object({
-  previewSnippetChars: z
-    .number()
-    .int()
-    .min(1)
-    .default(DEFAULT_ATTACHMENT_PREVIEW_SNIPPET_CHARS),
+  previewSnippetChars: z.number().int().min(1).default(DEFAULT_ATTACHMENT_PREVIEW_SNIPPET_CHARS),
 });
 
 export type AttachmentsConfig = z.infer<typeof AttachmentsConfigSchema>;

--- a/packages/agent-server/src/projections/toOpenAIMessages.ts
+++ b/packages/agent-server/src/projections/toOpenAIMessages.ts
@@ -1,5 +1,6 @@
 import type { ChatEvent } from '@assistant/shared';
 
+import { ASSISTANT_INTERNAL_TOOL_PREFIX } from '../bangCommand';
 import { getAgentCallbackText, getUserVisibleUserText } from '../chatEventText';
 import type {
   ChatCompletionMessage,
@@ -12,6 +13,18 @@ function isReplayableAssistantText(event: ChatEvent & { type: 'assistant_done' }
 
 export function toOpenAIMessages(events: ChatEvent[]): ChatCompletionMessage[] {
   const messages: ChatCompletionMessage[] = [];
+
+  // Suppress internal assistant tool events from LLM context.
+  // Track by toolCallId because toolName is optional on tool_result payloads.
+  const suppressedToolCallIds = new Set(
+    events
+      .filter(
+        (event) =>
+          event.type === 'tool_call' &&
+          event.payload.toolName.startsWith(ASSISTANT_INTERNAL_TOOL_PREFIX),
+      )
+      .map((event) => (event as ChatEvent & { type: 'tool_call' }).payload.toolCallId),
+  );
 
   for (const event of events) {
     switch (event.type) {
@@ -52,6 +65,9 @@ export function toOpenAIMessages(events: ChatEvent[]): ChatCompletionMessage[] {
       }
 
       case 'tool_call': {
+        if (suppressedToolCallIds.has(event.payload.toolCallId)) {
+          break;
+        }
         const toolCall: ChatCompletionToolCallMessageToolCall = {
           id: event.payload.toolCallId,
           type: 'function',
@@ -80,6 +96,9 @@ export function toOpenAIMessages(events: ChatEvent[]): ChatCompletionMessage[] {
       }
 
       case 'tool_result': {
+        if (suppressedToolCallIds.has(event.payload.toolCallId)) {
+          break;
+        }
         const { toolCallId, result, error } = event.payload;
 
         const content = JSON.stringify({

--- a/packages/agent-server/src/sessionChatMessages.test.ts
+++ b/packages/agent-server/src/sessionChatMessages.test.ts
@@ -53,9 +53,7 @@ describe('buildChatMessagesFromEvents', () => {
     expect(messages.length).toBe(2);
     expect(messages[0]?.role).toBe('system');
     expect(messages[1]?.role).toBe('user');
-    expect(messages[1]?.content).toBe(
-      '[Callback from target-agent]: Callback from target agent',
-    );
+    expect(messages[1]?.content).toBe('[Callback from target-agent]: Callback from target agent');
   });
 
   it('preserves visible interrupted assistant output when rebuilding prompt messages', () => {
@@ -113,9 +111,7 @@ describe('buildChatMessagesFromEvents', () => {
 
     expect(messages.length).toBe(1);
     expect(messages[0]?.role).toBe('system');
-    expect(messages[0]?.content).toContain(
-      'Project directory: /home/kevin/worktrees/project-a',
-    );
+    expect(messages[0]?.content).toContain('Project directory: /home/kevin/worktrees/project-a');
   });
 
   it('preserves tool call boundaries when rebuilding prompt messages', () => {
@@ -370,7 +366,12 @@ describe('buildChatMessagesFromEvents', () => {
 
     const messages = buildChatMessagesFromEvents(events, registry, undefined, []);
 
-    expect(messages.map((message) => message.role)).toEqual(['system', 'user', 'assistant', 'assistant']);
+    expect(messages.map((message) => message.role)).toEqual([
+      'system',
+      'user',
+      'assistant',
+      'assistant',
+    ]);
     expect(messages[2]).toMatchObject({
       role: 'assistant',
       content: 'Let me check.',
@@ -383,5 +384,119 @@ describe('buildChatMessagesFromEvents', () => {
       assistantTextPhase: 'final_answer',
       assistantTextSignature: '{"v":1,"id":"msg-final","phase":"final_answer"}',
     });
+  });
+
+  it('suppresses _assistant_ prefixed tool calls and results from LLM history', () => {
+    const registry = new AgentRegistry([]);
+    const sessionId = 'session-bang';
+    const timestamp = Date.now();
+    const events: ChatEvent[] = [
+      {
+        id: 'evt-user',
+        timestamp,
+        sessionId,
+        type: 'user_message',
+        payload: { text: 'Before the bang' },
+      },
+      {
+        id: 'evt-shell-call',
+        timestamp: timestamp + 1,
+        sessionId,
+        responseId: 'resp-1',
+        type: 'tool_call',
+        payload: {
+          toolCallId: 'call-shell',
+          toolName: '_assistant_shell',
+          args: { command: 'pwd', cwd: '/tmp' },
+        },
+      },
+      {
+        id: 'evt-shell-result',
+        timestamp: timestamp + 2,
+        sessionId,
+        responseId: 'resp-1',
+        type: 'tool_result',
+        payload: {
+          toolCallId: 'call-shell',
+          toolName: '_assistant_shell',
+          result: { output: '/tmp', exitCode: 0 },
+        },
+      },
+      {
+        id: 'evt-normal-call',
+        timestamp: timestamp + 3,
+        sessionId,
+        responseId: 'resp-2',
+        type: 'tool_call',
+        payload: {
+          toolCallId: 'call-normal',
+          toolName: 'lists_list',
+          args: { limit: 5 },
+        },
+      },
+      {
+        id: 'evt-normal-result',
+        timestamp: timestamp + 4,
+        sessionId,
+        responseId: 'resp-2',
+        type: 'tool_result',
+        payload: {
+          toolCallId: 'call-normal',
+          result: { ok: true },
+        },
+      },
+    ];
+
+    const messages = buildChatMessagesFromEvents(events, registry, undefined, []);
+
+    // Should have: system, user, assistant (tool_call for lists_list), tool (result for lists_list)
+    // The _assistant_shell call and result should be suppressed
+    const roles = messages.map((m) => m.role);
+    expect(roles).toEqual(['system', 'user', 'assistant', 'tool']);
+
+    // The remaining tool call should be lists_list, not _assistant_shell
+    const assistantMsg = messages[2] as Record<string, unknown>;
+    const toolCalls = assistantMsg?.['tool_calls'] as Array<{ function: { name: string } }>;
+    expect(toolCalls?.[0]?.function?.name).toBe('lists_list');
+
+    // The remaining tool result should reference call-normal, not call-shell
+    const toolMsg = messages[3] as Record<string, unknown>;
+    expect(toolMsg?.['tool_call_id']).toBe('call-normal');
+  });
+
+  it('suppresses tool_result by toolCallId even when toolName is missing', () => {
+    const registry = new AgentRegistry([]);
+    const sessionId = 'session-bang-no-name';
+    const timestamp = Date.now();
+    const events: ChatEvent[] = [
+      {
+        id: 'evt-shell-call',
+        timestamp,
+        sessionId,
+        type: 'tool_call',
+        payload: {
+          toolCallId: 'call-shell',
+          toolName: '_assistant_shell',
+          args: { command: 'ls' },
+        },
+      },
+      {
+        id: 'evt-shell-result',
+        timestamp: timestamp + 1,
+        sessionId,
+        type: 'tool_result',
+        payload: {
+          toolCallId: 'call-shell',
+          // toolName intentionally omitted — this is the case Gemini flagged
+          result: { output: 'file.txt' },
+        },
+      },
+    ];
+
+    const messages = buildChatMessagesFromEvents(events, registry, undefined, []);
+
+    // Only system message — both shell events suppressed
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.role).toBe('system');
   });
 });

--- a/packages/agent-server/src/sessionChatMessages.ts
+++ b/packages/agent-server/src/sessionChatMessages.ts
@@ -2,6 +2,7 @@ import type { ChatEvent } from '@assistant/shared';
 
 import type { Tool } from './tools';
 import type { AgentRegistry } from './agents';
+import { ASSISTANT_INTERNAL_TOOL_PREFIX } from './bangCommand';
 import { getAgentCallbackText, getUserVisibleUserText } from './chatEventText';
 import { buildSystemPrompt } from './systemPrompt';
 import type {
@@ -34,6 +35,21 @@ export function buildChatMessagesFromEvents(
       .filter((event) => event.type === 'interrupt')
       .map((event) => event.responseId?.trim())
       .filter((responseId): responseId is string => Boolean(responseId)),
+  );
+
+  // Collect toolCallIds for internal assistant tools (e.g. _assistant_shell)
+  // so we can suppress both the tool_call AND tool_result from LLM history.
+  // We track by toolCallId rather than toolName because toolName is optional
+  // on tool_result payloads — an orphaned role:'tool' message would crash the
+  // LLM completion request.
+  const suppressedToolCallIds = new Set(
+    events
+      .filter(
+        (event) =>
+          event.type === 'tool_call' &&
+          event.payload.toolName.startsWith(ASSISTANT_INTERNAL_TOOL_PREFIX),
+      )
+      .map((event) => (event as ChatEvent & { type: 'tool_call' }).payload.toolCallId),
   );
 
   const promptOptions = {
@@ -197,6 +213,9 @@ export function buildChatMessagesFromEvents(
         break;
       }
       case 'tool_call': {
+        if (suppressedToolCallIds.has(event.payload.toolCallId)) {
+          break;
+        }
         closeAssistantTextSegment(event.responseId?.trim());
         let argsJson = '{}';
         try {
@@ -237,6 +256,9 @@ export function buildChatMessagesFromEvents(
         break;
       }
       case 'tool_result': {
+        if (suppressedToolCallIds.has(event.payload.toolCallId)) {
+          break;
+        }
         closeAssistantToolCallSegment();
         closeAssistantTextSegment(event.responseId?.trim());
         const content = JSON.stringify({

--- a/packages/agent-server/src/sessionMessages.ts
+++ b/packages/agent-server/src/sessionMessages.ts
@@ -222,6 +222,7 @@ export async function startSessionMessage(options: {
       command: bangResult.command,
       sessionId: input.sessionId,
       sessionHub,
+      summary: state.summary,
       ...(eventStore ? { eventStore } : {}),
       ...(workingDir ? { workingDir } : {}),
     });

--- a/packages/agent-server/src/sessionMessages.ts
+++ b/packages/agent-server/src/sessionMessages.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type { AgentDefinition, AgentRegistry } from './agents';
+import { detectBangCommand, handleBangCommand } from './bangCommand';
 import { processUserMessage, isSessionBusy } from './chatProcessor';
 import type { ChatCompletionToolCallState } from './chatCompletionTypes';
 import type { EnvConfig } from './envConfig';
@@ -200,10 +201,50 @@ export async function startSessionMessage(options: {
 }): Promise<SessionMessageStartResult> {
   const { input, sessionIndex, sessionHub, toolHost, envConfig, eventStore } = options;
 
-  const content = input.content;
+  let content = input.content;
   if (!content.trim()) {
     throw new ToolError('invalid_arguments', 'content must be a non-empty string');
   }
+
+  // ── Bang command interception ──────────────────────────────────────────
+  const bangResult = detectBangCommand(content.trim());
+  if (bangResult.isBang) {
+    if (!bangResult.command) {
+      throw new ToolError(
+        'invalid_arguments',
+        'Shell command must not be empty (usage: !<command>)',
+      );
+    }
+    const summary = await requireSessionSummary(sessionIndex, input.sessionId);
+    const state = await sessionHub.ensureSessionState(input.sessionId, summary);
+    const workingDir = state.summary.attributes?.core?.workingDir as string | undefined;
+    await handleBangCommand({
+      command: bangResult.command,
+      sessionId: input.sessionId,
+      sessionHub,
+      ...(eventStore ? { eventStore } : {}),
+      ...(workingDir ? { workingDir } : {}),
+    });
+    return {
+      response: {
+        sessionId: input.sessionId,
+        sessionName: summary.name ?? input.sessionId,
+        agentId: summary.agentId ?? null,
+        created: false,
+        status: 'complete',
+        responseId: randomUUID(),
+        response: '',
+        truncated: false,
+        durationMs: 0,
+        toolCallCount: 0,
+        toolCalls: [],
+      },
+    };
+  }
+  if (!bangResult.isBang && bangResult.isEscape) {
+    content = bangResult.text;
+  }
+  // ── End bang command interception ───────────────────────────────────────
 
   const inputType = input.inputType ?? 'text';
   if (inputType !== 'text' && inputType !== 'audio') {

--- a/packages/agent-server/src/sessionMessages.ts
+++ b/packages/agent-server/src/sessionMessages.ts
@@ -207,16 +207,21 @@ export async function startSessionMessage(options: {
   }
 
   // ── Bang command interception ──────────────────────────────────────────
+  const bangAgentRegistry = options.agentRegistry ?? sessionHub.getAgentRegistry();
+  const bangSummary = await requireSessionSummary(sessionIndex, input.sessionId);
+  const bangAgentId = bangSummary.agentId;
+  const bangAgent = bangAgentId ? bangAgentRegistry.getAgent(bangAgentId) : undefined;
+  const bangEnabled = bangAgent?.bangCommandEnabled === true;
+
   const bangResult = detectBangCommand(content.trim());
-  if (bangResult.isBang) {
+  if (bangEnabled && bangResult.isBang) {
     if (!bangResult.command) {
       throw new ToolError(
         'invalid_arguments',
         'Shell command must not be empty (usage: !<command>)',
       );
     }
-    const summary = await requireSessionSummary(sessionIndex, input.sessionId);
-    const state = await sessionHub.ensureSessionState(input.sessionId, summary);
+    const state = await sessionHub.ensureSessionState(input.sessionId, bangSummary);
     const workingDir = state.summary.attributes?.core?.workingDir as string | undefined;
     await handleBangCommand({
       command: bangResult.command,
@@ -229,8 +234,8 @@ export async function startSessionMessage(options: {
     return {
       response: {
         sessionId: input.sessionId,
-        sessionName: summary.name ?? input.sessionId,
-        agentId: summary.agentId ?? null,
+        sessionName: bangSummary.name ?? input.sessionId,
+        agentId: bangSummary.agentId ?? null,
         created: false,
         status: 'complete',
         responseId: randomUUID(),
@@ -242,7 +247,7 @@ export async function startSessionMessage(options: {
       },
     };
   }
-  if (!bangResult.isBang && bangResult.isEscape) {
+  if (bangEnabled && !bangResult.isBang && bangResult.isEscape) {
     content = bangResult.text;
   }
   // ── End bang command interception ───────────────────────────────────────

--- a/packages/agent-server/src/ws/chatRunLifecycle.ts
+++ b/packages/agent-server/src/ws/chatRunLifecycle.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from 'node:crypto';
 
-import type { AssistantMessage as PiAssistantMessage, Message as PiSdkMessage } from '@mariozechner/pi-ai';
+import type {
+  AssistantMessage as PiAssistantMessage,
+  Message as PiSdkMessage,
+} from '@mariozechner/pi-ai';
 import type {
   ChatEvent,
   ClientAudioCapabilities,
@@ -9,6 +12,8 @@ import type {
   ServerTextDoneMessage,
   ServerUserMessageMessage,
 } from '@assistant/shared';
+
+import { detectBangCommand, handleBangCommand } from '../bangCommand';
 
 import type { ChatCompletionMessage, ChatCompletionToolCallState } from '../chatCompletionTypes';
 import type { AgentDefinition, PiSdkChatConfig } from '../agents';
@@ -288,11 +293,33 @@ export async function handleTextInputWithChatCompletions(options: {
     return;
   }
 
-  const text = message.text.trim();
+  let text = message.text.trim();
   if (!text) {
     sendError('empty_text', 'Text input must not be empty');
     return;
   }
+
+  // ── Bang command interception ──────────────────────────────────────────
+  const bangResult = detectBangCommand(text);
+  if (bangResult.isBang) {
+    if (!bangResult.command) {
+      sendError('empty_bang_command', 'Shell command must not be empty (usage: !<command>)');
+      return;
+    }
+    const workingDir = state.summary.attributes?.core?.workingDir as string | undefined;
+    await handleBangCommand({
+      command: bangResult.command,
+      sessionId,
+      sessionHub,
+      eventStore,
+      ...(workingDir ? { workingDir } : {}),
+    });
+    return;
+  }
+  if (!bangResult.isBang && bangResult.isEscape) {
+    text = bangResult.text;
+  }
+  // ── End bang command interception ───────────────────────────────────────
 
   const requestId = randomUUID();
 
@@ -525,9 +552,7 @@ export async function handleTextInputWithChatCompletions(options: {
       shouldEmitChatEvents,
       includeAgentExchangeIdInMessages: false,
       trackTextStartedAt: true,
-      ...(debugChatCompletionsContext !== undefined
-        ? { debugChatCompletionsContext }
-        : {}),
+      ...(debugChatCompletionsContext !== undefined ? { debugChatCompletionsContext } : {}),
       log,
       ...(agent ? { agent } : {}),
       ...(eventStore ? { eventStore } : {}),
@@ -572,12 +597,9 @@ export async function handleTextInputWithChatCompletions(options: {
         ...(runResult.provider === 'pi' ? { piTurnEndStatus: 'interrupted' as const } : {}),
       });
       if (timedOut) {
-        sendError(
-          'upstream_timeout',
-          'Chat backend request timed out',
-          undefined,
-          { retryable: true },
-        );
+        sendError('upstream_timeout', 'Chat backend request timed out', undefined, {
+          retryable: true,
+        });
       }
       return;
     }
@@ -602,7 +624,9 @@ export async function handleTextInputWithChatCompletions(options: {
         requestId,
         text: visibleAssistant.text,
         ...(visibleAssistant.phase ? { phase: visibleAssistant.phase } : {}),
-        ...(visibleAssistant.textSignature ? { textSignature: visibleAssistant.textSignature } : {}),
+        ...(visibleAssistant.textSignature
+          ? { textSignature: visibleAssistant.textSignature }
+          : {}),
       };
       sessionHub.broadcastToSession(sessionId, doneMessage);
 
@@ -721,25 +745,19 @@ export async function handleTextInputWithChatCompletions(options: {
       interruptReason: timedOut ? 'timeout' : 'error',
       error: {
         code: timedOut ? 'upstream_timeout' : isChatRunError(err) ? err.code : 'upstream_error',
-        message:
-          timedOut
-            ? 'Chat backend request timed out'
-            : isChatRunError(err)
-              ? err.message
-              : 'Chat backend error',
+        message: timedOut
+          ? 'Chat backend request timed out'
+          : isChatRunError(err)
+            ? err.message
+            : 'Chat backend error',
       },
       prependEvents: buildInterruptedAssistantEvents(),
       ...(chatProvider === 'pi' ? { piTurnEndStatus: 'interrupted' as const } : {}),
     });
     if (timedOut) {
-      sendError(
-        'upstream_timeout',
-        'Chat backend request timed out',
-        undefined,
-        {
-          retryable: true,
-        },
-      );
+      sendError('upstream_timeout', 'Chat backend request timed out', undefined, {
+        retryable: true,
+      });
       return;
     }
     if (isChatRunError(err)) {

--- a/packages/agent-server/src/ws/chatRunLifecycle.ts
+++ b/packages/agent-server/src/ws/chatRunLifecycle.ts
@@ -311,6 +311,7 @@ export async function handleTextInputWithChatCompletions(options: {
       command: bangResult.command,
       sessionId,
       sessionHub,
+      summary: state.summary,
       eventStore,
       ...(workingDir ? { workingDir } : {}),
     });

--- a/packages/agent-server/src/ws/chatRunLifecycle.ts
+++ b/packages/agent-server/src/ws/chatRunLifecycle.ts
@@ -300,8 +300,12 @@ export async function handleTextInputWithChatCompletions(options: {
   }
 
   // ── Bang command interception ──────────────────────────────────────────
+  const bangAgentId = state.summary.agentId;
+  const bangAgent = bangAgentId ? sessionHub.getAgentRegistry().getAgent(bangAgentId) : undefined;
+  const bangEnabled = bangAgent?.bangCommandEnabled === true;
+
   const bangResult = detectBangCommand(text);
-  if (bangResult.isBang) {
+  if (bangEnabled && bangResult.isBang) {
     if (!bangResult.command) {
       sendError('empty_bang_command', 'Shell command must not be empty (usage: !<command>)');
       return;
@@ -317,7 +321,7 @@ export async function handleTextInputWithChatCompletions(options: {
     });
     return;
   }
-  if (!bangResult.isBang && bangResult.isEscape) {
+  if (bangEnabled && !bangResult.isBang && bangResult.isEscape) {
     text = bangResult.text;
   }
   // ── End bang command interception ───────────────────────────────────────

--- a/packages/web-client/src/controllers/chatRenderer.ts
+++ b/packages/web-client/src/controllers/chatRenderer.ts
@@ -1638,8 +1638,9 @@ export class ChatRenderer {
     const offset = event.payload.offset;
     const eventToolName = event.payload.toolName;
 
-    // Dedup: ignore if we've already processed up to this offset
-    const lastOffset = this.toolOutputOffsets.get(callId) ?? 0;
+    // Dedup: ignore if we've already processed up to this offset.
+    // Default to -1 so the first chunk (offset=0) is not incorrectly skipped.
+    const lastOffset = this.toolOutputOffsets.get(callId) ?? -1;
     if (offset <= lastOffset) {
       return;
     }

--- a/packages/web-client/src/controllers/chatRenderer.ts
+++ b/packages/web-client/src/controllers/chatRenderer.ts
@@ -92,6 +92,7 @@ export type ProjectedTranscriptApplyResult = 'applied' | 'ignored' | 'reload';
 
 const VOICE_TOOL_NAMES = new Set(['voice_speak', 'voice_ask']);
 const ATTACHMENT_TOOL_NAME = 'attachment_send';
+const TERMINAL_TOOL_NAME = '_assistant_shell';
 
 type AttachmentExpansionState =
   | { status: 'loading' }
@@ -212,7 +213,10 @@ export class ChatRenderer {
   private readonly projectedTranscriptEvents = new Map<number, ProjectedTranscriptEvent>();
   private projectedTranscriptWatermarkRevision: number | null = null;
   private projectedTranscriptWatermarkSequence = -1;
-  private readonly attachmentExpansionStates = new WeakMap<HTMLDivElement, AttachmentExpansionState>();
+  private readonly attachmentExpansionStates = new WeakMap<
+    HTMLDivElement,
+    AttachmentExpansionState
+  >();
   private attachmentImageViewerOverlay: HTMLDivElement | null = null;
   private attachmentImageViewerEscapeHandler: ((event: KeyboardEvent) => void) | null = null;
   // Track text segment index per response.
@@ -448,25 +452,43 @@ export class ChatRenderer {
       case 'tool_call':
         this.handleToolCall({
           ...projectedBase,
-          payload: event.payload as { toolCallId: string; toolName: string; args?: Record<string, unknown> },
+          payload: event.payload as {
+            toolCallId: string;
+            toolName: string;
+            args?: Record<string, unknown>;
+          },
         });
         break;
       case 'tool_input':
         this.handleToolInputChunk({
           ...projectedBase,
-          payload: event.payload as { toolCallId: string; toolName: string; chunk: string; offset: number },
+          payload: event.payload as {
+            toolCallId: string;
+            toolName: string;
+            chunk: string;
+            offset: number;
+          },
         });
         break;
       case 'tool_output':
         this.handleToolOutputChunk({
           ...projectedBase,
-          payload: event.payload as { toolCallId: string; toolName: string; chunk: string; offset: number },
+          payload: event.payload as {
+            toolCallId: string;
+            toolName: string;
+            chunk: string;
+            offset: number;
+          },
         });
         break;
       case 'tool_result':
         this.handleToolResult({
           ...projectedBase,
-          payload: event.payload as { toolCallId: string; result?: unknown; error?: { code: string; message: string } },
+          payload: event.payload as {
+            toolCallId: string;
+            result?: unknown;
+            error?: { code: string; message: string };
+          },
         });
         break;
       case 'interaction_request':
@@ -522,7 +544,12 @@ export class ChatRenderer {
         if (event.chatEventType === 'agent_callback') {
           this.handleAgentCallback({
             ...projectedBase,
-            payload: event.payload as { messageId: string; fromAgentId: string; fromSessionId: string; result: string },
+            payload: event.payload as {
+              messageId: string;
+              fromAgentId: string;
+              fromSessionId: string;
+              result: string;
+            },
           });
           break;
         }
@@ -873,7 +900,6 @@ export class ChatRenderer {
           .join(' ');
       decorateUserMessageAsAgent(bubble, displayName || fromAgentId);
     }
-
   }
 
   private handleUserAudio(
@@ -912,10 +938,7 @@ export class ChatRenderer {
     return stripContextLine(rawText);
   }
 
-  private findRenderedUserBubble(
-    turnEl: HTMLDivElement,
-    eventId: string,
-  ): HTMLDivElement | null {
+  private findRenderedUserBubble(turnEl: HTMLDivElement, eventId: string): HTMLDivElement | null {
     const bubbles = turnEl.querySelectorAll<HTMLDivElement>('.message.user[data-event-id]');
     for (const bubble of Array.from(bubbles)) {
       if (bubble.dataset['eventId'] === eventId) {
@@ -966,7 +989,9 @@ export class ChatRenderer {
     bubble.textContent = text;
   }
 
-  private handleAssistantChunk(event: RenderedTranscriptEvent<AssistantChunkEvent['payload']>): void {
+  private handleAssistantChunk(
+    event: RenderedTranscriptEvent<AssistantChunkEvent['payload']>,
+  ): void {
     const responseId = this.getResponseId(event.responseId);
     if (!responseId) {
       return;
@@ -1312,6 +1337,41 @@ export class ChatRenderer {
       return;
     }
 
+    if (this.isTerminalToolName(toolName)) {
+      let bubble = this.toolCallElements.get(callId) ?? null;
+      if (!bubble) {
+        const responseEl = this.getOrCreateToolCallContainer(
+          event.id,
+          event.turnId,
+          callId,
+          responseId,
+          event.timestamp,
+        );
+        const terminalCommand = typeof args['command'] === 'string' ? args['command'] : undefined;
+        bubble = this.createTerminalBubble(callId, terminalCommand);
+        bubble.dataset['eventId'] = event.id;
+        bubble.dataset['renderer'] = 'unified';
+        const toolCallsContainer = this.getOrCreateToolCallsContainer(
+          responseEl,
+          responseId ?? undefined,
+        );
+        toolCallsContainer.appendChild(bubble);
+        this.toolCallElements.set(callId, bubble);
+      }
+
+      // Apply any buffered streaming output
+      const buffered = this.toolOutputBuffers.get(callId);
+      if (buffered) {
+        this.updateTerminalBubbleStreaming(bubble, buffered);
+      }
+      this.toolInputBuffers.delete(callId);
+      this.toolInputOffsets.delete(callId);
+      if (responseId) {
+        this.markTextSegmentBreak(responseId);
+      }
+      return;
+    }
+
     // Check if block was already created by tool_input_chunk streaming
     let block = this.toolCallElements.get(callId);
     const existingBlock = !!block;
@@ -1604,6 +1664,11 @@ export class ChatRenderer {
       return;
     }
 
+    if (this.isTerminalToolName(block.dataset['toolName'] ?? '')) {
+      this.updateTerminalBubbleStreaming(block, newBuffer);
+      return;
+    }
+
     const displayToolName = this.getDisplayToolNameForOutput(block, eventToolName);
 
     // Update with streaming content, mark as still pending
@@ -1659,8 +1724,42 @@ export class ChatRenderer {
       }
       return;
     }
+    if (block && this.isTerminalToolName(existingToolName)) {
+      const resultObj =
+        event.payload.result && typeof event.payload.result === 'object'
+          ? (event.payload.result as Record<string, unknown>)
+          : {};
+      this.finalizeTerminalBubble(block, resultObj, event.payload.error);
+      return;
+    }
     if (!block) {
       if (this.questionnaireToolCalls.has(callId)) {
+        return;
+      }
+      // Terminal tool result without a prior tool_call (e.g., on replay)
+      const resolvedToolName = resultToolName ?? streamedToolName ?? '';
+      if (this.isTerminalToolName(resolvedToolName)) {
+        const responseEl = this.getOrCreateToolCallContainer(
+          event.id,
+          event.turnId,
+          callId,
+          responseId,
+          event.timestamp,
+        );
+        block = this.createTerminalBubble(callId);
+        block.dataset['eventId'] = event.id;
+        block.dataset['renderer'] = 'unified';
+        const toolCallsContainer = this.getOrCreateToolCallsContainer(
+          responseEl,
+          responseId ?? undefined,
+        );
+        toolCallsContainer.appendChild(block);
+        this.toolCallElements.set(callId, block);
+        const resultObj =
+          event.payload.result && typeof event.payload.result === 'object'
+            ? (event.payload.result as Record<string, unknown>)
+            : {};
+        this.finalizeTerminalBubble(block, resultObj, event.payload.error);
         return;
       }
       const attachmentResult = getAttachmentToolResult(event.payload.result);
@@ -2673,7 +2772,6 @@ export class ChatRenderer {
       indicator.dataset['questionnaireTitle'] = payload.schemaTitle;
     }
     turnEl.appendChild(indicator);
-
   }
 
   private renderAgentCallbackIndicator(
@@ -2721,9 +2819,7 @@ export class ChatRenderer {
     }
   }
 
-  private handleError(
-    event: RenderedTranscriptEvent<{ code: string; message: string }>,
-  ): void {
+  private handleError(event: RenderedTranscriptEvent<{ code: string; message: string }>): void {
     const turnId = this.getTurnId(event.turnId, event.id);
     const turnEl = this.getOrCreateTurnContainer(turnId, event.timestamp);
 
@@ -3068,7 +3164,8 @@ export class ChatRenderer {
     return (
       toolName !== 'agents_message' &&
       !this.isVoiceToolName(toolName) &&
-      !this.isAttachmentToolName(toolName)
+      !this.isAttachmentToolName(toolName) &&
+      !this.isTerminalToolName(toolName)
     );
   }
 
@@ -3078,6 +3175,116 @@ export class ChatRenderer {
 
   private isAttachmentToolName(toolName: string): boolean {
     return toolName === ATTACHMENT_TOOL_NAME;
+  }
+
+  private isTerminalToolName(toolName: string): boolean {
+    return toolName === TERMINAL_TOOL_NAME;
+  }
+
+  private createTerminalBubble(callId: string, command?: string): HTMLDivElement {
+    const bubble = document.createElement('div');
+    bubble.className = 'message assistant terminal-tool-bubble';
+    bubble.dataset['toolCallId'] = callId;
+    bubble.dataset['toolName'] = TERMINAL_TOOL_NAME;
+    bubble.dataset['status'] = 'pending';
+    bubble.style.display = 'flex';
+    bubble.style.flexDirection = 'column';
+    bubble.style.gap = '8px';
+    bubble.style.padding = '12px 14px';
+    bubble.style.borderRadius = '14px';
+    bubble.style.border = '1px solid var(--color-border-subtle)';
+    bubble.style.background = 'var(--color-bg-elevated)';
+    bubble.style.maxWidth = '680px';
+
+    const header = document.createElement('div');
+    header.className = 'terminal-tool-header';
+    header.style.display = 'inline-flex';
+    header.style.alignItems = 'center';
+    header.style.gap = '8px';
+    header.style.color = 'var(--color-text-secondary)';
+    header.style.fontSize = '0.78em';
+    header.style.fontWeight = '600';
+    header.style.letterSpacing = '0.04em';
+    header.style.textTransform = 'uppercase';
+    header.appendChild(this.createTerminalIcon());
+
+    const label = document.createElement('span');
+    label.className = 'terminal-tool-label';
+    label.textContent = 'Terminal';
+    header.appendChild(label);
+
+    // Input block — shows the command immediately
+    const inputBlock = document.createElement('div');
+    inputBlock.className = 'terminal-tool-input markdown-content';
+    inputBlock.style.color = 'var(--color-message-assistant-text)';
+    inputBlock.style.lineHeight = 'var(--line-height-relaxed)';
+    if (command) {
+      applyMarkdownToElement(inputBlock, '```sh\n' + command + '\n```');
+    }
+    this.applyTerminalPreStyles(inputBlock);
+
+    // Output block — populated by streaming chunks and finalized result
+    const outputBlock = document.createElement('div');
+    outputBlock.className = 'terminal-tool-output markdown-content';
+    outputBlock.style.color = 'var(--color-message-assistant-text)';
+    outputBlock.style.lineHeight = 'var(--line-height-relaxed)';
+
+    bubble.append(header, inputBlock, outputBlock);
+    return bubble;
+  }
+
+  private updateTerminalBubbleStreaming(bubble: HTMLDivElement, text: string): void {
+    const outputBlock = bubble.querySelector<HTMLDivElement>('.terminal-tool-output');
+    if (outputBlock) {
+      applyMarkdownToElement(outputBlock, '```\n' + text.trimEnd() + '\n```');
+      this.applyTerminalPreStyles(outputBlock);
+    }
+  }
+
+  private finalizeTerminalBubble(
+    bubble: HTMLDivElement,
+    result: { output?: string; exitCode?: number | null; timedOut?: boolean; truncated?: boolean },
+    error?: { code: string; message: string },
+  ): void {
+    bubble.dataset['status'] = 'complete';
+    const isError =
+      !!error || (result.exitCode != null && result.exitCode !== 0) || result.timedOut;
+
+    if (isError) {
+      bubble.classList.add('error');
+      bubble.style.borderColor = 'var(--color-error-border)';
+      bubble.style.background = 'var(--color-error-soft)';
+    }
+
+    const outputBlock = bubble.querySelector<HTMLDivElement>('.terminal-tool-output');
+    if (outputBlock) {
+      const output = typeof result.output === 'string' ? result.output : '';
+      applyMarkdownToElement(outputBlock, output);
+      this.applyTerminalPreStyles(outputBlock);
+    }
+  }
+
+  /** Make `pre` blocks inside terminal bubbles span the full width. */
+  private applyTerminalPreStyles(container: HTMLDivElement): void {
+    const preEls = container.querySelectorAll<HTMLPreElement>('pre');
+    for (const pre of preEls) {
+      pre.style.display = 'block';
+      pre.style.width = '100%';
+    }
+  }
+
+  private createTerminalIcon(): HTMLSpanElement {
+    const icon = document.createElement('span');
+    icon.className = 'terminal-event-icon';
+    icon.setAttribute('aria-hidden', 'true');
+    icon.style.display = 'inline-flex';
+    icon.style.alignItems = 'center';
+    icon.style.justifyContent = 'center';
+    icon.style.width = '18px';
+    icon.style.height = '18px';
+    icon.innerHTML =
+      '<svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true"><polyline points="4 17 10 11 4 5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><line x1="12" y1="19" x2="20" y2="19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+    return icon;
   }
 
   private getVoiceToolText(args: Record<string, unknown>): string {
@@ -3354,7 +3561,10 @@ export class ChatRenderer {
           console.error('[attachments] Failed to copy attachment', error);
           button.disabled = false;
           button.textContent = originalLabel;
-          this.showAttachmentToolActionError(button.closest<HTMLDivElement>('.attachment-tool-bubble') ?? bubble, 'Failed to copy attachment.');
+          this.showAttachmentToolActionError(
+            button.closest<HTMLDivElement>('.attachment-tool-bubble') ?? bubble,
+            'Failed to copy attachment.',
+          );
         });
     });
   }
@@ -3518,7 +3728,8 @@ export class ChatRenderer {
 
     const metaEl = bubble.querySelector<HTMLElement>('.attachment-tool-meta');
     if (metaEl) {
-      metaEl.textContent = summary.title && summary.fileName ? summary.fileName : 'Preparing attachment…';
+      metaEl.textContent =
+        summary.title && summary.fileName ? summary.fileName : 'Preparing attachment…';
     }
 
     const previewEl = bubble.querySelector<HTMLDivElement>('.attachment-tool-preview');
@@ -3564,12 +3775,16 @@ export class ChatRenderer {
     const previewEl = bubble.querySelector<HTMLDivElement>('.attachment-tool-preview');
     const expansionState = this.attachmentExpansionStates.get(bubble);
     const expandedText =
-      expansionState?.status === 'ready' && expansionState.expanded ? expansionState.fullText : undefined;
+      expansionState?.status === 'ready' && expansionState.expanded
+        ? expansionState.fullText
+        : undefined;
     if (previewEl) {
       previewEl.replaceChildren();
       previewEl.classList.remove('expanded');
       if (typeof expandedText === 'string') {
-        this.renderAttachmentPreviewContent(previewEl, attachment, expandedText, { expanded: true });
+        this.renderAttachmentPreviewContent(previewEl, attachment, expandedText, {
+          expanded: true,
+        });
       } else if (this.isImageAttachmentPreviewable(attachment)) {
         this.renderAttachmentPreviewContent(previewEl, attachment, '', {});
       } else if (
@@ -3683,10 +3898,12 @@ export class ChatRenderer {
       if (attachment.openUrl && attachment.openMode === 'browser_blob') {
         const openButton = this.createAttachmentActionButton('Open', () => {
           this.clearAttachmentToolActionError(bubble);
-          void openHtmlAttachmentInBrowser(attachment.openUrl!, attachment.fileName).catch((error) => {
-            console.error('[attachments] Failed to open HTML attachment', error);
-            this.showAttachmentToolActionError(bubble, 'Failed to open attachment.');
-          });
+          void openHtmlAttachmentInBrowser(attachment.openUrl!, attachment.fileName).catch(
+            (error) => {
+              console.error('[attachments] Failed to open HTML attachment', error);
+              this.showAttachmentToolActionError(bubble, 'Failed to open attachment.');
+            },
+          );
         });
         actionsEl.appendChild(openButton);
       }


### PR DESCRIPTION
## Summary
- Add `!command` syntax for executing shell commands directly in chat sessions with real-time streaming output
- Uses the existing tool pipeline (`tool_call_start` → `tool_output_chunk` → `tool_result`) for streaming, persistence, and multi-user broadcast
- Suppresses `_assistant_` prefixed tool events from LLM context while keeping them in transcript history for replay
- Renders a dedicated terminal bubble with command input and streaming output in separate blocks
- Gated behind `bangCommandEnabled` agent config flag (default: false)
- Fixes a latent bug where the first `tool_output_chunk` (offset=0) was silently dropped by the renderer's dedup logic for all tools

## Test plan
- [x] Bang detection: `!pwd`, `!  ls`, `!!escape`, `!`, empty command, context line prefix
- [x] Shell execution: exit codes, timeout, output truncation during streaming, abort signal, cwd
- [x] LLM suppression: `_assistant_` tool events excluded from `buildChatMessagesFromEvents` and `toOpenAIMessages`, including missing `toolName` on `tool_result`
- [x] TypeScript compiles clean, lint passes, 121 tests pass (32 new + 89 existing chatRenderer)
- [x] Manual: verify streaming with `!for i in $(seq 1 5); do date; sleep 1; done`
- [x] Manual: verify turn deletion (delete before/after/this) removes terminal bubbles
- [x] Manual: verify `!!text` sends `!text` as normal message to LLM
