### PR TITLE
Sync Android status bar theme with web theme

### DIFF
--- a/.plans/status-bar-theme-sync/plan.md
+++ b/.plans/status-bar-theme-sync/plan.md
@@ -1,0 +1,184 @@
+# Status Bar Theme Sync Plan
+
+## Goal
+Make the Android native status bar icon/text appearance follow the web app's effective light/dark theme so status bar content stays readable for:
+- initial app launch
+- manual theme changes in Settings
+- live OS theme changes while the app is using `auto`
+
+## Current Findings
+
+### Web theme source of truth
+- Theme preferences are loaded and applied in `packages/web-client/src/index.ts`.
+- `syncThemePreferences()` already centralizes all theme updates:
+  - `init` on startup
+  - `user` when the theme select changes
+  - `system` when `watchSystemThemeChanges()` fires for `auto`
+- `applyThemePreferences()` in `packages/web-client/src/utils/themeManager.ts` resolves the effective scheme and returns it as `detail.scheme`.
+- `applyThemePreferences()` also emits `assistant:theme-updated`, but that event is currently informational only.
+
+### Current Capacitor status bar behavior
+- `packages/web-client/src/utils/capacitor.ts` has `configureStatusBar()`.
+- That function currently:
+  - applies Android CSS/layout shims
+  - imports `@capacitor/status-bar`
+  - unconditionally calls `StatusBar.setStyle({ style: Style.Dark })`
+- Result: the status bar is configured once and never updated when the app theme changes.
+
+### Native/plugin constraints
+- `@capacitor/status-bar` is already installed for the mobile build.
+- Capacitor's official docs define:
+  - `Style.Dark` = light text/icons for dark backgrounds
+  - `Style.Light` = dark text/icons for light backgrounds
+- The same docs note that `backgroundColor` and `overlaysWebView` are ineffective on Android 16+, but `setStyle()` still applies. That matches this task: we only need icon/text style sync, not background control.
+
+## Chosen Integration Point
+Use `syncThemePreferences()` in `packages/web-client/src/index.ts` as the only place that tells the native layer about theme changes.
+
+Why this is the best integration point:
+- it already sees every meaningful theme transition
+- it already has the resolved effective scheme, so the bridge does not need to re-implement theme resolution
+- it covers startup and runtime changes with one path
+- it keeps `themeManager.ts` platform-agnostic and keeps Capacitor-specific code in `capacitor.ts`
+- it avoids making core behavior depend on a window-level custom event listener
+
+The existing `assistant:theme-updated` event can remain for other consumers, but the status bar sync should be a direct call, not an event side effect.
+
+## Proposed Data Flow
+1. App startup loads saved theme preferences in `packages/web-client/src/index.ts`.
+2. `syncThemePreferences('init')` calls `applyThemePreferences(...)`.
+3. `applyThemePreferences(...)` returns `ThemeUpdateDetail`, including the resolved `scheme` (`light` or `dark`).
+4. `syncThemePreferences(...)` immediately calls a Capacitor helper with that resolved scheme.
+5. The Capacitor helper maps web scheme to native status bar style:
+   - `dark` web scheme -> `Style.Dark`
+   - `light` web scheme -> `Style.Light`
+6. The helper calls `StatusBar.setStyle(...)` only when running on Capacitor Android.
+7. The same path runs again for:
+   - manual theme selection changes
+   - `prefers-color-scheme` changes while `themeId === 'auto'`
+
+## Implementation Design
+
+### 1. Split static Android setup from dynamic style sync
+Keep `configureStatusBar()` responsible for Android WebView/layout setup only:
+- set `--capacitor-status-bar-height`
+- set `--capacitor-nav-bar-height`
+- add `.capacitor-android`
+- enable keyboard visibility handling
+
+Remove the hardcoded `StatusBar.setStyle({ style: Style.Dark })` from this startup-only setup.
+
+### 2. Add a dedicated status bar theme bridge
+Add a helper in `packages/web-client/src/utils/capacitor.ts`, for example:
+- `syncStatusBarThemeForScheme(scheme: ThemeScheme, options?)`
+
+Expected behavior:
+- no-op outside Capacitor Android
+- lazy-import `@capacitor/status-bar`
+- map resolved scheme to Capacitor style enum
+- swallow plugin/import failures like the other Capacitor helpers
+- cache the last applied native style to avoid redundant bridge calls when:
+  - fonts change without scheme changes
+  - `auto` recalculates to the same scheme
+  - startup/re-render paths repeat the same state
+
+### 3. Call the bridge from the existing theme sync path
+Update `packages/web-client/src/index.ts`:
+- after `const detail = applyThemePreferences(...)`
+- call `void syncStatusBarThemeForScheme(detail.scheme)`
+
+This gives one explicit path for:
+- first render after preferences load
+- user-initiated theme changes
+- system dark/light changes in `auto`
+
+### 4. Keep theme resolution in one place
+Do not make the Capacitor helper inspect `localStorage`, `matchMedia`, or DOM attributes.
+
+The helper should receive the resolved scheme from `applyThemePreferences(...)`. That keeps the native bridge dumb and prevents web/native theme logic from diverging.
+
+## Task Breakdown
+
+### Task 1: Add native sync helper
+- File: `packages/web-client/src/utils/capacitor.ts`
+- Add scheme-to-status-bar-style mapping helper.
+- Add last-applied caching for the native style.
+- Keep failure behavior silent/no-op outside Capacitor Android.
+
+### Task 2: Refactor startup setup
+- File: `packages/web-client/src/utils/capacitor.ts`
+- Remove the unconditional startup `Style.Dark` call from `configureStatusBar()`.
+- Leave the Android CSS/layout setup intact.
+
+### Task 3: Wire theme updates to native sync
+- File: `packages/web-client/src/index.ts`
+- Call the new helper from `syncThemePreferences()` using `detail.scheme`.
+
+### Task 4: Add unit coverage
+- File: `packages/web-client/src/utils/capacitor.test.ts`
+- Cover:
+  - `dark` scheme maps to `Style.Dark`
+  - `light` scheme maps to `Style.Light`
+  - non-Android / non-Capacitor is a no-op
+  - repeated same-scheme syncs do not call `setStyle` again
+  - importer/plugin failures are swallowed
+
+### Task 5: Validate on Android
+- Manual verification on a Capacitor Android build:
+  - launch with saved dark theme
+  - launch with saved light theme
+  - switch theme in Settings while app is open
+  - use `auto`, then change device theme while app is foregrounded
+
+## Edge Cases And Risks
+
+### Startup mismatch window
+- `configureStatusBar()` currently runs before theme preferences are applied in `main()`.
+- After the refactor, the first correct native style will be applied from `syncThemePreferences('init')`.
+- This should still happen very early, but there may be a brief mismatch during startup on light themes because the bridge call is async.
+- If this flash is noticeable, a follow-up optimization is to move the initial theme preference load even earlier in `main()` so the first native sync happens as soon as possible.
+
+### `auto` mode must track effective scheme, not stored theme id
+- The native bridge must not receive `'auto'`.
+- It must receive the resolved effective scheme from `applyThemePreferences(...)`.
+
+### Font-only preference changes
+- Changing UI/code font currently reuses `syncThemePreferences()`.
+- Without caching, font changes would spam `StatusBar.setStyle(...)` even though the scheme did not change.
+- The helper should dedupe by last applied native style.
+
+### Android-only behavior
+- This change should be a no-op on:
+  - desktop web
+  - mobile browser
+  - non-Android Capacitor targets unless explicitly expanded later
+
+### Status bar background is out of scope
+- This plan only syncs icon/text contrast.
+- Do not add background-color management as part of this change.
+- Capacitor docs explicitly warn that `backgroundColor`/`overlaysWebView` do not behave the same on newer Android versions, so that would expand scope and platform risk.
+
+### Existing theme attribute inconsistency
+- The preload script in `packages/web-client/public/index.html` sets `data-theme-tone`.
+- Runtime theme application sets `data-theme-scheme`.
+- This is not required for the status bar fix because the bridge should use `detail.scheme` directly.
+- Still, it is worth noting as a separate cleanup item because it shows two parallel representations of the same light/dark state.
+
+## Files Expected To Change
+- `packages/web-client/src/utils/capacitor.ts`
+- `packages/web-client/src/utils/capacitor.test.ts`
+- `packages/web-client/src/index.ts`
+- `CHANGELOG.md`
+
+## Out Of Scope
+- status bar background color changes
+- iOS-specific status bar theming work
+- redesigning the broader theme bootstrap flow
+- unifying `data-theme-tone` vs `data-theme-scheme` in this same task unless it becomes necessary during implementation
+
+## Recommended Implementation Order
+1. Add and test the new Capacitor status bar sync helper.
+2. Remove the hardcoded startup style from `configureStatusBar()`.
+3. Wire `syncThemePreferences()` to call the helper with `detail.scheme`.
+4. Run focused web-client tests.
+5. Verify behavior on Android manually.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 
+- Fixed Android Capacitor status bar styling so native status bar icons/text now follow the effective web light/dark theme, including live updates for `auto` system theme changes. ([#95](https://github.com/kcosr/assistant/pull/95))
 - Fixed first streaming `tool_output_chunk` (offset=0) being silently dropped by the renderer's dedup logic, improving incremental output visibility for all tool calls. ([#94](https://github.com/kcosr/assistant/pull/94))
 - Fixed Pi transcript replay and live hydration so canonical replay cursors, projected sequence watermarks, and same-revision live state stay monotonic across reloads/reconnects instead of rewinding, forcing reload loops, or resurfacing already-rendered events. ([#93](https://github.com/kcosr/assistant/pull/93))
 - Fixed Pi refresh/reconnect transcript startup so redundant session-ready reloads no longer trigger overlapping reset-style replay passes for the same session. ([#93](https://github.com/kcosr/assistant/pull/93))

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -237,6 +237,7 @@ import { apiFetch, getApiBaseUrl, getWebSocketUrl } from './utils/api';
 import {
   configureStatusBar,
   isCapacitorAndroid,
+  syncStatusBarThemeForScheme,
   setupAndroidAppLifecycleHandlers,
   setupBackButtonHandler,
 } from './utils/capacitor';
@@ -292,6 +293,8 @@ async function main(): Promise<void> {
       deactivateWindowSlot(WINDOW_ID);
     },
     onResume: () => {
+      const scheme = document.documentElement.getAttribute('data-theme-scheme') === 'dark' ? 'dark' : 'light';
+      void syncStatusBarThemeForScheme(scheme, { force: true });
       startHeartbeat();
       ensureConnected('capacitor-resume');
       void refreshSessions();
@@ -3412,6 +3415,7 @@ async function main(): Promise<void> {
   let themePreferences = loadThemePreferences();
   const syncThemePreferences = (source: 'init' | 'user' | 'system'): void => {
     const detail = applyThemePreferences(themePreferences, { source });
+    void syncStatusBarThemeForScheme(detail.scheme);
     themePreferences = {
       themeId: detail.themeId,
       uiFont: detail.uiFont,

--- a/packages/web-client/src/utils/capacitor.test.ts
+++ b/packages/web-client/src/utils/capacitor.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { setupAndroidAppLifecycleHandlers, setupBackButtonHandler } from './capacitor';
+import {
+  __resetCapacitorTestState,
+  setupAndroidAppLifecycleHandlers,
+  setupBackButtonHandler,
+  syncStatusBarThemeForScheme,
+} from './capacitor';
 
 type BackButtonListener = (event: { canGoBack?: boolean }) => void;
 
@@ -23,6 +28,7 @@ const createAppMock = () => {
 
 describe('setupBackButtonHandler', () => {
   afterEach(() => {
+    __resetCapacitorTestState();
     vi.restoreAllMocks();
   });
 
@@ -115,6 +121,7 @@ const createAppStateMock = () => {
 
 describe('setupAndroidAppLifecycleHandlers', () => {
   afterEach(() => {
+    __resetCapacitorTestState();
     vi.restoreAllMocks();
   });
 
@@ -180,5 +187,203 @@ describe('setupAndroidAppLifecycleHandlers', () => {
     Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
     document.dispatchEvent(new Event('visibilitychange'));
     expect(onResume).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('syncStatusBarThemeForScheme', () => {
+  afterEach(() => {
+    __resetCapacitorTestState();
+    delete (window as typeof window & { Capacitor?: unknown }).Capacitor;
+    vi.restoreAllMocks();
+  });
+
+  it('maps dark scheme to Style.Dark', async () => {
+    const setStyle = vi.fn(async () => {});
+    const importModule = (async () => ({
+      StatusBar: { setStyle },
+      Style: { Dark: 'DARK', Light: 'LIGHT' },
+    })) as unknown as <T>(specifier: string) => Promise<T>;
+
+    await syncStatusBarThemeForScheme('dark', {
+      importModule,
+      isAndroid: () => true,
+    });
+
+    expect(setStyle).toHaveBeenCalledWith({ style: 'DARK' });
+  });
+
+  it('maps light scheme to Style.Light', async () => {
+    const setStyle = vi.fn(async () => {});
+    const importModule = (async () => ({
+      StatusBar: { setStyle },
+      Style: { Dark: 'DARK', Light: 'LIGHT' },
+    })) as unknown as <T>(specifier: string) => Promise<T>;
+
+    await syncStatusBarThemeForScheme('light', {
+      importModule,
+      isAndroid: () => true,
+    });
+
+    expect(setStyle).toHaveBeenCalledWith({ style: 'LIGHT' });
+  });
+
+  it('is a no-op outside Android', async () => {
+    const importModule = vi.fn(async () => ({
+      StatusBar: { setStyle: vi.fn(async () => {}) },
+      Style: { Dark: 'DARK', Light: 'LIGHT' },
+    })) as unknown as <T>(specifier: string) => Promise<T>;
+
+    await syncStatusBarThemeForScheme('dark', {
+      importModule,
+      isAndroid: () => false,
+    });
+
+    expect(importModule).not.toHaveBeenCalled();
+  });
+
+  it('dedupes repeated syncs for the same scheme', async () => {
+    const setStyle = vi.fn(async () => {});
+    const importModule = (async () => ({
+      StatusBar: { setStyle },
+      Style: { Dark: 'DARK', Light: 'LIGHT' },
+    })) as unknown as <T>(specifier: string) => Promise<T>;
+
+    await syncStatusBarThemeForScheme('dark', {
+      importModule,
+      isAndroid: () => true,
+    });
+    await syncStatusBarThemeForScheme('dark', {
+      importModule,
+      isAndroid: () => true,
+    });
+
+    expect(setStyle).toHaveBeenCalledTimes(1);
+  });
+
+  it('reapplies the same scheme when forced', async () => {
+    const setStyle = vi.fn(async () => {});
+    const importModule = (async () => ({
+      StatusBar: { setStyle },
+      Style: { Dark: 'DARK', Light: 'LIGHT' },
+    })) as unknown as <T>(specifier: string) => Promise<T>;
+
+    await syncStatusBarThemeForScheme('dark', {
+      importModule,
+      isAndroid: () => true,
+    });
+    await syncStatusBarThemeForScheme('dark', {
+      importModule,
+      isAndroid: () => true,
+      force: true,
+    });
+
+    expect(setStyle).toHaveBeenCalledTimes(2);
+  });
+
+  it('applies the latest requested scheme after an in-flight update completes', async () => {
+    let resolveFirstCall: (() => void) | null = null;
+    const firstCallDone = new Promise<void>((resolve) => {
+      resolveFirstCall = resolve;
+    });
+    const setStyle = vi.fn(async ({ style }: { style: string }) => {
+      if (style === 'DARK') {
+        await firstCallDone;
+      }
+    });
+    const importModule = (async () => ({
+      StatusBar: { setStyle },
+      Style: { Dark: 'DARK', Light: 'LIGHT' },
+    })) as unknown as <T>(specifier: string) => Promise<T>;
+
+    const firstSync = syncStatusBarThemeForScheme('dark', {
+      importModule,
+      isAndroid: () => true,
+    });
+    await Promise.resolve();
+    const secondSync = syncStatusBarThemeForScheme('light', {
+      importModule,
+      isAndroid: () => true,
+    });
+
+    if (typeof resolveFirstCall !== 'function') {
+      throw new Error('Expected first call resolver to be assigned');
+    }
+    (resolveFirstCall as () => void)();
+    await Promise.all([firstSync, secondSync]);
+
+    expect(setStyle.mock.calls).toEqual([[{ style: 'DARK' }], [{ style: 'LIGHT' }]]);
+  });
+
+  it('swallows importer failures', async () => {
+    const importModule = vi.fn(async () => {
+      throw new Error('boom');
+    }) as unknown as <T>(specifier: string) => Promise<T>;
+
+    await expect(
+      syncStatusBarThemeForScheme('dark', {
+        importModule,
+        isAndroid: () => true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('falls back to the global Capacitor StatusBar plugin when import fails', async () => {
+    const setStyle = vi.fn(async () => {});
+    (
+      window as typeof window & {
+        Capacitor?: {
+          Plugins?: {
+            StatusBar?: {
+              setStyle: typeof setStyle;
+            };
+          };
+        };
+      }
+    ).Capacitor = {
+      Plugins: {
+        StatusBar: {
+          setStyle,
+        },
+      },
+    };
+
+    const importModule = vi.fn(async () => {
+      throw new Error('boom');
+    }) as unknown as <T>(specifier: string) => Promise<T>;
+
+    await syncStatusBarThemeForScheme('light', {
+      importModule,
+      isAndroid: () => true,
+    });
+
+    expect(setStyle).toHaveBeenCalledWith({ style: 'LIGHT' });
+  });
+
+  it('registers the global Capacitor StatusBar plugin when import fails', async () => {
+    const setStyle = vi.fn(async () => {});
+    const registerPlugin = vi.fn(() => ({
+      setStyle,
+    }));
+    (
+      window as typeof window & {
+        Capacitor?: {
+          registerPlugin?: typeof registerPlugin;
+        };
+      }
+    ).Capacitor = {
+      registerPlugin,
+    };
+
+    const importModule = vi.fn(async () => {
+      throw new Error('boom');
+    }) as unknown as <T>(specifier: string) => Promise<T>;
+
+    await syncStatusBarThemeForScheme('dark', {
+      importModule,
+      isAndroid: () => true,
+    });
+
+    expect(registerPlugin).toHaveBeenCalledWith('StatusBar');
+    expect(setStyle).toHaveBeenCalledWith({ style: 'DARK' });
   });
 });

--- a/packages/web-client/src/utils/capacitor.ts
+++ b/packages/web-client/src/utils/capacitor.ts
@@ -3,14 +3,50 @@
  * These functions safely no-op when not running in a Capacitor context.
  */
 
+export type NativeThemeScheme = 'light' | 'dark';
+
+type StatusBarPlugin = {
+  setStyle: (opts: { style: unknown }) => Promise<void> | void;
+};
+
+type StatusBarStyleValues = {
+  Dark: unknown;
+  Light: unknown;
+};
+
 // Helper to dynamically import Capacitor plugins without TypeScript resolution
 const importModule = new Function('specifier', 'return import(specifier)') as <T>(
   specifier: string,
 ) => Promise<T>;
 
-/**
- * Check if running in Capacitor Android context.
- */
+let lastAppliedStatusBarStyle: 'dark' | 'light' | null = null;
+let requestedStatusBarStyle: 'dark' | 'light' | null = null;
+let pendingStatusBarSync: Promise<void> | null = null;
+let lastStatusBarSyncFailed = false;
+
+function getCapacitorGlobal(): {
+  Plugins?: {
+    App?: unknown;
+    StatusBar?: unknown;
+  };
+  App?: unknown;
+  StatusBar?: unknown;
+  registerPlugin?: (name: string) => unknown;
+} | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  return ((window as unknown as { Capacitor?: unknown }).Capacitor ?? null) as {
+    Plugins?: {
+      App?: unknown;
+      StatusBar?: unknown;
+    };
+    App?: unknown;
+    StatusBar?: unknown;
+    registerPlugin?: (name: string) => unknown;
+  } | null;
+}
+
 /**
  * Check if running in Capacitor Android context.
  */
@@ -77,9 +113,7 @@ export async function setupBackButtonHandler(
         }
         return null;
       } catch {
-        const cap = (window as unknown as {
-          Capacitor?: { Plugins?: { App?: unknown }; App?: unknown };
-        }).Capacitor;
+        const cap = getCapacitorGlobal();
         const appPlugin = (
           (cap?.Plugins?.App as {
             addListener?: (
@@ -160,8 +194,111 @@ function setupKeyboardDetection(): void {
   window.visualViewport.addEventListener('resize', handleResize);
 }
 
+async function loadStatusBarPlugin(
+  importer: typeof importModule,
+): Promise<{ StatusBar: StatusBarPlugin; Style: StatusBarStyleValues } | null> {
+  try {
+    const { StatusBar, Style } = await importer<{
+      StatusBar: StatusBarPlugin;
+      Style: StatusBarStyleValues;
+    }>('@capacitor/status-bar');
+    if (StatusBar && typeof StatusBar.setStyle === 'function') {
+      return { StatusBar, Style };
+    }
+  } catch {
+    // Fall through to the global Capacitor bridge.
+  }
+
+  const cap = getCapacitorGlobal();
+  const statusBarPlugin = (
+    (cap?.Plugins?.StatusBar as StatusBarPlugin | undefined) ??
+    (cap?.StatusBar as StatusBarPlugin | undefined) ??
+    (typeof cap?.registerPlugin === 'function'
+      ? (cap.registerPlugin('StatusBar') as StatusBarPlugin)
+      : null)
+  ) as StatusBarPlugin | null;
+  if (!statusBarPlugin || typeof statusBarPlugin.setStyle !== 'function') {
+    return null;
+  }
+
+  // The native bridge accepts string enum values even without the ESM wrapper.
+  return {
+    StatusBar: statusBarPlugin,
+    Style: {
+      Dark: 'DARK',
+      Light: 'LIGHT',
+    },
+  };
+}
+
+export async function syncStatusBarThemeForScheme(
+  scheme: NativeThemeScheme,
+  options?: {
+    importModule?: typeof importModule;
+    isAndroid?: () => boolean;
+    force?: boolean;
+  },
+): Promise<void> {
+  const isAndroid = options?.isAndroid ?? isCapacitorAndroid;
+  if (!isAndroid()) {
+    return;
+  }
+
+  const styleKey = scheme === 'dark' ? 'dark' : 'light';
+  if (options?.force && lastAppliedStatusBarStyle === styleKey && !pendingStatusBarSync) {
+    lastAppliedStatusBarStyle = null;
+  }
+  requestedStatusBarStyle = styleKey;
+  if (lastAppliedStatusBarStyle === styleKey && !pendingStatusBarSync) {
+    return;
+  }
+  if (pendingStatusBarSync) {
+    await pendingStatusBarSync;
+    return;
+  }
+
+  const importer = options?.importModule ?? importModule;
+
+  pendingStatusBarSync = (async () => {
+    try {
+      lastStatusBarSyncFailed = false;
+      const statusBarModule = await loadStatusBarPlugin(importer);
+      if (!statusBarModule) {
+        return;
+      }
+      const { StatusBar, Style } = statusBarModule;
+
+      while (requestedStatusBarStyle && requestedStatusBarStyle !== lastAppliedStatusBarStyle) {
+        const nextStyle = requestedStatusBarStyle;
+        await StatusBar.setStyle({
+          style: nextStyle === 'dark' ? Style.Dark : Style.Light,
+        });
+        lastAppliedStatusBarStyle = nextStyle;
+      }
+    } catch {
+      // Not in Capacitor context or plugin not available.
+      lastStatusBarSyncFailed = true;
+    } finally {
+      pendingStatusBarSync = null;
+    }
+  })();
+
+  await pendingStatusBarSync;
+  if (
+    requestedStatusBarStyle &&
+    requestedStatusBarStyle !== lastAppliedStatusBarStyle &&
+    !pendingStatusBarSync &&
+    !lastStatusBarSyncFailed
+  ) {
+    await syncStatusBarThemeForScheme(
+      requestedStatusBarStyle === 'dark' ? 'dark' : 'light',
+      options,
+    );
+  }
+}
+
 /**
- * Configure mobile-specific styles and status bar.
+ * Configure mobile-specific layout shims for Capacitor Android.
  *
  * Adds fixed padding for Android status bar and navigation bar since
  * CSS safe-area-inset doesn't work reliably in Android WebView.
@@ -176,20 +313,6 @@ export async function configureStatusBar(): Promise<void> {
 
     // Detect keyboard visibility and hide bottom padding when keyboard is up
     setupKeyboardDetection();
-  }
-
-  try {
-    const { StatusBar, Style } = await importModule<{
-      StatusBar: {
-        setStyle: (opts: { style: unknown }) => Promise<void>;
-      };
-      Style: { Dark: unknown; Light: unknown };
-    }>('@capacitor/status-bar');
-
-    // Dark style (light text) to match our dark theme
-    await StatusBar.setStyle({ style: Style.Dark });
-  } catch {
-    // Not in Capacitor context or plugin not available
   }
 }
 
@@ -335,4 +458,11 @@ export async function openExternalUrl(url: string): Promise<void> {
   } catch {
     // Ignore failures opening the URL on web.
   }
+}
+
+export function __resetCapacitorTestState(): void {
+  lastAppliedStatusBarStyle = null;
+  requestedStatusBarStyle = null;
+  pendingStatusBarSync = null;
+  lastStatusBarSyncFailed = false;
 }


### PR DESCRIPTION
## Summary
- sync Android Capacitor status bar style from the resolved web light/dark scheme
- update the status bar style on theme changes and Android resume
- add focused coverage for mapping, dedupe, fallback, and async update ordering

## Testing
- npm test
- npm run build
