### PR TITLE
Add Pi session context compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Changed
 
+- Migrated Pi SDK dependencies from `@mariozechner/*` packages to the `@earendil-works/*` scope at `0.74.0`.
 - Removed startup caches for instruction skills and context files. Skills and context files are now read from disk on every access, ensuring the skills dropdown and system prompt always reflect the current state of files without requiring a server restart. ([#93](https://github.com/kcosr/assistant/pull/93))
 - Moved environment variable substitution to run before Zod validation (previously ran after), enabling `${VAR}` usage in template definitions. ([#93](https://github.com/kcosr/assistant/pull/93))
 - Changed Android native voice controls so the floating mobile FAB owns explicit voice start/stop with a target-session title chip, the chat-row control becomes stop-only, `Manual` mode allows explicit mic starts without automatic response/tool playback, and voice settings include standalone notification playback plus notification-title speech toggles. ([#97](https://github.com/kcosr/assistant/pull/97))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Added
 
-- Added Pi SDK session context compaction with Pi-compatible JSONL `compaction` entries, manual chat menu/API compaction, effective replay context, and threshold auto-compaction.
+- Added Pi SDK session context compaction with Pi-compatible JSONL `compaction` entries, manual chat menu/API compaction, effective replay context, and threshold auto-compaction. ([#98](https://github.com/kcosr/assistant/pull/98))
 - Added core notifications panel plugin with server-side storage, tool/HTTP/CLI ingress, live WebSocket panel updates, All/Unread filtering, Card/Compact density modes, read/unread toggle, session-linked navigation with resolved session titles, overflow menu for bulk actions, and panel tab unread-count badge. ([#96](https://github.com/kcosr/assistant/pull/96))
 - Added bang shell command feature (`!command`) for executing shell commands directly in chat with real-time streaming output, dedicated terminal bubble rendering, and `_assistant_` prefix LLM suppression. Gated behind `bangCommandEnabled` agent config flag (default: false). ([#94](https://github.com/kcosr/assistant/pull/94))
 - Added template-based agent configuration with `extends` support. Templates are named partial agent configs defined in a top-level `templates` section of `config.json`. Agents and templates can extend one or more templates via `extends` (string or array). Deep merge with null-clearing semantics. ([#93](https://github.com/kcosr/assistant/pull/93))
@@ -20,7 +20,7 @@
 
 ### Changed
 
-- Migrated Pi SDK dependencies from `@mariozechner/*` packages to the `@earendil-works/*` scope at `0.74.0`.
+- Migrated Pi SDK dependencies from `@mariozechner/*` packages to the `@earendil-works/*` scope at `0.74.0`. ([#98](https://github.com/kcosr/assistant/pull/98))
 - Removed startup caches for instruction skills and context files. Skills and context files are now read from disk on every access, ensuring the skills dropdown and system prompt always reflect the current state of files without requiring a server restart. ([#93](https://github.com/kcosr/assistant/pull/93))
 - Moved environment variable substitution to run before Zod validation (previously ran after), enabling `${VAR}` usage in template definitions. ([#93](https://github.com/kcosr/assistant/pull/93))
 - Changed Android native voice controls so the floating mobile FAB owns explicit voice start/stop with a target-session title chip, the chat-row control becomes stop-only, `Manual` mode allows explicit mic starts without automatic response/tool playback, and voice settings include standalone notification playback plus notification-title speech toggles. ([#97](https://github.com/kcosr/assistant/pull/97))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 
 ### Removed
 
+
 ## [0.18.1] - 2026-04-05
 
 ### Breaking Changes
@@ -84,6 +85,7 @@
 - Fixed panel inventory and `panels_selected` to report the actual active chat tab as the selected panel instead of surfacing a stale `empty` placeholder when chat is focused.
 
 ### Removed
+
 
 ## [0.18.0] - 2026-04-05
 
@@ -106,7 +108,6 @@
 - Added installable PWA icons to the mobile web manifest so the mobile app can be added to a home screen with proper `any maskable` icon sizes from 48px through 512px.
 
 ### Changed
-
 - Allowed Pi-backed agents to target custom `provider/model` ids through `chat.config.baseUrl` by
   synthesizing an `openai-responses` model when the provider has no built-in Pi model catalog.
 - Changed Android share-intent chat destinations to prefer the configured native voice session
@@ -156,6 +157,7 @@
 - Removed dead Pi EventStore overlay mirroring; Pi sessions now ignore EventStore persistence on the canonical path instead of duplicating overlay writes into the Pi transcript log.
 - Removed the dead Pi `ChatEvent` reconstruction helper and stale Pi history-provider test matrix; Pi replay validation now targets canonical transcript projection only.
 - Removed Pi replay support for legacy assistant overlay custom entries; canonical replay now restores only from canonical Pi `message` records plus request-boundary markers.
+
 
 ## [0.17.5] - 2026-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Added Pi SDK session context compaction with Pi-compatible JSONL `compaction` entries, manual chat menu/API compaction, effective replay context, and threshold auto-compaction.
 - Added core notifications panel plugin with server-side storage, tool/HTTP/CLI ingress, live WebSocket panel updates, All/Unread filtering, Card/Compact density modes, read/unread toggle, session-linked navigation with resolved session titles, overflow menu for bulk actions, and panel tab unread-count badge. ([#96](https://github.com/kcosr/assistant/pull/96))
 - Added bang shell command feature (`!command`) for executing shell commands directly in chat with real-time streaming output, dedicated terminal bubble rendering, and `_assistant_` prefix LLM suppression. Gated behind `bangCommandEnabled` agent config flag (default: false). ([#94](https://github.com/kcosr/assistant/pull/94))
 - Added template-based agent configuration with `extends` support. Templates are named partial agent configs defined in a top-level `templates` section of `config.json`. Agents and templates can extend one or more templates via `extends` (string or array). Deep merge with null-clearing semantics. ([#93](https://github.com/kcosr/assistant/pull/93))
@@ -63,7 +64,6 @@
 
 ### Removed
 
-
 ## [0.18.1] - 2026-04-05
 
 ### Breaking Changes
@@ -84,7 +84,6 @@
 - Fixed panel inventory and `panels_selected` to report the actual active chat tab as the selected panel instead of surfacing a stale `empty` placeholder when chat is focused.
 
 ### Removed
-
 
 ## [0.18.0] - 2026-04-05
 
@@ -107,6 +106,7 @@
 - Added installable PWA icons to the mobile web manifest so the mobile app can be added to a home screen with proper `any maskable` icon sizes from 48px through 512px.
 
 ### Changed
+
 - Allowed Pi-backed agents to target custom `provider/model` ids through `chat.config.baseUrl` by
   synthesizing an `openai-responses` model when the provider has no built-in Pi model catalog.
 - Changed Android share-intent chat destinations to prefer the configured native voice session
@@ -156,7 +156,6 @@
 - Removed dead Pi EventStore overlay mirroring; Pi sessions now ignore EventStore persistence on the canonical path instead of duplicating overlay writes into the Pi transcript log.
 - Removed the dead Pi `ChatEvent` reconstruction helper and stale Pi history-provider test matrix; Pi replay validation now targets canonical transcript projection only.
 - Removed Pi replay support for legacy assistant overlay custom entries; canonical replay now restores only from canonical Pi `message` records plus request-boundary markers.
-
 
 ## [0.17.5] - 2026-04-01
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -661,7 +661,7 @@ Notes:
   (default: 100).
 - `config.compaction`: optional Pi SDK context compaction controls. Compaction is enabled by
   default with Pi-compatible defaults: `reserveTokens: 16384` and `keepRecentTokens: 20000`.
-  Manual compaction is available from the chat request history menu for Pi-backed sessions, and
+  Manual compaction is available from the chat request history menu for in-process Pi SDK sessions, and
   automatic threshold compaction runs after completed Pi turns when usage exceeds
   `contextWindow - reserveTokens`.
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -338,12 +338,13 @@ relative file paths and `bash` commands anchor to the session picker’s working
 }
 ```
 
-| Field                 | Type   | Description                                                                                                                        |
-| --------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `mode`                | string | Execution mode. Only `local` is supported.                                                                                         |
+| Field                 | Type   | Description                                                                                                                         |
+| --------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `mode`                | string | Execution mode. Only `local` is supported.                                                                                          |
 | `local.workspaceRoot` | string | Root directory for local workspaces. `${session.workingDir}` resolves from `attributes.core.workingDir` for interactive tool calls. |
 
 Notes:
+
 - Coding tools now execute directly through the imported `@mariozechner/pi-coding-agent` local tool implementations.
 
 ##### Agents plugin tools (when enabled)
@@ -631,6 +632,11 @@ Notes:
       "maxTokens": 4096,
       "temperature": 0.7,
       "maxToolIterations": 100,
+      "compaction": {
+        "enabled": true,
+        "reserveTokens": 16384,
+        "keepRecentTokens": 20000
+      },
       "headers": {
         "X-Request-Source": "assistant"
       }
@@ -653,6 +659,11 @@ Notes:
 - `config.contextWindow`: optional context window override used for synthesized models (providers without a built-in Pi catalog entry when `config.baseUrl` is set).
 - `config.maxToolIterations`: max consecutive tool iterations before aborting with an error
   (default: 100).
+- `config.compaction`: optional Pi SDK context compaction controls. Compaction is enabled by
+  default with Pi-compatible defaults: `reserveTokens: 16384` and `keepRecentTokens: 20000`.
+  Manual compaction is available from the chat request history menu for Pi-backed sessions, and
+  automatic threshold compaction runs after completed Pi turns when usage exceeds
+  `contextWindow - reserveTokens`.
 
 Pi SDK sessions are mirrored to the Pi JSONL format so they can be resumed by the
 pi-mono CLI. Sessions are written to:
@@ -660,7 +671,9 @@ pi-mono CLI. Sessions are written to:
 The `cwd` comes from `attributes.core.workingDir` when available (otherwise the
 server working directory).
 Canceled runs still write partial assistant/tool entries so the pi-mono CLI can resume.
-Pi-backed sessions always persist canonical Pi JSONL history for replay and reload.
+Pi-backed sessions always persist canonical Pi JSONL history for replay and reload. Compacted Pi
+JSONL logs keep the full raw history on disk and add Pi-compatible `compaction` entries; future
+model context is rebuilt as summary plus the recent kept messages.
 
 #### CLI Providers (`claude-cli`, `codex-cli`, `pi-cli`)
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -50,7 +50,7 @@ Pi SDK chat uses provider-specific environment variables. Common examples includ
 
 The assistant does not resolve these itself; it passes requests to the Pi SDK, which
 reads the provider environment variables directly. For a complete list, see the
-`@mariozechner/pi-ai` README.
+`@earendil-works/pi-ai` README.
 
 ### Server
 
@@ -345,7 +345,7 @@ relative file paths and `bash` commands anchor to the session picker’s working
 
 Notes:
 
-- Coding tools now execute directly through the imported `@mariozechner/pi-coding-agent` local tool implementations.
+- Coding tools now execute directly through the imported `@earendil-works/pi-coding-agent` local tool implementations.
 
 ##### Agents plugin tools (when enabled)
 

--- a/docs/design/design-summary-pi-session-compaction.md
+++ b/docs/design/design-summary-pi-session-compaction.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-Add Pi-style context compaction for assistant's in-process `pi` provider sessions. Assistant already mirrors Pi SDK sessions to canonical Pi JSONL under `~/.pi/agent/sessions/...` and reloads Pi-backed state from that log; this feature extends that path so the log can contain Pi-compatible `compaction` entries, assistant can rebuild effective model context from them, users can trigger manual compaction from the chat request menu, and the server can automatically compact after threshold conditions. The compaction algorithm is vendored/adapted into assistant from pi-mono's coding-agent reference implementation rather than imported from `@mariozechner/pi-coding-agent` internals.
+Add Pi-style context compaction for assistant's in-process `pi` provider sessions. Assistant already mirrors Pi SDK sessions to canonical Pi JSONL under `~/.pi/agent/sessions/...` and reloads Pi-backed state from that log; this feature extends that path so the log can contain Pi-compatible `compaction` entries, assistant can rebuild effective model context from them, users can trigger manual compaction from the chat request menu, and the server can automatically compact after threshold or context-overflow conditions. The compaction algorithm is vendored/adapted into assistant from pi-mono's coding-agent reference implementation rather than imported from `@mariozechner/pi-coding-agent` internals.
 
 ## Motivation
 
-Long Pi-backed sessions can overflow while the agent is still working through tool calls. Pi mono mitigates this with threshold compaction and one-shot overflow recovery; this implementation adds the threshold/manual compaction foundation first so long-running local Pi SDK sessions can shed old context before the next turn.
+Long Pi-backed sessions can overflow while the agent is still working through tool calls. Pi mono mitigates this with threshold compaction and one-shot overflow recovery; assistant should mirror that behavior so unattended local Pi SDK sessions can continue instead of failing at the context limit.
 
 ## Scope
 
@@ -18,6 +18,7 @@ In scope:
 - Add a sessions plugin HTTP/tool operation for manual compaction.
 - Add per-agent Pi SDK compaction config with Pi mono-compatible defaults.
 - Add threshold auto-compaction after completed Pi runs.
+- Add defensive context-overflow detection that compacts and retries once.
 - Keep Pi transcript projection compatible with existing `summary_message` display.
 
 Out of scope:
@@ -27,7 +28,6 @@ Out of scope:
 - Adding extension hook support equivalent to Pi mono's `session_before_compact` / `session_compact` hooks.
 - Adding a custom-instructions UI for manual compaction.
 - Changing non-Pi event-store session persistence.
-- Adding defensive context-overflow detection that compacts and retries once. This remains a follow-up item.
 
 ## Contract
 
@@ -157,9 +157,9 @@ After a successful provider `pi` chat run:
 5. If over threshold, append a `compaction` entry with reason `threshold`, reload effective context into `state.chatMessages`, clear/update context usage as appropriate, and broadcast history change. The next Pi run rebuilds `piAgentRuntime.agent.state.messages` from canonical replay.
 6. Do not retry or continue automatically for threshold compaction; it prepares the next run.
 
-### Deferred overflow recovery
+### Overflow recovery
 
-One-shot overflow recovery is intentionally not part of this patch. A follow-up implementation should handle Pi assistant messages that end with `stopReason: 'error'`:
+When a Pi assistant message ends with `stopReason: 'error'`:
 
 1. If `isContextOverflow(message, contextWindow)` is false, keep current error behavior.
 2. If true and no overflow recovery was attempted for this outer run:
@@ -261,7 +261,7 @@ Assistant's internal Pi session entry union must add the `compaction` entry shap
 | `packages/agent-server/src/history/piSessionReplay.ts`    | Rebuild effective context from latest compaction instead of iterating only `message` entries; current replay loop only consumes `type: message` at lines 193-261.                                                         | `packages/agent-server/src/history/piSessionReplay.test.ts`                                                                 |
 | `packages/agent-server/src/history/historyProvider.ts`    | Keep/verify transcript projection for `compaction`; existing code maps `compaction` to `summary_message` at lines 2123-2137.                                                                                              | `packages/agent-server/src/history/historyProvider` coverage via `chatEventUtils.test.ts` and sessions plugin replay tests. |
 | `packages/agent-server/src/sessionHub.ts`                 | Add `compactSession`; enforce no active run for manual compaction; update state and broadcast history change like `editSessionHistory`; current Pi writer access is lines 166-212 and history edit flow is lines 610-680. | `packages/agent-server/src/sessionHub.test.ts`                                                                              |
-| `packages/agent-server/src/chatRunCore.ts`                | Pass Pi context-window information through the run result so the processor can evaluate threshold compaction after a completed turn. Overflow detection/retry is deferred.                                                | `packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts`                                                                  |
+| `packages/agent-server/src/chatRunCore.ts`                | Add overflow detection/retry around Pi agent prompt; current Pi branch creates the agent at lines 1285-1455 and throws upstream errors at lines 1799-1810.                                                                | `packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts`                                                                  |
 | `packages/agent-server/src/chatProcessor.ts`              | Trigger threshold auto-compaction after Pi sync/finalization; current final Pi sync is lines 818-833 and turn finalization is lines 840-848.                                                                              | `packages/agent-server/src/chatProcessor.test.ts`, Pi lifecycle tests.                                                      |
 | `packages/agent-server/src/chatTurnFinalization.ts`       | No code change required; `chatProcessor.ts` calls `finalizeChatTurn()` before threshold compaction, so the compaction entry remains outside the just-finished request boundary.                                           | `packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts`                                                                  |
 | `packages/plugins/core/sessions/manifest.json`            | Add `compact` operation next to `clear` and `history-edit`; existing operations are listed around lines 213-247.                                                                                                          | `packages/plugins/core/sessions/server/index.test.ts`                                                                       |
@@ -282,7 +282,8 @@ Assistant's internal Pi session entry union must add the `compaction` entry shap
 6. Add sessions plugin `compact` operation and web-client `SessionManager.compactSession()` method.
 7. Add **Compact Context** to the chat request history menu with confirmation and status handling.
 8. Add threshold auto-compaction after successful Pi turn finalization and final Pi history sync.
-9. Add tests for config parsing, compaction preparation, Pi JSONL replay, writer alignment, manual operation, UI action path, and threshold compaction.
+9. Add one-shot overflow recovery in the Pi runtime path using `isContextOverflow`, compacting and retrying the same prompt once.
+10. Add tests for config parsing, compaction preparation, Pi JSONL replay, writer alignment, manual operation, UI action path, threshold compaction, and overflow retry.
 
 ## Diagrams
 
@@ -303,11 +304,27 @@ sequenceDiagram
   Sessions-->>UI: {compacted:true, revision}
 ```
 
+```mermaid
+sequenceDiagram
+  participant Runtime as Pi chat runtime
+  participant Model as Pi SDK/model
+  participant Writer as PiSessionWriter
+
+  Runtime->>Model: prompt / continue
+  Model-->>Runtime: assistant error (context overflow)
+  Runtime->>Runtime: detect isContextOverflow and not attempted
+  Runtime->>Writer: compact persisted/effective context
+  Writer-->>Runtime: compaction result
+  Runtime->>Runtime: reload effective context without overflow error
+  Runtime->>Model: retry same prompt once
+```
+
 ## Risks
 
 - **Replay mismatch after compaction:** `PiSessionWriter.sync()` currently aligns against every persisted message signature; after compaction it must align against effective context or future writes may be skipped as unreconcilable.
 - **Visible transcript vs model context divergence:** transcript projection should show `summary_message`, while model context should receive a synthetic user summary message. These are related but not identical paths.
 - **Request boundary ordering:** auto threshold compaction should append after `appendTurnEnd`, otherwise history edit spans and replay grouping could include compaction inside the just-finished request.
+- **Overflow retry duplication:** retrying after an overflow must avoid duplicating user prompts, tool results, or partial assistant text in `state.chatMessages` and Pi JSONL.
 - **Stale usage after compaction:** kept assistant messages may carry pre-compaction usage; threshold logic must ignore usage older than the latest compaction entry, mirroring Pi mono's stale-usage guard.
 - **Concurrent manual compaction:** manual compaction must reject active runs, and writer operations must remain serialized through the existing write queue.
 - **Default-on behavior:** enabling compaction by default mirrors Pi mono but changes runtime behavior for existing Pi SDK agents; documentation and config override are required.
@@ -321,6 +338,7 @@ Implemented tests:
 - `packages/agent-server/src/history/piCompaction.test.ts`: covers the Pi threshold rule and previous-summary update behavior.
 - `packages/agent-server/src/history/piSessionReplay.test.ts`: loads a Pi JSONL file with a `compaction` entry and verifies effective context is summary + kept messages + post-compaction messages.
 - `packages/agent-server/src/chatProcessor.test.ts`: threshold auto-compaction delegates to `SessionHub.compactSession` after a completed Pi run, with `allowActiveRun: true` because the active run is cleared in the processor's `finally` block.
+- `packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts`: one-shot overflow compaction/retry when a Pi run returns a context-overflow error.
 - `packages/plugins/core/sessions/server/index.test.ts`: `compact` operation delegates to `SessionHub.compactSession` and returns the expected response.
 - `packages/shared/src/protocol.test.ts`: accepts any new compact response schema.
 
@@ -330,7 +348,6 @@ Follow-up coverage still worth adding:
 - `packages/agent-server/src/history/piSessionWriter.test.ts`: compaction entry append, effective signature reload, appending messages after compaction, and history rewrite compatibility.
 - `packages/agent-server/src/sessionHub.test.ts`: non-Pi and active-session rejections, successful state reload, revision/context usage updates, and broadcasts.
 - Web client unit coverage for `SessionManager.compactSession` error display if a controller harness is added.
-- Future overflow recovery coverage when that feature is implemented.
 
 Commands:
 
@@ -338,7 +355,7 @@ Commands:
 npm run build -w @assistant/shared
 npm run build -w @assistant/agent-server
 npm run build -w @assistant/web-client
-npm test -- packages/agent-server/src/history/piCompaction.test.ts packages/agent-server/src/history/piSessionReplay.test.ts packages/agent-server/src/chatProcessor.test.ts packages/plugins/core/sessions/server/index.test.ts packages/shared/src/protocol.test.ts
+npm test -- packages/agent-server/src/history/piCompaction.test.ts packages/agent-server/src/history/piSessionReplay.test.ts packages/agent-server/src/chatProcessor.test.ts packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts packages/plugins/core/sessions/server/index.test.ts packages/shared/src/protocol.test.ts
 npm run lint
 npm run format
 ```
@@ -347,6 +364,7 @@ Manual checks:
 
 - Start the server with a Pi SDK agent and low synthetic `contextWindow` / high reserve to force threshold compaction.
 - Verify **Compact Context** appears at the bottom of the request history menu and causes a compaction summary to appear in replay.
+- Verify a forced context overflow compacts and retries once without surfacing the first overflow error.
 
 ## Open Assumptions
 

--- a/docs/design/design-summary-pi-session-compaction.md
+++ b/docs/design/design-summary-pi-session-compaction.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-Add Pi-style context compaction for assistant's in-process `pi` provider sessions. Assistant already mirrors Pi SDK sessions to canonical Pi JSONL under `~/.pi/agent/sessions/...` and reloads Pi-backed state from that log; this feature extends that path so the log can contain Pi-compatible `compaction` entries, assistant can rebuild effective model context from them, users can trigger manual compaction from the chat request menu, and the server can automatically compact after threshold or context-overflow conditions. The compaction algorithm should be vendored/adapted into assistant from pi-mono's coding-agent reference implementation rather than imported from `@mariozechner/pi-coding-agent` internals.
+Add Pi-style context compaction for assistant's in-process `pi` provider sessions. Assistant already mirrors Pi SDK sessions to canonical Pi JSONL under `~/.pi/agent/sessions/...` and reloads Pi-backed state from that log; this feature extends that path so the log can contain Pi-compatible `compaction` entries, assistant can rebuild effective model context from them, users can trigger manual compaction from the chat request menu, and the server can automatically compact after threshold conditions. The compaction algorithm is vendored/adapted into assistant from pi-mono's coding-agent reference implementation rather than imported from `@mariozechner/pi-coding-agent` internals.
 
 ## Motivation
 
-Long Pi-backed sessions can overflow while the agent is still working through tool calls. Pi mono mitigates this with threshold compaction and one-shot overflow recovery; assistant should mirror that behavior so unattended local Pi SDK sessions can continue instead of failing at the context limit.
+Long Pi-backed sessions can overflow while the agent is still working through tool calls. Pi mono mitigates this with threshold compaction and one-shot overflow recovery; this implementation adds the threshold/manual compaction foundation first so long-running local Pi SDK sessions can shed old context before the next turn.
 
 ## Scope
 
@@ -18,7 +18,6 @@ In scope:
 - Add a sessions plugin HTTP/tool operation for manual compaction.
 - Add per-agent Pi SDK compaction config with Pi mono-compatible defaults.
 - Add threshold auto-compaction after completed Pi runs.
-- Add defensive context-overflow detection that compacts and retries once.
 - Keep Pi transcript projection compatible with existing `summary_message` display.
 
 Out of scope:
@@ -28,6 +27,7 @@ Out of scope:
 - Adding extension hook support equivalent to Pi mono's `session_before_compact` / `session_compact` hooks.
 - Adding a custom-instructions UI for manual compaction.
 - Changing non-Pi event-store session persistence.
+- Adding defensive context-overflow detection that compacts and retries once. This remains a follow-up item.
 
 ## Contract
 
@@ -39,8 +39,8 @@ Extend `PiSdkChatConfig` with an optional `compaction` object:
 interface PiSdkChatConfig {
   // existing fields...
   compaction?: {
-    enabled?: boolean;        // default: true
-    reserveTokens?: number;  // default: 16384
+    enabled?: boolean; // default: true
+    reserveTokens?: number; // default: 16384
     keepRecentTokens?: number; // default: 20000
   };
 }
@@ -105,7 +105,7 @@ Error behavior:
   - Confirm style: primary.
 - On confirm, call `POST /api/plugins/sessions/operations/compact`.
 - On success with `compacted: true`, reload the session transcript just like `session_history_changed` handling does today.
-- On failure, show `Failed to compact context`.
+- On failure, show the server-provided compact error when available, otherwise show `Failed to compact context`.
 
 ### Pi JSONL compaction entry
 
@@ -124,7 +124,7 @@ type PiSessionCompactionEntry = {
     readFiles: string[];
     modifiedFiles: string[];
   };
-  fromHook?: false;
+  fromHook?: boolean;
 };
 ```
 
@@ -154,12 +154,12 @@ After a successful provider `pi` chat run:
 4. Evaluate the final assistant message usage against compaction settings:
    - `contextTokens = usage.totalTokens || input + output + cacheRead + cacheWrite`
    - compact when `contextTokens > contextWindow - reserveTokens`
-5. If over threshold, append a `compaction` entry with reason `threshold`, reload effective context into `state.chatMessages` and `piAgentRuntime.agent.state.messages`, clear/update context usage as appropriate, and broadcast history change.
+5. If over threshold, append a `compaction` entry with reason `threshold`, reload effective context into `state.chatMessages`, clear/update context usage as appropriate, and broadcast history change. The next Pi run rebuilds `piAgentRuntime.agent.state.messages` from canonical replay.
 6. Do not retry or continue automatically for threshold compaction; it prepares the next run.
 
-### Overflow recovery
+### Deferred overflow recovery
 
-When a Pi assistant message ends with `stopReason: 'error'`:
+One-shot overflow recovery is intentionally not part of this patch. A follow-up implementation should handle Pi assistant messages that end with `stopReason: 'error'`:
 
 1. If `isContextOverflow(message, contextWindow)` is false, keep current error behavior.
 2. If true and no overflow recovery was attempted for this outer run:
@@ -173,15 +173,15 @@ When a Pi assistant message ends with `stopReason: 'error'`:
 
 ## Surface Inventory
 
-| Name | Disposition | Layers | Symmetric peers | Removal twin |
-|---|---|---|---|---|
-| `Compact Context` | Added | Chat request history menu, confirmation dialog, `SessionManager` client method, sessions plugin `compact` operation, `SessionHub.compactSession`, `PiSessionWriter.appendCompaction` | Existing `Delete Before`, `Delete Request`, `Delete After`, `Reset Session` menu actions | None |
-| `POST /api/plugins/sessions/operations/compact` | Added | Sessions plugin manifest, plugin operation handler, generic plugin operation HTTP route, web client API call | Existing `/api/plugins/sessions/operations/history-edit` and `/clear` | None |
-| `chat.config.compaction.enabled` | Added | Config schema, agent runtime compaction checks, docs | Pi mono `CompactionSettings.enabled` | None |
-| `chat.config.compaction.reserveTokens` | Added | Config schema, threshold check, docs | Pi mono `reserveTokens` default 16384 | None |
-| `chat.config.compaction.keepRecentTokens` | Added | Config schema, cut point selection, docs | Pi mono `keepRecentTokens` default 20000 | None |
-| Pi JSONL entry `type: "compaction"` | Added for assistant writer, already understood by Pi mono | Pi session writer, replay parser, transcript projector, tests | Pi mono `SessionManager.appendCompaction()` | None |
-| `summary_message` with `summaryType: "compaction"` | Existing/used | Canonical Pi transcript projection and UI transcript rendering | Existing branch summary projection | None |
+| Name                                               | Disposition                                               | Layers                                                                                                                                                                               | Symmetric peers                                                                          | Removal twin |
+| -------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- | ------------ |
+| `Compact Context`                                  | Added                                                     | Chat request history menu, confirmation dialog, `SessionManager` client method, sessions plugin `compact` operation, `SessionHub.compactSession`, `PiSessionWriter.appendCompaction` | Existing `Delete Before`, `Delete Request`, `Delete After`, `Reset Session` menu actions | None         |
+| `POST /api/plugins/sessions/operations/compact`    | Added                                                     | Sessions plugin manifest, plugin operation handler, generic plugin operation HTTP route, web client API call                                                                         | Existing `/api/plugins/sessions/operations/history-edit` and `/clear`                    | None         |
+| `chat.config.compaction.enabled`                   | Added                                                     | Config schema, agent runtime compaction checks, docs                                                                                                                                 | Pi mono `CompactionSettings.enabled`                                                     | None         |
+| `chat.config.compaction.reserveTokens`             | Added                                                     | Config schema, threshold check, docs                                                                                                                                                 | Pi mono `reserveTokens` default 16384                                                    | None         |
+| `chat.config.compaction.keepRecentTokens`          | Added                                                     | Config schema, cut point selection, docs                                                                                                                                             | Pi mono `keepRecentTokens` default 20000                                                 | None         |
+| Pi JSONL entry `type: "compaction"`                | Added for assistant writer, already understood by Pi mono | Pi session writer, replay parser, transcript projector, tests                                                                                                                        | Pi mono `SessionManager.appendCompaction()`                                              | None         |
+| `summary_message` with `summaryType: "compaction"` | Existing/used                                             | Canonical Pi transcript projection and UI transcript rendering                                                                                                                       | Existing branch summary projection                                                       | None         |
 
 ## Schema
 
@@ -229,15 +229,19 @@ export const SessionCompactResponseSchema = z.object({
   reason: z.literal('manual'),
   updatedAt: z.string(),
   revision: z.number().int().nonnegative(),
-  result: z.object({
-    summary: z.string(),
-    firstKeptEntryId: z.string(),
-    tokensBefore: z.number().int().nonnegative(),
-    details: z.object({
-      readFiles: z.array(z.string()),
-      modifiedFiles: z.array(z.string()),
-    }).optional(),
-  }).optional(),
+  result: z
+    .object({
+      summary: z.string(),
+      firstKeptEntryId: z.string(),
+      tokensBefore: z.number().int().nonnegative(),
+      details: z
+        .object({
+          readFiles: z.array(z.string()),
+          modifiedFiles: z.array(z.string()),
+        })
+        .optional(),
+    })
+    .optional(),
 });
 ```
 
@@ -247,30 +251,30 @@ Assistant's internal Pi session entry union must add the `compaction` entry shap
 
 ## Impact Surface
 
-| File | Responsibility | Existing tests |
-|---|---|---|
-| `packages/agent-server/src/config.ts` | Parse `chat.config.compaction` under `PiSdkChatConfigSchema`; current Pi config includes `timeoutMs`, `maxTokens`, `contextWindow`, `temperature`, `maxToolIterations` at lines 213-222. | `packages/agent-server/src/config.test.ts` |
-| `packages/agent-server/src/agents.ts` | Add `compaction` to `PiSdkChatConfig`; current interface is lines 182-196. | Config and lifecycle tests indirectly cover resolved agent definitions. |
-| `packages/agent-server/src/contextUsage.ts` | Reuse `calculateContextTokens()` and `buildSessionContextUsage()` logic; current usage calculation and percent are lines 4-44. | `packages/agent-server/src/contextUsage.test.ts` |
-| `packages/agent-server/src/history/piCompaction.ts` (new) | Vendored/adapted pure compaction logic: settings, token estimation, cut-point selection, summarization, file-op tracking. | New unit tests mirroring pi-mono compaction cases. |
-| `packages/agent-server/src/history/piSessionWriter.ts` | Add compaction entry type, `appendCompaction`, effective-signature loading, history rewrite compatibility; current entry union lacks compaction at lines 50-92 and sync alignment is lines 1472-1674. | `packages/agent-server/src/history/piSessionWriter.test.ts` |
-| `packages/agent-server/src/history/piSessionReplay.ts` | Rebuild effective context from latest compaction instead of iterating only `message` entries; current replay loop only consumes `type: message` at lines 193-261. | `packages/agent-server/src/history/piSessionReplay.test.ts` |
-| `packages/agent-server/src/history/historyProvider.ts` | Keep/verify transcript projection for `compaction`; existing code maps `compaction` to `summary_message` at lines 2123-2137. | `packages/agent-server/src/history/historyProvider` coverage via `chatEventUtils.test.ts` and sessions plugin replay tests. |
-| `packages/agent-server/src/sessionHub.ts` | Add `compactSession`; enforce no active run for manual compaction; update state and broadcast history change like `editSessionHistory`; current Pi writer access is lines 166-212 and history edit flow is lines 610-680. | `packages/agent-server/src/sessionHub.test.ts` |
-| `packages/agent-server/src/chatRunCore.ts` | Add overflow detection/retry around Pi agent prompt; current Pi branch creates the agent at lines 1285-1455 and currently throws upstream errors at lines 1799-1810. | `packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts` |
-| `packages/agent-server/src/chatProcessor.ts` | Trigger threshold auto-compaction after Pi sync/finalization; current final Pi sync is lines 818-833 and turn finalization is lines 840-848. | `packages/agent-server/src/chatProcessor.test.ts`, Pi lifecycle tests. |
-| `packages/agent-server/src/chatTurnFinalization.ts` | Ensure auto-compaction runs after `appendTurnEnd` so the compaction entry is outside the just-finished request boundary; turn-end persistence is lines 84-116. | `packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts` |
-| `packages/plugins/core/sessions/manifest.json` | Add `compact` operation next to `clear` and `history-edit`; existing operations are listed around lines 213-247. | `packages/plugins/core/sessions/server/index.test.ts` |
-| `packages/plugins/core/sessions/server/index.ts` | Add `compact` operation handler returning `SessionCompactResponse`; current `history-edit` delegates to `SessionHub.editSessionHistory` at lines 700-728. | `packages/plugins/core/sessions/server/index.test.ts` |
-| `packages/shared/src/protocol.ts` | Add optional `SessionCompactResponseSchema`; existing session history edit schemas are lines 585-607 and context usage schemas are lines 5-17. | `packages/shared/src/protocol.test.ts` |
-| `packages/web-client/src/index.ts` | Add menu item and confirmation dialog; existing request menu items are lines 3447-3493. | Existing web-client tests are sparse; add targeted controller/utility tests if practical. |
-| `packages/web-client/src/controllers/sessionManager.ts` | Add `compactSession(sessionId)` calling `sessionsOperationPath('compact')`; current history edit method is lines 131-152. | Add unit coverage if a harness exists; otherwise cover via manual/browser smoke. |
-| `docs/CONFIG.md` | Document `chat.config.compaction`; current Pi provider docs and Pi JSONL note are lines 619-663. | Documentation review. |
-| `docs/design/pi-sdk-provider.md` | Optional cross-link to this design; current history compatibility section describes Pi JSONL mirroring. | Documentation review. |
+| File                                                      | Responsibility                                                                                                                                                                                                            | Existing tests                                                                                                              |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `packages/agent-server/src/config.ts`                     | Parse `chat.config.compaction` under `PiSdkChatConfigSchema`; current Pi config includes `timeoutMs`, `maxTokens`, `contextWindow`, `temperature`, `maxToolIterations` at lines 213-222.                                  | `packages/agent-server/src/config.test.ts`                                                                                  |
+| `packages/agent-server/src/agents.ts`                     | Add `compaction` to `PiSdkChatConfig`; current interface is lines 182-196.                                                                                                                                                | Config and lifecycle tests indirectly cover resolved agent definitions.                                                     |
+| `packages/agent-server/src/contextUsage.ts`               | Reuse `calculateContextTokens()` and `buildSessionContextUsage()` logic; current usage calculation and percent are lines 4-44.                                                                                            | `packages/agent-server/src/contextUsage.test.ts`                                                                            |
+| `packages/agent-server/src/history/piCompaction.ts` (new) | Vendored/adapted pure compaction logic: settings, token estimation, cut-point selection, summarization, file-op tracking.                                                                                                 | New unit tests mirroring pi-mono compaction cases.                                                                          |
+| `packages/agent-server/src/history/piSessionWriter.ts`    | Add compaction entry type, `appendCompaction`, effective-signature loading, history rewrite compatibility; current entry union lacks compaction at lines 50-92 and sync alignment is lines 1472-1674.                     | `packages/agent-server/src/history/piSessionWriter.test.ts`                                                                 |
+| `packages/agent-server/src/history/piSessionReplay.ts`    | Rebuild effective context from latest compaction instead of iterating only `message` entries; current replay loop only consumes `type: message` at lines 193-261.                                                         | `packages/agent-server/src/history/piSessionReplay.test.ts`                                                                 |
+| `packages/agent-server/src/history/historyProvider.ts`    | Keep/verify transcript projection for `compaction`; existing code maps `compaction` to `summary_message` at lines 2123-2137.                                                                                              | `packages/agent-server/src/history/historyProvider` coverage via `chatEventUtils.test.ts` and sessions plugin replay tests. |
+| `packages/agent-server/src/sessionHub.ts`                 | Add `compactSession`; enforce no active run for manual compaction; update state and broadcast history change like `editSessionHistory`; current Pi writer access is lines 166-212 and history edit flow is lines 610-680. | `packages/agent-server/src/sessionHub.test.ts`                                                                              |
+| `packages/agent-server/src/chatRunCore.ts`                | Pass Pi context-window information through the run result so the processor can evaluate threshold compaction after a completed turn. Overflow detection/retry is deferred.                                                | `packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts`                                                                  |
+| `packages/agent-server/src/chatProcessor.ts`              | Trigger threshold auto-compaction after Pi sync/finalization; current final Pi sync is lines 818-833 and turn finalization is lines 840-848.                                                                              | `packages/agent-server/src/chatProcessor.test.ts`, Pi lifecycle tests.                                                      |
+| `packages/agent-server/src/chatTurnFinalization.ts`       | No code change required; `chatProcessor.ts` calls `finalizeChatTurn()` before threshold compaction, so the compaction entry remains outside the just-finished request boundary.                                           | `packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts`                                                                  |
+| `packages/plugins/core/sessions/manifest.json`            | Add `compact` operation next to `clear` and `history-edit`; existing operations are listed around lines 213-247.                                                                                                          | `packages/plugins/core/sessions/server/index.test.ts`                                                                       |
+| `packages/plugins/core/sessions/server/index.ts`          | Add `compact` operation handler returning `SessionCompactResponse`; current `history-edit` delegates to `SessionHub.editSessionHistory` at lines 700-728.                                                                 | `packages/plugins/core/sessions/server/index.test.ts`                                                                       |
+| `packages/shared/src/protocol.ts`                         | Add optional `SessionCompactResponseSchema`; existing session history edit schemas are lines 585-607 and context usage schemas are lines 5-17.                                                                            | `packages/shared/src/protocol.test.ts`                                                                                      |
+| `packages/web-client/src/index.ts`                        | Add menu item and confirmation dialog; existing request menu items are lines 3447-3493.                                                                                                                                   | Existing web-client tests are sparse; add targeted controller/utility tests if practical.                                   |
+| `packages/web-client/src/controllers/sessionManager.ts`   | Add `compactSession(sessionId)` calling `sessionsOperationPath('compact')`; current history edit method is lines 131-152.                                                                                                 | Add unit coverage if a harness exists; otherwise cover via manual/browser smoke.                                            |
+| `docs/CONFIG.md`                                          | Document `chat.config.compaction`; current Pi provider docs and Pi JSONL note are lines 619-663.                                                                                                                          | Documentation review.                                                                                                       |
+| `docs/design/pi-sdk-provider.md`                          | Optional cross-link to this design; current history compatibility section describes Pi JSONL mirroring.                                                                                                                   | Documentation review.                                                                                                       |
 
 ## Higher-Level Implementation Steps
 
-1. Add assistant-local Pi compaction modules adapted from pi-mono `packages/coding-agent/src/core/compaction`, preserving source comments and adding an adaptation note with the referenced pi-mono version/commit.
+1. Add assistant-local Pi compaction modules adapted from pi-mono `packages/coding-agent/src/core/compaction`, preserving source comments and adding an adaptation note with the referenced pi-mono version.
 2. Extend `PiSdkChatConfig` parsing, type definitions, and docs with compaction settings and Pi mono-compatible defaults.
 3. Add compaction-aware Pi JSONL parsing utilities that return both raw entries and effective context, including synthetic compaction summary user messages.
 4. Update `PiSessionWriter` to append `compaction` entries, reload effective signatures, and keep history rewrite/rechain behavior valid after compaction.
@@ -278,8 +282,7 @@ Assistant's internal Pi session entry union must add the `compaction` entry shap
 6. Add sessions plugin `compact` operation and web-client `SessionManager.compactSession()` method.
 7. Add **Compact Context** to the chat request history menu with confirmation and status handling.
 8. Add threshold auto-compaction after successful Pi turn finalization and final Pi history sync.
-9. Add one-shot overflow recovery in the Pi runtime path using `isContextOverflow`, compacting and retrying the same prompt once.
-10. Add tests for config parsing, compaction preparation, Pi JSONL replay, writer alignment, manual operation, UI action path, threshold compaction, and overflow retry.
+9. Add tests for config parsing, compaction preparation, Pi JSONL replay, writer alignment, manual operation, UI action path, and threshold compaction.
 
 ## Diagrams
 
@@ -300,27 +303,11 @@ sequenceDiagram
   Sessions-->>UI: {compacted:true, revision}
 ```
 
-```mermaid
-sequenceDiagram
-  participant Runtime as Pi chat runtime
-  participant Model as Pi SDK/model
-  participant Writer as PiSessionWriter
-
-  Runtime->>Model: prompt / continue
-  Model-->>Runtime: assistant error (context overflow)
-  Runtime->>Runtime: detect isContextOverflow and not attempted
-  Runtime->>Writer: compact persisted/effective context
-  Writer-->>Runtime: compaction result
-  Runtime->>Runtime: reload effective context without overflow error
-  Runtime->>Model: retry same prompt once
-```
-
 ## Risks
 
 - **Replay mismatch after compaction:** `PiSessionWriter.sync()` currently aligns against every persisted message signature; after compaction it must align against effective context or future writes may be skipped as unreconcilable.
 - **Visible transcript vs model context divergence:** transcript projection should show `summary_message`, while model context should receive a synthetic user summary message. These are related but not identical paths.
 - **Request boundary ordering:** auto threshold compaction should append after `appendTurnEnd`, otherwise history edit spans and replay grouping could include compaction inside the just-finished request.
-- **Overflow retry duplication:** retrying after an overflow must avoid duplicating user prompts, tool results, or partial assistant text in `state.chatMessages` and Pi JSONL.
 - **Stale usage after compaction:** kept assistant messages may carry pre-compaction usage; threshold logic must ignore usage older than the latest compaction entry, mirroring Pi mono's stale-usage guard.
 - **Concurrent manual compaction:** manual compaction must reject active runs, and writer operations must remain serialized through the existing write queue.
 - **Default-on behavior:** enabling compaction by default mirrors Pi mono but changes runtime behavior for existing Pi SDK agents; documentation and config override are required.
@@ -328,18 +315,22 @@ sequenceDiagram
 
 ## Test Strategy
 
-New/updated tests:
+Implemented tests:
 
 - `packages/agent-server/src/config.test.ts`: parses `chat.config.compaction`, defaults are applied by resolver/helper, invalid numbers are rejected.
-- `packages/agent-server/src/history/piCompaction.test.ts`: covers token estimation, cut-point selection, previous-summary update behavior, split-turn summary preparation, and file-op details.
+- `packages/agent-server/src/history/piCompaction.test.ts`: covers the Pi threshold rule and previous-summary update behavior.
 - `packages/agent-server/src/history/piSessionReplay.test.ts`: loads a Pi JSONL file with a `compaction` entry and verifies effective context is summary + kept messages + post-compaction messages.
-- `packages/agent-server/src/history/piSessionWriter.test.ts`: appends compaction entries, reloads effective signatures after compaction, appends new messages after compaction, and keeps history rewrite behavior valid.
-- `packages/agent-server/src/sessionHub.test.ts`: manual compact rejects non-Pi and active sessions; successful compact reloads state, bumps revision, clears/updates context usage, and broadcasts history change.
-- `packages/plugins/core/sessions/server/index.test.ts`: `compact` operation delegates to `SessionHub.compactSession` and returns expected response/errors.
-- `packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts`: threshold auto-compaction after completed Pi run and one-shot overflow compaction/retry.
-- `packages/agent-server/src/chatProcessor.test.ts`: final assistant sync occurs before threshold compaction and turn finalization ordering remains correct.
+- `packages/agent-server/src/chatProcessor.test.ts`: threshold auto-compaction delegates to `SessionHub.compactSession` after a completed Pi run, with `allowActiveRun: true` because the active run is cleared in the processor's `finally` block.
+- `packages/plugins/core/sessions/server/index.test.ts`: `compact` operation delegates to `SessionHub.compactSession` and returns the expected response.
 - `packages/shared/src/protocol.test.ts`: accepts any new compact response schema.
-- Web client test if practical for `SessionManager.compactSession`; otherwise manual browser smoke for the menu.
+
+Follow-up coverage still worth adding:
+
+- `packages/agent-server/src/history/piCompaction.test.ts`: token estimation edge cases, cut-point selection, split-turn summary preparation, and file-op details.
+- `packages/agent-server/src/history/piSessionWriter.test.ts`: compaction entry append, effective signature reload, appending messages after compaction, and history rewrite compatibility.
+- `packages/agent-server/src/sessionHub.test.ts`: non-Pi and active-session rejections, successful state reload, revision/context usage updates, and broadcasts.
+- Web client unit coverage for `SessionManager.compactSession` error display if a controller harness is added.
+- Future overflow recovery coverage when that feature is implemented.
 
 Commands:
 
@@ -347,7 +338,7 @@ Commands:
 npm run build -w @assistant/shared
 npm run build -w @assistant/agent-server
 npm run build -w @assistant/web-client
-npm test -- packages/agent-server/src/history/piSessionReplay.test.ts packages/agent-server/src/history/piSessionWriter.test.ts packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts packages/plugins/core/sessions/server/index.test.ts packages/shared/src/protocol.test.ts
+npm test -- packages/agent-server/src/history/piCompaction.test.ts packages/agent-server/src/history/piSessionReplay.test.ts packages/agent-server/src/chatProcessor.test.ts packages/plugins/core/sessions/server/index.test.ts packages/shared/src/protocol.test.ts
 npm run lint
 npm run format
 ```
@@ -356,7 +347,6 @@ Manual checks:
 
 - Start the server with a Pi SDK agent and low synthetic `contextWindow` / high reserve to force threshold compaction.
 - Verify **Compact Context** appears at the bottom of the request history menu and causes a compaction summary to appear in replay.
-- Verify a forced context overflow compacts and retries once without surfacing the first overflow error.
 
 ## Open Assumptions
 

--- a/docs/design/design-summary-pi-session-compaction.md
+++ b/docs/design/design-summary-pi-session-compaction.md
@@ -92,12 +92,12 @@ Error behavior:
 - `session_not_found` if the session does not exist.
 - `invalid_arguments` if the session is not Pi-backed.
 - `invalid_arguments` if `PiSessionWriter` is unavailable.
-- `invalid_arguments` if the session has an active chat run; manual compaction does not interrupt active runs.
+- `session_busy` if the session has an active chat run; manual compaction does not interrupt active runs.
 - `invalid_arguments` with `Already compacted` or `Nothing to compact (session too small)` when no compaction entry can be produced.
 
 ### UI behavior
 
-- Add **Compact Context** at the bottom of the existing request history menu, below **Reset Session**.
+- Add **Compact Context** at the bottom of the existing request history menu, below **Reset Session**, only for provider `pi` sessions.
 - The action opens a confirmation dialog:
   - Title: `Compact Context`
   - Message: `Summarize older Pi session history and keep recent context?`

--- a/docs/design/design-summary-pi-session-compaction.md
+++ b/docs/design/design-summary-pi-session-compaction.md
@@ -1,0 +1,367 @@
+# Pi Session Compaction
+
+## Overview
+
+Add Pi-style context compaction for assistant's in-process `pi` provider sessions. Assistant already mirrors Pi SDK sessions to canonical Pi JSONL under `~/.pi/agent/sessions/...` and reloads Pi-backed state from that log; this feature extends that path so the log can contain Pi-compatible `compaction` entries, assistant can rebuild effective model context from them, users can trigger manual compaction from the chat request menu, and the server can automatically compact after threshold or context-overflow conditions. The compaction algorithm should be vendored/adapted into assistant from pi-mono's coding-agent reference implementation rather than imported from `@mariozechner/pi-coding-agent` internals.
+
+## Motivation
+
+Long Pi-backed sessions can overflow while the agent is still working through tool calls. Pi mono mitigates this with threshold compaction and one-shot overflow recovery; assistant should mirror that behavior so unattended local Pi SDK sessions can continue instead of failing at the context limit.
+
+## Scope
+
+In scope:
+
+- Add assistant-owned Pi compaction helpers adapted from pi-mono coding-agent's pure compaction logic.
+- Add Pi JSONL `compaction` entry writing and effective-context replay in assistant's Pi session history layer.
+- Add a manual **Compact Context** action to the existing request history menu in the chat UI.
+- Add a sessions plugin HTTP/tool operation for manual compaction.
+- Add per-agent Pi SDK compaction config with Pi mono-compatible defaults.
+- Add threshold auto-compaction after completed Pi runs.
+- Add defensive context-overflow detection that compacts and retries once.
+- Keep Pi transcript projection compatible with existing `summary_message` display.
+
+Out of scope:
+
+- Changing `claude-cli`, `codex-cli`, or `pi-cli` compaction behavior.
+- Importing or deep-importing `@mariozechner/pi-coding-agent` compaction modules directly.
+- Adding extension hook support equivalent to Pi mono's `session_before_compact` / `session_compact` hooks.
+- Adding a custom-instructions UI for manual compaction.
+- Changing non-Pi event-store session persistence.
+
+## Contract
+
+### Configuration
+
+Extend `PiSdkChatConfig` with an optional `compaction` object:
+
+```ts
+interface PiSdkChatConfig {
+  // existing fields...
+  compaction?: {
+    enabled?: boolean;        // default: true
+    reserveTokens?: number;  // default: 16384
+    keepRecentTokens?: number; // default: 20000
+  };
+}
+```
+
+Validation rules:
+
+- `enabled` is boolean.
+- `reserveTokens` and `keepRecentTokens` are positive integers.
+- Missing `compaction` uses `{ enabled: true, reserveTokens: 16384, keepRecentTokens: 20000 }`, matching pi-mono coding-agent defaults.
+- These settings apply only to provider `pi`.
+
+### Manual compaction operation
+
+Add a sessions plugin operation and HTTP endpoint:
+
+```http
+POST /api/plugins/sessions/operations/compact
+Content-Type: application/json
+
+{
+  "sessionId": "<session-id>"
+}
+```
+
+Successful response:
+
+```ts
+type SessionCompactResponse = {
+  sessionId: string;
+  compacted: boolean;
+  reason: 'manual';
+  updatedAt: string;
+  revision: number;
+  result?: {
+    summary: string;
+    firstKeptEntryId: string;
+    tokensBefore: number;
+    details?: {
+      readFiles: string[];
+      modifiedFiles: string[];
+    };
+  };
+};
+```
+
+Error behavior:
+
+- `session_not_found` if the session does not exist.
+- `invalid_arguments` if the session is not Pi-backed.
+- `invalid_arguments` if `PiSessionWriter` is unavailable.
+- `invalid_arguments` if the session has an active chat run; manual compaction does not interrupt active runs.
+- `invalid_arguments` with `Already compacted` or `Nothing to compact (session too small)` when no compaction entry can be produced.
+
+### UI behavior
+
+- Add **Compact Context** at the bottom of the existing request history menu, below **Reset Session**.
+- The action opens a confirmation dialog:
+  - Title: `Compact Context`
+  - Message: `Summarize older Pi session history and keep recent context?`
+  - Confirm text: `Compact`
+  - Confirm style: primary.
+- On confirm, call `POST /api/plugins/sessions/operations/compact`.
+- On success with `compacted: true`, reload the session transcript just like `session_history_changed` handling does today.
+- On failure, show `Failed to compact context`.
+
+### Pi JSONL compaction entry
+
+Append Pi-compatible compaction entries:
+
+```ts
+type PiSessionCompactionEntry = {
+  type: 'compaction';
+  id: string;
+  parentId: string | null;
+  timestamp: string;
+  summary: string;
+  firstKeptEntryId: string;
+  tokensBefore: number;
+  details?: {
+    readFiles: string[];
+    modifiedFiles: string[];
+  };
+  fromHook?: false;
+};
+```
+
+After a compaction entry is written, assistant must bump the Pi transcript revision and broadcast `session_history_changed` so connected clients reload canonical replay.
+
+### Effective context replay
+
+When loading or syncing Pi-backed state from canonical Pi JSONL:
+
+1. Walk the current linear parent chain.
+2. Locate the latest `compaction` entry on that chain.
+3. Build effective model context as:
+   - a synthetic user message containing the compaction summary, using the Pi mono text wrapper:
+     `The conversation history before this point was compacted into the following summary:\n\n<summary>...`
+   - kept messages from `firstKeptEntryId` up to the compaction entry
+   - messages after the compaction entry
+4. Preserve assistant `piSdkMessage` objects and tool result linkage for kept messages.
+5. Use the same effective context signatures in `PiSessionWriter.sync()` alignment so appending after compaction does not compare against discarded raw-history signatures.
+
+### Auto threshold compaction
+
+After a successful provider `pi` chat run:
+
+1. Finish normal assistant response handling.
+2. Persist final Pi assistant/tool messages with `PiSessionWriter.sync()`.
+3. Persist the Pi turn end boundary.
+4. Evaluate the final assistant message usage against compaction settings:
+   - `contextTokens = usage.totalTokens || input + output + cacheRead + cacheWrite`
+   - compact when `contextTokens > contextWindow - reserveTokens`
+5. If over threshold, append a `compaction` entry with reason `threshold`, reload effective context into `state.chatMessages` and `piAgentRuntime.agent.state.messages`, clear/update context usage as appropriate, and broadcast history change.
+6. Do not retry or continue automatically for threshold compaction; it prepares the next run.
+
+### Overflow recovery
+
+When a Pi assistant message ends with `stopReason: 'error'`:
+
+1. If `isContextOverflow(message, contextWindow)` is false, keep current error behavior.
+2. If true and no overflow recovery was attempted for this outer run:
+   - mark recovery attempted
+   - remove the failed assistant error from active model context
+   - compact current persisted/effective Pi context with reason `overflow`
+   - reload effective context
+   - retry the same prompt/request once
+3. If the retry also overflows or compaction fails, surface an error equivalent to: `Context overflow recovery failed after one compact-and-retry attempt. Try reducing context or switching to a larger-context model.`
+4. The overflow error assistant message should not be part of the retried model context.
+
+## Surface Inventory
+
+| Name | Disposition | Layers | Symmetric peers | Removal twin |
+|---|---|---|---|---|
+| `Compact Context` | Added | Chat request history menu, confirmation dialog, `SessionManager` client method, sessions plugin `compact` operation, `SessionHub.compactSession`, `PiSessionWriter.appendCompaction` | Existing `Delete Before`, `Delete Request`, `Delete After`, `Reset Session` menu actions | None |
+| `POST /api/plugins/sessions/operations/compact` | Added | Sessions plugin manifest, plugin operation handler, generic plugin operation HTTP route, web client API call | Existing `/api/plugins/sessions/operations/history-edit` and `/clear` | None |
+| `chat.config.compaction.enabled` | Added | Config schema, agent runtime compaction checks, docs | Pi mono `CompactionSettings.enabled` | None |
+| `chat.config.compaction.reserveTokens` | Added | Config schema, threshold check, docs | Pi mono `reserveTokens` default 16384 | None |
+| `chat.config.compaction.keepRecentTokens` | Added | Config schema, cut point selection, docs | Pi mono `keepRecentTokens` default 20000 | None |
+| Pi JSONL entry `type: "compaction"` | Added for assistant writer, already understood by Pi mono | Pi session writer, replay parser, transcript projector, tests | Pi mono `SessionManager.appendCompaction()` | None |
+| `summary_message` with `summaryType: "compaction"` | Existing/used | Canonical Pi transcript projection and UI transcript rendering | Existing branch summary projection | None |
+
+## Schema
+
+### Config schema
+
+Before:
+
+```ts
+const PiSdkChatConfigSchema = z.object({
+  provider: ...,
+  apiKey: ...,
+  baseUrl: ...,
+  headers: ...,
+  timeoutMs: ...,
+  maxTokens: ...,
+  contextWindow: ...,
+  temperature: ...,
+  maxToolIterations: ...,
+});
+```
+
+After:
+
+```ts
+const PiSdkCompactionConfigSchema = z.object({
+  enabled: z.boolean().optional(),
+  reserveTokens: z.number().int().min(1).optional(),
+  keepRecentTokens: z.number().int().min(1).optional(),
+});
+
+const PiSdkChatConfigSchema = z.object({
+  // existing fields...
+  compaction: PiSdkCompactionConfigSchema.optional(),
+});
+```
+
+### Shared protocol / operation types
+
+Add shared response typing for manual compaction if the project keeps session operation payloads in `@assistant/shared`:
+
+```ts
+export const SessionCompactResponseSchema = z.object({
+  sessionId: z.string(),
+  compacted: z.boolean(),
+  reason: z.literal('manual'),
+  updatedAt: z.string(),
+  revision: z.number().int().nonnegative(),
+  result: z.object({
+    summary: z.string(),
+    firstKeptEntryId: z.string(),
+    tokensBefore: z.number().int().nonnegative(),
+    details: z.object({
+      readFiles: z.array(z.string()),
+      modifiedFiles: z.array(z.string()),
+    }).optional(),
+  }).optional(),
+});
+```
+
+### Pi JSONL schema
+
+Assistant's internal Pi session entry union must add the `compaction` entry shape described in the Contract. Existing Pi transcript projection already treats `compaction` entries as `summary_message` events.
+
+## Impact Surface
+
+| File | Responsibility | Existing tests |
+|---|---|---|
+| `packages/agent-server/src/config.ts` | Parse `chat.config.compaction` under `PiSdkChatConfigSchema`; current Pi config includes `timeoutMs`, `maxTokens`, `contextWindow`, `temperature`, `maxToolIterations` at lines 213-222. | `packages/agent-server/src/config.test.ts` |
+| `packages/agent-server/src/agents.ts` | Add `compaction` to `PiSdkChatConfig`; current interface is lines 182-196. | Config and lifecycle tests indirectly cover resolved agent definitions. |
+| `packages/agent-server/src/contextUsage.ts` | Reuse `calculateContextTokens()` and `buildSessionContextUsage()` logic; current usage calculation and percent are lines 4-44. | `packages/agent-server/src/contextUsage.test.ts` |
+| `packages/agent-server/src/history/piCompaction.ts` (new) | Vendored/adapted pure compaction logic: settings, token estimation, cut-point selection, summarization, file-op tracking. | New unit tests mirroring pi-mono compaction cases. |
+| `packages/agent-server/src/history/piSessionWriter.ts` | Add compaction entry type, `appendCompaction`, effective-signature loading, history rewrite compatibility; current entry union lacks compaction at lines 50-92 and sync alignment is lines 1472-1674. | `packages/agent-server/src/history/piSessionWriter.test.ts` |
+| `packages/agent-server/src/history/piSessionReplay.ts` | Rebuild effective context from latest compaction instead of iterating only `message` entries; current replay loop only consumes `type: message` at lines 193-261. | `packages/agent-server/src/history/piSessionReplay.test.ts` |
+| `packages/agent-server/src/history/historyProvider.ts` | Keep/verify transcript projection for `compaction`; existing code maps `compaction` to `summary_message` at lines 2123-2137. | `packages/agent-server/src/history/historyProvider` coverage via `chatEventUtils.test.ts` and sessions plugin replay tests. |
+| `packages/agent-server/src/sessionHub.ts` | Add `compactSession`; enforce no active run for manual compaction; update state and broadcast history change like `editSessionHistory`; current Pi writer access is lines 166-212 and history edit flow is lines 610-680. | `packages/agent-server/src/sessionHub.test.ts` |
+| `packages/agent-server/src/chatRunCore.ts` | Add overflow detection/retry around Pi agent prompt; current Pi branch creates the agent at lines 1285-1455 and currently throws upstream errors at lines 1799-1810. | `packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts` |
+| `packages/agent-server/src/chatProcessor.ts` | Trigger threshold auto-compaction after Pi sync/finalization; current final Pi sync is lines 818-833 and turn finalization is lines 840-848. | `packages/agent-server/src/chatProcessor.test.ts`, Pi lifecycle tests. |
+| `packages/agent-server/src/chatTurnFinalization.ts` | Ensure auto-compaction runs after `appendTurnEnd` so the compaction entry is outside the just-finished request boundary; turn-end persistence is lines 84-116. | `packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts` |
+| `packages/plugins/core/sessions/manifest.json` | Add `compact` operation next to `clear` and `history-edit`; existing operations are listed around lines 213-247. | `packages/plugins/core/sessions/server/index.test.ts` |
+| `packages/plugins/core/sessions/server/index.ts` | Add `compact` operation handler returning `SessionCompactResponse`; current `history-edit` delegates to `SessionHub.editSessionHistory` at lines 700-728. | `packages/plugins/core/sessions/server/index.test.ts` |
+| `packages/shared/src/protocol.ts` | Add optional `SessionCompactResponseSchema`; existing session history edit schemas are lines 585-607 and context usage schemas are lines 5-17. | `packages/shared/src/protocol.test.ts` |
+| `packages/web-client/src/index.ts` | Add menu item and confirmation dialog; existing request menu items are lines 3447-3493. | Existing web-client tests are sparse; add targeted controller/utility tests if practical. |
+| `packages/web-client/src/controllers/sessionManager.ts` | Add `compactSession(sessionId)` calling `sessionsOperationPath('compact')`; current history edit method is lines 131-152. | Add unit coverage if a harness exists; otherwise cover via manual/browser smoke. |
+| `docs/CONFIG.md` | Document `chat.config.compaction`; current Pi provider docs and Pi JSONL note are lines 619-663. | Documentation review. |
+| `docs/design/pi-sdk-provider.md` | Optional cross-link to this design; current history compatibility section describes Pi JSONL mirroring. | Documentation review. |
+
+## Higher-Level Implementation Steps
+
+1. Add assistant-local Pi compaction modules adapted from pi-mono `packages/coding-agent/src/core/compaction`, preserving source comments and adding an adaptation note with the referenced pi-mono version/commit.
+2. Extend `PiSdkChatConfig` parsing, type definitions, and docs with compaction settings and Pi mono-compatible defaults.
+3. Add compaction-aware Pi JSONL parsing utilities that return both raw entries and effective context, including synthetic compaction summary user messages.
+4. Update `PiSessionWriter` to append `compaction` entries, reload effective signatures, and keep history rewrite/rechain behavior valid after compaction.
+5. Add `SessionHub.compactSession()` for manual compaction, including Pi-backed validation, active-run guard, writer invocation, state reload, transcript revision bump, context usage update/clear, and `session_history_changed` broadcast.
+6. Add sessions plugin `compact` operation and web-client `SessionManager.compactSession()` method.
+7. Add **Compact Context** to the chat request history menu with confirmation and status handling.
+8. Add threshold auto-compaction after successful Pi turn finalization and final Pi history sync.
+9. Add one-shot overflow recovery in the Pi runtime path using `isContextOverflow`, compacting and retrying the same prompt once.
+10. Add tests for config parsing, compaction preparation, Pi JSONL replay, writer alignment, manual operation, UI action path, threshold compaction, and overflow retry.
+
+## Diagrams
+
+```mermaid
+sequenceDiagram
+  participant UI as Chat UI
+  participant Sessions as sessions operation
+  participant Hub as SessionHub
+  participant Writer as PiSessionWriter
+  participant Log as Pi JSONL
+
+  UI->>Sessions: POST /operations/compact {sessionId}
+  Sessions->>Hub: compactSession(sessionId, manual)
+  Hub->>Writer: prepare + appendCompaction(...)
+  Writer->>Log: append {type:"compaction", ...}
+  Hub->>Hub: reload effective Pi context
+  Hub-->>UI: session_history_changed
+  Sessions-->>UI: {compacted:true, revision}
+```
+
+```mermaid
+sequenceDiagram
+  participant Runtime as Pi chat runtime
+  participant Model as Pi SDK/model
+  participant Writer as PiSessionWriter
+
+  Runtime->>Model: prompt / continue
+  Model-->>Runtime: assistant error (context overflow)
+  Runtime->>Runtime: detect isContextOverflow and not attempted
+  Runtime->>Writer: compact persisted/effective context
+  Writer-->>Runtime: compaction result
+  Runtime->>Runtime: reload effective context without overflow error
+  Runtime->>Model: retry same prompt once
+```
+
+## Risks
+
+- **Replay mismatch after compaction:** `PiSessionWriter.sync()` currently aligns against every persisted message signature; after compaction it must align against effective context or future writes may be skipped as unreconcilable.
+- **Visible transcript vs model context divergence:** transcript projection should show `summary_message`, while model context should receive a synthetic user summary message. These are related but not identical paths.
+- **Request boundary ordering:** auto threshold compaction should append after `appendTurnEnd`, otherwise history edit spans and replay grouping could include compaction inside the just-finished request.
+- **Overflow retry duplication:** retrying after an overflow must avoid duplicating user prompts, tool results, or partial assistant text in `state.chatMessages` and Pi JSONL.
+- **Stale usage after compaction:** kept assistant messages may carry pre-compaction usage; threshold logic must ignore usage older than the latest compaction entry, mirroring Pi mono's stale-usage guard.
+- **Concurrent manual compaction:** manual compaction must reject active runs, and writer operations must remain serialized through the existing write queue.
+- **Default-on behavior:** enabling compaction by default mirrors Pi mono but changes runtime behavior for existing Pi SDK agents; documentation and config override are required.
+- **Vendored code drift:** copied pi-mono logic can drift; include source provenance and focused tests rather than relying on package internals.
+
+## Test Strategy
+
+New/updated tests:
+
+- `packages/agent-server/src/config.test.ts`: parses `chat.config.compaction`, defaults are applied by resolver/helper, invalid numbers are rejected.
+- `packages/agent-server/src/history/piCompaction.test.ts`: covers token estimation, cut-point selection, previous-summary update behavior, split-turn summary preparation, and file-op details.
+- `packages/agent-server/src/history/piSessionReplay.test.ts`: loads a Pi JSONL file with a `compaction` entry and verifies effective context is summary + kept messages + post-compaction messages.
+- `packages/agent-server/src/history/piSessionWriter.test.ts`: appends compaction entries, reloads effective signatures after compaction, appends new messages after compaction, and keeps history rewrite behavior valid.
+- `packages/agent-server/src/sessionHub.test.ts`: manual compact rejects non-Pi and active sessions; successful compact reloads state, bumps revision, clears/updates context usage, and broadcasts history change.
+- `packages/plugins/core/sessions/server/index.test.ts`: `compact` operation delegates to `SessionHub.compactSession` and returns expected response/errors.
+- `packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts`: threshold auto-compaction after completed Pi run and one-shot overflow compaction/retry.
+- `packages/agent-server/src/chatProcessor.test.ts`: final assistant sync occurs before threshold compaction and turn finalization ordering remains correct.
+- `packages/shared/src/protocol.test.ts`: accepts any new compact response schema.
+- Web client test if practical for `SessionManager.compactSession`; otherwise manual browser smoke for the menu.
+
+Commands:
+
+```bash
+npm run build -w @assistant/shared
+npm run build -w @assistant/agent-server
+npm run build -w @assistant/web-client
+npm test -- packages/agent-server/src/history/piSessionReplay.test.ts packages/agent-server/src/history/piSessionWriter.test.ts packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts packages/plugins/core/sessions/server/index.test.ts packages/shared/src/protocol.test.ts
+npm run lint
+npm run format
+```
+
+Manual checks:
+
+- Start the server with a Pi SDK agent and low synthetic `contextWindow` / high reserve to force threshold compaction.
+- Verify **Compact Context** appears at the bottom of the request history menu and causes a compaction summary to appear in replay.
+- Verify a forced context overflow compacts and retries once without surfacing the first overflow error.
+
+## Open Assumptions
+
+- Manual compaction does not accept custom instructions in the first UI/API contract.
+- Auto compaction is enabled by default for provider `pi`, matching Pi mono defaults, but can be disabled with `chat.config.compaction.enabled: false`.
+- The feature targets in-process Pi SDK sessions only; `pi-cli` may display existing Pi CLI compaction entries but assistant will not initiate compaction for `pi-cli` sessions.
+- The existing `session_history_changed` websocket message is sufficient for UI transcript reloads after compaction.
+- The already-installed `@mariozechner/pi-coding-agent` dependency remains for local coding tools, but compaction code is vendored/adapted into assistant because the package exports only `.` and `./hooks` and does not expose the full preparation API needed here.

--- a/docs/design/design-summary-pi-session-compaction.md
+++ b/docs/design/design-summary-pi-session-compaction.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Add Pi-style context compaction for assistant's in-process `pi` provider sessions. Assistant already mirrors Pi SDK sessions to canonical Pi JSONL under `~/.pi/agent/sessions/...` and reloads Pi-backed state from that log; this feature extends that path so the log can contain Pi-compatible `compaction` entries, assistant can rebuild effective model context from them, users can trigger manual compaction from the chat request menu, and the server can automatically compact after threshold or context-overflow conditions. The compaction algorithm is vendored/adapted into assistant from pi-mono's coding-agent reference implementation rather than imported from `@mariozechner/pi-coding-agent` internals.
+Add Pi-style context compaction for assistant's in-process `pi` provider sessions. Assistant already mirrors Pi SDK sessions to canonical Pi JSONL under `~/.pi/agent/sessions/...` and reloads Pi-backed state from that log; this feature extends that path so the log can contain Pi-compatible `compaction` entries, assistant can rebuild effective model context from them, users can trigger manual compaction from the chat request menu, and the server can automatically compact after threshold or context-overflow conditions. The compaction algorithm is vendored/adapted into assistant from pi-mono's coding-agent reference implementation rather than imported from `@earendil-works/pi-coding-agent` internals.
 
 ## Motivation
 
@@ -24,7 +24,7 @@ In scope:
 Out of scope:
 
 - Changing `claude-cli`, `codex-cli`, or `pi-cli` compaction behavior.
-- Importing or deep-importing `@mariozechner/pi-coding-agent` compaction modules directly.
+- Importing or deep-importing `@earendil-works/pi-coding-agent` compaction modules directly.
 - Adding extension hook support equivalent to Pi mono's `session_before_compact` / `session_compact` hooks.
 - Adding a custom-instructions UI for manual compaction.
 - Changing non-Pi event-store session persistence.
@@ -373,4 +373,4 @@ Manual checks:
 - Auto compaction is enabled by default for provider `pi`, matching Pi mono defaults, but can be disabled with `chat.config.compaction.enabled: false`.
 - The feature targets in-process Pi SDK sessions only; `pi-cli` may display existing Pi CLI compaction entries but assistant will not initiate compaction for `pi-cli` sessions.
 - The existing `session_history_changed` websocket message is sufficient for UI transcript reloads after compaction.
-- The already-installed `@mariozechner/pi-coding-agent` dependency remains for local coding tools, but compaction code is vendored/adapted into assistant because the package exports only `.` and `./hooks` and does not expose the full preparation API needed here.
+- The already-installed `@earendil-works/pi-coding-agent` dependency remains for local coding tools, but compaction code is vendored/adapted into assistant because the package exports only `.` and `./hooks` and does not expose the full preparation API needed here.

--- a/docs/design/design-summary-pi-session-compaction.md
+++ b/docs/design/design-summary-pi-session-compaction.md
@@ -338,7 +338,8 @@ Implemented tests:
 - `packages/agent-server/src/history/piCompaction.test.ts`: covers the Pi threshold rule and previous-summary update behavior.
 - `packages/agent-server/src/history/piSessionReplay.test.ts`: loads a Pi JSONL file with a `compaction` entry and verifies effective context is summary + kept messages + post-compaction messages.
 - `packages/agent-server/src/chatProcessor.test.ts`: threshold auto-compaction delegates to `SessionHub.compactSession` after a completed Pi run, with `allowActiveRun: true` because the active run is cleared in the processor's `finally` block.
-- `packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts`: one-shot overflow compaction/retry when a Pi run returns a context-overflow error.
+- `packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts`: one-shot overflow compaction/retry when a Pi run returns a context-overflow error; verifies the overflow error assistant is not present in the compacted or retried context.
+- `packages/agent-server/src/sessionHub.test.ts`: direct guard coverage for missing, deleted, active, non-Pi, writer-unavailable, and model-missing compaction failures.
 - `packages/plugins/core/sessions/server/index.test.ts`: `compact` operation delegates to `SessionHub.compactSession` and returns the expected response.
 - `packages/shared/src/protocol.test.ts`: accepts any new compact response schema.
 
@@ -346,7 +347,7 @@ Follow-up coverage still worth adding:
 
 - `packages/agent-server/src/history/piCompaction.test.ts`: token estimation edge cases, cut-point selection, split-turn summary preparation, and file-op details.
 - `packages/agent-server/src/history/piSessionWriter.test.ts`: compaction entry append, effective signature reload, appending messages after compaction, and history rewrite compatibility.
-- `packages/agent-server/src/sessionHub.test.ts`: non-Pi and active-session rejections, successful state reload, revision/context usage updates, and broadcasts.
+- `packages/agent-server/src/sessionHub.test.ts`: successful compaction state reload, revision/context usage updates, and broadcasts.
 - Web client unit coverage for `SessionManager.compactSession` error display if a controller harness is added.
 
 Commands:

--- a/docs/design/pi-agent-oauth-reuse.md
+++ b/docs/design/pi-agent-oauth-reuse.md
@@ -51,7 +51,7 @@ Credentials can be:
 
 ### Pi SDK Provider Auth
 
-The `@mariozechner/pi-ai` SDK resolves API keys in this order:
+The `@earendil-works/pi-ai` SDK resolves API keys in this order:
 1. Explicit `options.apiKey` passed to `streamSimple()`
 2. Environment variables (e.g., `ANTHROPIC_API_KEY`, `ANTHROPIC_OAUTH_TOKEN`)
 
@@ -77,7 +77,7 @@ Behavior:
 2. Reads `~/.pi/agent/auth.json` (or `$PI_CODING_AGENT_DIR/auth.json`).
 3. For `type: "api_key"`: returns the `key` field directly.
 4. For `type: "oauth"`:
-   - Calls `getOAuthApiKey()` from `@mariozechner/pi-ai` which handles refresh if expired.
+   - Calls `getOAuthApiKey()` from `@earendil-works/pi-ai` which handles refresh if expired.
    - Writes updated credentials back to `auth.json` (preserving extra fields like `accountId`).
    - Returns the access token.
 5. Returns `undefined` if no credentials found or on error.
@@ -144,7 +144,7 @@ entry is used. No `chat.config.apiKey` is needed.
 
 ### Token Refresh
 
-OAuth tokens expire. The `getOAuthApiKey()` function from `@mariozechner/pi-ai`:
+OAuth tokens expire. The `getOAuthApiKey()` function from `@earendil-works/pi-ai`:
 1. Checks if the token is expired (`Date.now() >= expires`).
 2. If expired, calls the provider's `refreshToken()` method.
 3. Returns updated credentials.
@@ -174,14 +174,14 @@ level with a clear "no API key" error.
 
 ## Dependencies
 
-No new dependencies. Uses existing `@mariozechner/pi-ai` exports:
+No new dependencies. Uses existing `@earendil-works/pi-ai` exports:
 - `getOAuthApiKey()`
 - `OAuthCredentials` type
 
 ## Testing
 
 Manual testing:
-1. Run `npx @mariozechner/pi-ai login anthropic` to populate auth.json.
+1. Run `npx @earendil-works/pi-ai login anthropic` to populate auth.json.
 2. Configure agent with `anthropic/claude-sonnet-4-5` model.
 3. Verify assistant uses OAuth token (check debug logs or network).
 4. Let token expire and verify refresh works.
@@ -195,6 +195,7 @@ Unit tests (future):
 ## Future Considerations
 
 - **File locking**: Add `proper-lockfile` if multi-process refresh races become an issue.
-- **Additional providers**: Could extend to `github-copilot`, `google-gemini-cli` if needed.
+- **Additional providers**: Could extend to `github-copilot` if needed. Pi 0.71.0 removed the
+  built-in Google Gemini CLI OAuth provider.
 - **Cache in memory**: Currently re-reads auth.json per chat run; could cache with TTL.
 - **Login UI**: Could add OAuth login to assistant's web UI in the future.

--- a/docs/design/pi-mono-openai-provider-notes.md
+++ b/docs/design/pi-mono-openai-provider-notes.md
@@ -4,6 +4,6 @@
 
 This file is retained for historical context only. The current implementation:
 
-- Uses the Pi SDK (`@mariozechner/pi-ai`) for in-process chat under provider id `pi`.
+- Uses the Pi SDK (`@earendil-works/pi-ai`) for in-process chat under provider id `pi`.
 - Removes `openai` / `openai-compatible` from assistant chat providers (Pi handles upstream).
 - Keeps CLI providers (`claude-cli`, `codex-cli`, `pi-cli`) unchanged.

--- a/docs/design/pi-sdk-provider.md
+++ b/docs/design/pi-sdk-provider.md
@@ -3,14 +3,14 @@
 ## Overview
 
 Replace the OpenAI chat integration in assistant with the native Pi SDK integration
-used by agent-hub. We add a Pi SDK provider that wraps `@mariozechner/pi-ai`
+used by agent-hub. We add a Pi SDK provider that wraps `@earendil-works/pi-ai`
 streaming and wire it into the agent server’s chat run loop so tool calls,
 streaming deltas, and event logging continue to work. Upstream providers (OpenAI,
 Anthropic, etc.) are configured and resolved inside Pi.
 
 ## Goals
 
-- Use the Pi SDK (`@mariozechner/pi-ai`) for in-process chat completions.
+- Use the Pi SDK (`@earendil-works/pi-ai`) for in-process chat completions.
 - Preserve streaming deltas, tool call handling, and chat event logging.
 - Keep assistant-owned model/thinking selection (per-agent + session overrides) and pass it through to Pi.
 - Document configuration and defaults clearly.
@@ -111,7 +111,7 @@ Introduce a Pi SDK adapter similar to `SdkLlmProvider` in agent-hub:
 
 ### Dependencies
 
-- Add `@mariozechner/pi-ai` to `packages/agent-server/package.json`.
+- Add `@earendil-works/pi-ai` to `packages/agent-server/package.json`.
 - Keep `openai` only for TTS/STT.
 
 ### Docs & Defaults

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,26 +63,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.90.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
-      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "4.1.0",
       "license": "MIT",
@@ -1615,6 +1595,311 @@
         "node": ">=18"
       }
     },
+    "node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.74.0.tgz",
+      "integrity": "sha512-6GMR7/wwjEJ1EsXLWEz03QOWin4AMrJ/AZoMpgm5DJ6GHsF6q6GOhQbj5Zip4dow3vo/TmBAVqM+vmGfrjGAFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.74.0",
+        "typebox": "^1.1.24"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.74.0.tgz",
+      "integrity": "sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+        "@google/genai": "^1.40.0",
+        "@mistralai/mistralai": "^2.2.0",
+        "chalk": "^5.6.2",
+        "openai": "6.26.0",
+        "partial-json": "^0.1.7",
+        "proxy-agent": "^6.5.0",
+        "typebox": "^1.1.24",
+        "undici": "^7.19.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-ai/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai/node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.74.0.tgz",
+      "integrity": "sha512-Q5GikbB5vRBrsrrf/uvet53rPSQ1sn5I5mO+l7sIobdXYpS04/X2oOc2UHFm90fNdkl3yU+ANTZL0zOtHbnqRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.74.0",
+        "@earendil-works/pi-ai": "^0.74.0",
+        "@earendil-works/pi-tui": "^0.74.0",
+        "@silvia-odwyer/photon-node": "^0.3.4",
+        "chalk": "^5.5.0",
+        "cli-highlight": "^2.1.11",
+        "diff": "^8.0.2",
+        "extract-zip": "^2.0.1",
+        "file-type": "^21.1.1",
+        "glob": "^13.0.1",
+        "hosted-git-info": "^9.0.2",
+        "ignore": "^7.0.5",
+        "jiti": "^2.7.0",
+        "marked": "^15.0.12",
+        "minimatch": "^10.2.3",
+        "proper-lockfile": "^4.1.2",
+        "strip-ansi": "^7.1.0",
+        "typebox": "^1.1.24",
+        "undici": "^7.19.1",
+        "uuid": "^14.0.0",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "^0.3.5"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-tui": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.74.0.tgz",
+      "integrity": "sha512-1aIfXZp7D/z+1VlZX8BZcs6pgO8rjmil7kwyhctNDsWvce3Yfl8GVgu4eq+I0Mjhr8Cj+ipBiv9CLIzdoyCOIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime-types": "^2.1.4",
+        "chalk": "^5.5.0",
+        "get-east-asian-width": "^1.3.0",
+        "marked": "^15.0.12",
+        "mime-types": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "koffi": "^2.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-tui/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-tui/node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@earendil-works/pi-tui/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@earendil-works/pi-tui/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
@@ -2555,31 +2840,31 @@
       }
     },
     "node_modules/@mariozechner/clipboard": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.3.tgz",
-      "integrity": "sha512-e7jASirzfm+ROiOGFh843+cFZTy3DfzP+jldCvh8RnEk0C3QihDTn7dd7Yh7KAJydwIJ18FJSZ2swHvCJhk18g==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.5.tgz",
+      "integrity": "sha512-D3F+UrU9CR7roJt0zDLp6Oc+4/KlLDIrN4frH+6V90SJNW2KKUec1oCQIPaaDjCqeOsQyX9dyqYbImIQIM45PA==",
       "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@mariozechner/clipboard-darwin-arm64": "0.3.3",
-        "@mariozechner/clipboard-darwin-universal": "0.3.3",
-        "@mariozechner/clipboard-darwin-x64": "0.3.3",
-        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.3",
-        "@mariozechner/clipboard-linux-arm64-musl": "0.3.3",
-        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.3",
-        "@mariozechner/clipboard-linux-x64-gnu": "0.3.3",
-        "@mariozechner/clipboard-linux-x64-musl": "0.3.3",
-        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.3",
-        "@mariozechner/clipboard-win32-x64-msvc": "0.3.3"
+        "@mariozechner/clipboard-darwin-arm64": "0.3.2",
+        "@mariozechner/clipboard-darwin-universal": "0.3.2",
+        "@mariozechner/clipboard-darwin-x64": "0.3.2",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.2",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.2",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.2",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.2",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.2",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.2"
       }
     },
     "node_modules/@mariozechner/clipboard-darwin-arm64": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.3.tgz",
-      "integrity": "sha512-+zhuZGXqVrdkbIRdnwiZNbTJ7V3elq/A+C5d5laJoyhJgWs41eO5NUMkBkj6f23F2L4PRXEhdn5/ktlPx+bG3Q==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.2.tgz",
+      "integrity": "sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==",
       "cpu": [
         "arm64"
       ],
@@ -2593,9 +2878,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard-darwin-universal": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.3.tgz",
-      "integrity": "sha512-x9aRfTyndVqpEQ44LNNCK/EXZd9y8rWkLQgNhmWpby9PXrjPhNxfjUc2Db4mt4nJjU/4zzO8F5v/XyzlUGSdhQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.2.tgz",
+      "integrity": "sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2606,9 +2891,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard-darwin-x64": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.3.tgz",
-      "integrity": "sha512-6ut/NawB0KiYPCwrirgNp6Br62LntL978q7G6d/Rs2pmPvQb53bP96eUMYl+Y3a7Qk13bGZ4w9rVPFxRE9m9ag==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.2.tgz",
+      "integrity": "sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==",
       "cpu": [
         "x64"
       ],
@@ -2622,9 +2907,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.3.tgz",
-      "integrity": "sha512-gf3dH4kBddU1AOyHVB53mjLUFfJAKlTmxTMw51jdeg7eE7IjfEBXVvM4bifMtBxbWkT0eA0FUZ1C0KQ6Z5l6pw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.2.tgz",
+      "integrity": "sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==",
       "cpu": [
         "arm64"
       ],
@@ -2638,9 +2923,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard-linux-arm64-musl": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.3.tgz",
-      "integrity": "sha512-o1paj2+zmAQ/LaPS85XJCxhNowNQpxYM2cGY6pWvB5Kqmz6hZjl6CzDg5tbf1hZkn/Em6jpOaE2UtMxKdELBDA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.2.tgz",
+      "integrity": "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==",
       "cpu": [
         "arm64"
       ],
@@ -2654,9 +2939,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.3.tgz",
-      "integrity": "sha512-dkEhE4ekePJwMbBq9HP1//CFMNmDzA/iV9AXqBfvL5CWmmDIRXqh4A3YZt3tWO/HdMerX+xNCEiR7WiOsIG+UA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.2.tgz",
+      "integrity": "sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==",
       "cpu": [
         "riscv64"
       ],
@@ -2670,9 +2955,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard-linux-x64-gnu": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.3.tgz",
-      "integrity": "sha512-lT2yANtTLlEtFBIH3uGoRa/CQas/eBoLNi3qr9axQFoRgF4RGPSJ66yHOSnMECBneTIb1Iqv3UxokTfX27CdoQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.2.tgz",
+      "integrity": "sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==",
       "cpu": [
         "x64"
       ],
@@ -2686,9 +2971,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard-linux-x64-musl": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.3.tgz",
-      "integrity": "sha512-saq/MCB0QHK/7ZZLjAZ0QkbY944dyjOsur8gneGCfMitt+GOiE1CU4OUipHC4b6x8UDY9bRLsR4aBaxu22OFPA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.2.tgz",
+      "integrity": "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==",
       "cpu": [
         "x64"
       ],
@@ -2702,9 +2987,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.3.tgz",
-      "integrity": "sha512-cGuvSj0/2X2w983yEcKw+i+r1EBej6ZZIN+fXG3eY2G/HaIQpbXpLvMxKyZ9LKtbZx+Z6q/gELEoSBMLML6BaQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.2.tgz",
+      "integrity": "sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==",
       "cpu": [
         "arm64"
       ],
@@ -2718,9 +3003,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard-win32-x64-msvc": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.3.tgz",
-      "integrity": "sha512-5hvaEq/bgYovTIGx43O/S7loIHYV3ue90WcV1dz0wdMXroVKZKeU/yfwM0PALQA1OcrEHiGXGySFReXr72lGtA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.2.tgz",
+      "integrity": "sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==",
       "cpu": [
         "x64"
       ],
@@ -2731,304 +3016,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/jiti": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
-      "integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
-      "license": "MIT",
-      "dependencies": {
-        "std-env": "^3.10.0",
-        "yoctocolors": "^2.1.2"
-      },
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.70.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.70.5.tgz",
-      "integrity": "sha512-ZUnJ7fFeJog97KG8FewEyqaObY2sLWvfDurKHl9kImVEbgt3l1LJ9A5pb+4/5KXnCVsoF/Brd0h+7yBEd1Aj5g==",
-      "license": "MIT",
-      "dependencies": {
-        "@mariozechner/pi-ai": "^0.70.5",
-        "typebox": "^1.1.24"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@mariozechner/pi-ai": {
-      "version": "0.70.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.70.5.tgz",
-      "integrity": "sha512-eyeyOfu/YiqzY6q391oRYdmnPIIU1VTKAn3hWIvzqkRHkcArd41/YynG8mw6bgoLdmCnIBoY3fD6nzEHEHLIMA==",
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.90.0",
-        "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
-        "@google/genai": "^1.40.0",
-        "@mistralai/mistralai": "^2.2.0",
-        "chalk": "^5.6.2",
-        "openai": "6.26.0",
-        "partial-json": "^0.1.7",
-        "proxy-agent": "^6.5.0",
-        "typebox": "^1.1.24",
-        "undici": "^7.19.1",
-        "zod-to-json-schema": "^3.24.6"
-      },
-      "bin": {
-        "pi-ai": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@mariozechner/pi-ai/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@mariozechner/pi-ai/node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent": {
-      "version": "0.70.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.70.5.tgz",
-      "integrity": "sha512-5sQjY2LQLvYfMjo4Dn6P6iy3LFm3MZYgrYmgCQSwQSUM5yqzWceidYYXS4knloW7gNkko+nnhKB2u4NF3w+dVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@mariozechner/jiti": "^2.6.2",
-        "@mariozechner/pi-agent-core": "^0.70.5",
-        "@mariozechner/pi-ai": "^0.70.5",
-        "@mariozechner/pi-tui": "^0.70.5",
-        "@silvia-odwyer/photon-node": "^0.3.4",
-        "chalk": "^5.5.0",
-        "cli-highlight": "^2.1.11",
-        "diff": "^8.0.2",
-        "extract-zip": "^2.0.1",
-        "file-type": "^21.1.1",
-        "glob": "^13.0.1",
-        "hosted-git-info": "^9.0.2",
-        "ignore": "^7.0.5",
-        "marked": "^15.0.12",
-        "minimatch": "^10.2.3",
-        "proper-lockfile": "^4.1.2",
-        "strip-ansi": "^7.1.0",
-        "typebox": "^1.1.24",
-        "undici": "^7.19.1",
-        "uuid": "^14.0.0",
-        "yaml": "^2.8.2"
-      },
-      "bin": {
-        "pi": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.6.0"
-      },
-      "optionalDependencies": {
-        "@mariozechner/clipboard": "^0.3.3"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/hosted-git-info": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^11.1.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@mariozechner/pi-tui": {
-      "version": "0.70.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.70.5.tgz",
-      "integrity": "sha512-5Ol9weTqpsQ85gg1C6Mo8M8o/HYz4uN7nM7QTPrw/Rm/UoFgO1/T/Irago5aGfzlIj/nmsGcqb7NlkWtT4vXUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime-types": "^2.1.4",
-        "chalk": "^5.5.0",
-        "get-east-asian-width": "^1.3.0",
-        "marked": "^15.0.12",
-        "mime-types": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "optionalDependencies": {
-        "koffi": "^2.9.0"
-      }
-    },
-    "node_modules/@mariozechner/pi-tui/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@mariozechner/pi-tui/node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@mariozechner/pi-tui/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@mariozechner/pi-tui/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@mistralai/mistralai": {
@@ -8719,6 +8706,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11535,6 +11531,7 @@
     },
     "node_modules/std-env": {
       "version": "3.10.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/stream-buffers": {
@@ -12910,18 +12907,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/zip-stream": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
@@ -13021,9 +13006,9 @@
       "version": "0.18.2",
       "dependencies": {
         "@assistant/shared": "*",
-        "@mariozechner/pi-agent-core": "^0.70.5",
-        "@mariozechner/pi-ai": "^0.70.5",
-        "@mariozechner/pi-coding-agent": "^0.70.5",
+        "@earendil-works/pi-agent-core": "^0.74.0",
+        "@earendil-works/pi-ai": "^0.74.0",
+        "@earendil-works/pi-coding-agent": "^0.74.0",
         "@mozilla/readability": "^0.5.0",
         "cron-parser": "^4.9.0",
         "cronstrue": "^2.50.0",

--- a/packages/agent-server/package.json
+++ b/packages/agent-server/package.json
@@ -13,9 +13,9 @@
   },
   "dependencies": {
     "@assistant/shared": "*",
-    "@mariozechner/pi-agent-core": "^0.70.5",
-    "@mariozechner/pi-ai": "^0.70.5",
-    "@mariozechner/pi-coding-agent": "^0.70.5",
+    "@earendil-works/pi-agent-core": "^0.74.0",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "@mozilla/readability": "^0.5.0",
     "cron-parser": "^4.9.0",
     "cronstrue": "^2.50.0",

--- a/packages/agent-server/src/agents.ts
+++ b/packages/agent-server/src/agents.ts
@@ -193,6 +193,11 @@ export interface PiSdkChatConfig {
   contextWindow?: number;
   temperature?: number;
   maxToolIterations?: number;
+  compaction?: {
+    enabled?: boolean;
+    reserveTokens?: number;
+    keepRecentTokens?: number;
+  };
 }
 
 export class AgentRegistry {

--- a/packages/agent-server/src/chatCompletionTypes.ts
+++ b/packages/agent-server/src/chatCompletionTypes.ts
@@ -1,4 +1,4 @@
-import type { Message as PiSdkMessage } from '@mariozechner/pi-ai';
+import type { Message as PiSdkMessage } from '@earendil-works/pi-ai';
 import type { AssistantTextPhase } from '@assistant/shared';
 
 export interface ChatCompletionToolCallState {

--- a/packages/agent-server/src/chatProcessor.test.ts
+++ b/packages/agent-server/src/chatProcessor.test.ts
@@ -124,7 +124,8 @@ vi.mock('./llm/piSdkProvider', async () => {
 });
 
 vi.mock('./notificationProducers', async () => {
-  const actual = await vi.importActual<typeof import('./notificationProducers')>('./notificationProducers');
+  const actual =
+    await vi.importActual<typeof import('./notificationProducers')>('./notificationProducers');
   return {
     ...actual,
     publishFinalResponseNotification: vi.fn(async () => undefined),
@@ -174,6 +175,33 @@ function createAssistantMessage(options: {
     stopReason,
     timestamp: Date.now(),
   };
+}
+
+function createEnvConfig(): EnvConfig {
+  return {
+    apiKey: 'test-api-key',
+    port: 0,
+    toolsEnabled: false,
+    dataDir: '/tmp/assistant-tests',
+    audioInputMode: 'manual',
+    audioSampleRate: 24000,
+    audioTranscriptionEnabled: false,
+    audioOutputVoice: undefined,
+    audioOutputSpeed: undefined,
+    ttsModel: 'gpt-4o-mini-tts',
+    ttsVoice: undefined,
+    ttsFrameDurationMs: 250,
+    ttsBackend: 'openai',
+    elevenLabsApiKey: undefined,
+    elevenLabsVoiceId: undefined,
+    elevenLabsModelId: undefined,
+    elevenLabsBaseUrl: undefined,
+    maxMessagesPerMinute: 60,
+    maxAudioBytesPerMinute: 2_000_000,
+    maxToolCallsPerMinute: 30,
+    debugChatCompletions: false,
+    debugHttpRequests: false,
+  } as EnvConfig;
 }
 
 describe('processUserMessage stream event emission', () => {
@@ -695,6 +723,118 @@ describe('processUserMessage stream event emission', () => {
     ).rejects.toMatchObject({ code: 'tool_iteration_limit' });
   });
 
+  it('allows threshold compaction while the just-finished Pi run is still active', async () => {
+    vi.mocked(resolvePiSdkModel).mockResolvedValue({
+      model: {
+        id: 'gpt-4o-mini',
+        provider: 'openai',
+        api: 'openai-responses',
+        contextWindow: 100,
+      } as never,
+      providerId: 'openai',
+      modelId: 'gpt-4o-mini',
+    });
+
+    const assistantMessage = createAssistantMessage({
+      text: 'Final answer',
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      api: 'openai-responses',
+    });
+    assistantMessage.usage = {
+      ...assistantMessage.usage,
+      totalTokens: 91,
+    };
+
+    vi.mocked(runPiSdkChatCompletionIteration).mockImplementationOnce(async (options) => {
+      await options.onDeltaText?.('Final answer', 'Final answer', 'final_answer');
+      return {
+        text: 'Final answer',
+        toolCalls: [],
+        aborted: false,
+        assistantMessage: assistantMessage as never,
+      };
+    });
+
+    const compactSession = vi.fn(async (options) => ({
+      summary: {
+        sessionId: 's1',
+        agentId: 'pi',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        model: 'openai/gpt-4o-mini',
+      },
+      compacted: true as const,
+      reason: options.reason,
+      result: {
+        summary: 'Compacted summary',
+        firstKeptEntryId: 'entry-kept',
+        tokensBefore: 91,
+      },
+    }));
+
+    const agent = {
+      agentId: 'pi',
+      displayName: 'Pi',
+      description: 'Pi SDK agent.',
+      chat: {
+        provider: 'pi',
+        models: ['openai/gpt-4o-mini'],
+        config: {
+          contextWindow: 100,
+          compaction: {
+            reserveTokens: 10,
+            keepRecentTokens: 20,
+          },
+        },
+      },
+    };
+    const sessionHub: SessionHub = {
+      broadcastToSession: () => undefined,
+      broadcastToSessionExcluding: () => undefined,
+      recordSessionActivity: () => undefined,
+      processNextQueuedMessage: async () => false,
+      compactSession,
+      getAgentRegistry: () =>
+        ({
+          getAgent: (agentId: string) => (agentId === 'pi' ? agent : undefined),
+        }) as never,
+      getPiSessionWriter: () => undefined,
+      updateSessionAttributes: vi.fn(async () => undefined),
+      updateSessionContextUsage: vi.fn(async () => undefined),
+    } as unknown as SessionHub;
+
+    const state: LogicalSessionState = {
+      summary: {
+        sessionId: 's1',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        agentId: 'pi',
+        model: 'openai/gpt-4o-mini',
+      },
+      chatMessages: [],
+      messageQueue: [],
+    } as unknown as LogicalSessionState;
+
+    await processUserMessage({
+      sessionId: 's1',
+      state,
+      text: 'hi',
+      sessionHub,
+      envConfig: createEnvConfig(),
+      chatCompletionTools: [],
+      handleChatToolCalls: async () => undefined,
+      outputMode: 'text',
+      ttsBackendFactory: null,
+    });
+
+    expect(compactSession).toHaveBeenCalledWith({
+      sessionId: 's1',
+      reason: 'threshold',
+      allowActiveRun: true,
+    });
+  });
+
   it('emits commentary and final assistant_done events from Pi assistant text blocks', async () => {
     vi.mocked(resolvePiSdkModel).mockResolvedValue({
       model: { id: 'gpt-4o-mini', provider: 'openai', api: 'openai-responses' } as never,
@@ -1213,7 +1353,7 @@ describe('processUserMessage stream event emission', () => {
     });
 
     expect(sync).toHaveBeenCalledTimes(1);
-    const syncPayload = ((sync.mock.calls as unknown) as Array<[unknown]>)[0]?.[0];
+    const syncPayload = (sync.mock.calls as unknown as Array<[unknown]>)[0]?.[0];
     expect(syncPayload).toBeDefined();
     expect(syncPayload).toMatchObject({
       summary: state.summary,

--- a/packages/agent-server/src/chatProcessor.test.ts
+++ b/packages/agent-server/src/chatProcessor.test.ts
@@ -21,9 +21,9 @@ const mockPiAgentPrompt = vi.fn<
   }) => Promise<void>
 >();
 
-vi.mock('@mariozechner/pi-agent-core', async () => {
-  const actual = await vi.importActual<typeof import('@mariozechner/pi-agent-core')>(
-    '@mariozechner/pi-agent-core',
+vi.mock('@earendil-works/pi-agent-core', async () => {
+  const actual = await vi.importActual<typeof import('@earendil-works/pi-agent-core')>(
+    '@earendil-works/pi-agent-core',
   );
   class MockAgent {
     state = {

--- a/packages/agent-server/src/chatProcessor.test.ts
+++ b/packages/agent-server/src/chatProcessor.test.ts
@@ -832,6 +832,7 @@ describe('processUserMessage stream event emission', () => {
       sessionId: 's1',
       reason: 'threshold',
       allowActiveRun: true,
+      signal: expect.any(AbortSignal),
     });
   });
 

--- a/packages/agent-server/src/chatProcessor.ts
+++ b/packages/agent-server/src/chatProcessor.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import type { Message as PiSdkMessage } from '@mariozechner/pi-ai';
+import type { Message as PiSdkMessage } from '@earendil-works/pi-ai';
 import type {
   ServerTextDoneMessage,
   ServerUserAudioMessage,

--- a/packages/agent-server/src/chatProcessor.ts
+++ b/packages/agent-server/src/chatProcessor.ts
@@ -870,6 +870,7 @@ export async function processUserMessage(
           const compacted = await sessionHub.compactSession({
             sessionId,
             reason: 'threshold',
+            allowActiveRun: true,
           });
           state.summary = compacted.summary;
         } catch (err) {

--- a/packages/agent-server/src/chatProcessor.ts
+++ b/packages/agent-server/src/chatProcessor.ts
@@ -44,6 +44,8 @@ import { resolveSessionModelForRun, resolveSessionThinkingForRun } from './sessi
 import { resolveVisibleAssistantText } from './piAssistantText';
 import { buildMessagesForPiSync } from './history/piSessionSync';
 import { publishFinalResponseNotification } from './notificationProducers';
+import { DEFAULT_PI_COMPACTION_SETTINGS, shouldCompactPiContext } from './history/piCompaction';
+import { calculateContextTokens } from './contextUsage';
 
 function buildAssistantDoneEvents(options: {
   sessionId: string;
@@ -97,6 +99,7 @@ async function persistInterruptedPiAssistantMessage(options: {
     fullText: string;
     piSdkMessage?: PiSdkMessage;
     piReplayMessages?: ChatCompletionMessage[];
+    piContextWindow?: number;
   };
   log: (...args: unknown[]) => void;
 }): Promise<void> {
@@ -759,9 +762,7 @@ export async function processUserMessage(
             },
           });
         }
-        const events: ChatEvent[] = [
-          ...assistantDoneEvents,
-        ];
+        const events: ChatEvent[] = [...assistantDoneEvents];
         void appendAndBroadcastChatEvents(
           {
             ...(eventStore ? { eventStore } : {}),
@@ -847,6 +848,36 @@ export async function processUserMessage(
       ...(chatProvider === 'pi' ? { piTurnEndStatus: 'completed' as const } : {}),
     });
 
+    if (runResult.provider === 'pi' && runResult.piSdkMessage?.role === 'assistant') {
+      const piConfig = agent?.chat?.config as PiSdkChatConfig | undefined;
+      const compactionSettings = {
+        enabled: piConfig?.compaction?.enabled ?? DEFAULT_PI_COMPACTION_SETTINGS.enabled,
+        reserveTokens:
+          piConfig?.compaction?.reserveTokens ?? DEFAULT_PI_COMPACTION_SETTINGS.reserveTokens,
+        keepRecentTokens:
+          piConfig?.compaction?.keepRecentTokens ?? DEFAULT_PI_COMPACTION_SETTINGS.keepRecentTokens,
+      };
+      const contextWindow = runResult.piContextWindow ?? piConfig?.contextWindow ?? 0;
+      if (
+        runResult.piSdkMessage.usage &&
+        shouldCompactPiContext({
+          contextTokens: calculateContextTokens(runResult.piSdkMessage.usage),
+          contextWindow,
+          settings: compactionSettings,
+        })
+      ) {
+        try {
+          const compacted = await sessionHub.compactSession({
+            sessionId,
+            reason: 'threshold',
+          });
+          state.summary = compacted.summary;
+        } catch (err) {
+          log('failed to compact Pi session after threshold check', err);
+        }
+      }
+    }
+
     const durationMs = Date.now() - startTime;
 
     let responseText = fullText;
@@ -897,12 +928,11 @@ export async function processUserMessage(
         interruptReason: timedOut ? 'timeout' : 'error',
         error: {
           code: timedOut ? 'upstream_timeout' : isChatRunError(err) ? err.code : 'upstream_error',
-          message:
-            timedOut
-              ? 'Chat backend request timed out'
-              : isChatRunError(err)
-                ? err.message
-                : 'Chat backend error',
+          message: timedOut
+            ? 'Chat backend request timed out'
+            : isChatRunError(err)
+              ? err.message
+              : 'Chat backend error',
         },
         prependEvents: buildInterruptedAssistantEvents(),
         ...(chatProvider === 'pi' ? { piTurnEndStatus: 'interrupted' as const } : {}),

--- a/packages/agent-server/src/chatProcessor.ts
+++ b/packages/agent-server/src/chatProcessor.ts
@@ -871,6 +871,9 @@ export async function processUserMessage(
             sessionId,
             reason: 'threshold',
             allowActiveRun: true,
+            ...(state.activeChatRun?.abortController.signal
+              ? { signal: state.activeChatRun.abortController.signal }
+              : {}),
           });
           state.summary = compacted.summary;
         } catch (err) {

--- a/packages/agent-server/src/chatRunCore.ts
+++ b/packages/agent-server/src/chatRunCore.ts
@@ -66,6 +66,7 @@ import {
   resolvePiSdkAuthApiKey,
 } from './llm/piSdkProvider';
 import {
+  calculateContextTokens,
   extractSessionContextUsageFromAssistantMessage,
   isSessionContextUsageEqual,
 } from './contextUsage';
@@ -199,6 +200,50 @@ export function isChatRunError(err: unknown): err is ChatRunError {
 }
 
 const DEFAULT_PI_REQUEST_TIMEOUT_MS = 300_000;
+const PI_CONTEXT_OVERFLOW_RECOVERY_MESSAGE =
+  'Context overflow recovery failed after one compact-and-retry attempt. Try reducing context or switching to a larger-context model.';
+
+function isPiContextOverflow(
+  message: AssistantMessage,
+  contextWindow: number | undefined,
+): boolean {
+  if (message.stopReason !== 'error') {
+    return false;
+  }
+
+  if (
+    typeof contextWindow === 'number' &&
+    Number.isFinite(contextWindow) &&
+    contextWindow > 0 &&
+    message.usage &&
+    calculateContextTokens(message.usage) >= contextWindow
+  ) {
+    return true;
+  }
+
+  const contentText = message.content
+    .filter((block): block is TextContent => block.type === 'text')
+    .map((block) => block.text)
+    .join('\n');
+  const errorText = `${message.errorMessage ?? ''}\n${contentText}`.toLowerCase();
+  if (!errorText.trim()) {
+    return false;
+  }
+
+  return [
+    'context_length_exceeded',
+    'context length',
+    'context window',
+    'maximum context',
+    'max context',
+    'too many tokens',
+    'token limit',
+    'input is too long',
+    'prompt is too long',
+    'exceeds the maximum',
+    'exceeded maximum',
+  ].some((pattern) => errorText.includes(pattern));
+}
 
 function isPiReasoningLevel(
   value: string,
@@ -1343,10 +1388,10 @@ export async function runChatCompletionCore(
     const canonicalReplayMessages = await loadCanonicalPiReplayMessages({
       summary: state.summary,
     });
+    const systemMessage =
+      state.chatMessages[0]?.role === 'system' ? state.chatMessages[0] : undefined;
     piReplayMessages = state.chatMessages;
     if (canonicalReplayMessages) {
-      const systemMessage =
-        state.chatMessages[0]?.role === 'system' ? state.chatMessages[0] : undefined;
       const currentUserMessage =
         state.chatMessages[state.chatMessages.length - 1]?.role === 'user'
           ? state.chatMessages[state.chatMessages.length - 1]
@@ -1454,21 +1499,27 @@ export async function runChatCompletionCore(
     piAgentRuntime.agent.state.thinkingLevel = (reasoning ?? 'off') as PiAgentThinkingLevel;
     piAgentRuntime.agent.state.tools = agentTools as never;
 
-    const { contextMessages, promptMessage, systemPrompt } = buildPiAgentContext({
-      messages: piReplayMessages,
-      text,
-      model: agentModel,
-    });
-    piAgentRuntime.agent.state.systemPrompt = systemPrompt;
-    piAgentRuntime.agent.state.messages = contextMessages;
+    let promptMessage: AgentMessage;
+    const configurePiAgentContext = (messages: ChatCompletionMessage[]): void => {
+      const context = buildPiAgentContext({
+        messages,
+        text,
+        model: agentModel,
+      });
+      piAgentRuntime.agent.state.systemPrompt = context.systemPrompt;
+      piAgentRuntime.agent.state.messages = context.contextMessages;
+      promptMessage = context.promptMessage;
+    };
+    configurePiAgentContext(piReplayMessages);
 
     const toolInputOffsets = new Map<string, number>();
     const toolOutputOffsets = new Map<string, number>();
     const toolOutputTexts = new Map<string, string>();
     piBaseReplayMessages = piReplayMessages.slice();
-    const piReplayAccumulator = piReplayMessages.slice();
+    let piReplayAccumulator = piReplayMessages.slice();
     let toolIterationCount = 0;
     let hitToolIterationLimit = false;
+    let overflowRecoveryAttempted = false;
 
     const emitToolResultMessage = async (
       event: Extract<AgentEvent, { type: 'tool_execution_end' }>,
@@ -1709,43 +1760,72 @@ export async function runChatCompletionCore(
       }
     };
 
-    const subscription = piAgentRuntime.agent.subscribe((event) => {
-      subscriptionWork = subscriptionWork
-        .then(async () => {
-          if (subscriptionError) {
-            return;
-          }
-          await handleAgentEvent(event);
-        })
-        .catch((error) => {
-          if (subscriptionError) {
-            return;
-          }
-          subscriptionError = error;
-          piAgentRuntime.agent.abort();
-        });
-    });
+    const subscribePiAgentEvents = (): (() => void) =>
+      piAgentRuntime.agent.subscribe((event) => {
+        subscriptionWork = subscriptionWork
+          .then(async () => {
+            if (subscriptionError) {
+              return;
+            }
+            await handleAgentEvent(event);
+          })
+          .catch((error) => {
+            if (subscriptionError) {
+              return;
+            }
+            subscriptionError = error;
+            piAgentRuntime.agent.abort();
+          });
+      });
+    const subscription = subscribePiAgentEvents();
 
     const onAbort = () => {
       piAgentRuntime.agent.abort();
     };
-    abortController.signal.addEventListener('abort', onAbort, { once: true });
-    let promptError: unknown = null;
+    const promptPiAgent = async (): Promise<void> => {
+      let promptError: unknown = null;
+      abortController.signal.addEventListener('abort', onAbort, { once: true });
+      try {
+        await piAgentRuntime.agent.prompt(promptMessage);
+      } catch (error) {
+        promptError = error;
+      } finally {
+        abortController.signal.removeEventListener('abort', onAbort);
+        await subscriptionWork;
+      }
+
+      if (subscriptionError) {
+        throw subscriptionError;
+      }
+      if (promptError) {
+        throw promptError;
+      }
+    };
+
+    const persistPiContextBeforeOverflowCompaction = async (): Promise<void> => {
+      const writer = sessionHub.getPiSessionWriter?.();
+      if (!writer) {
+        return;
+      }
+      const updatedSummary = await writer.sync({
+        summary: state.summary,
+        messages: piReplayAccumulator,
+        ...(modelSpec ? { modelSpec } : {}),
+        ...(piConfig?.provider ? { defaultProvider: piConfig.provider } : {}),
+        ...(thinking ? { thinkingLevel: thinking } : {}),
+        updateAttributes: (patch) => sessionHub.updateSessionAttributes(sessionId, patch),
+      });
+      if (updatedSummary) {
+        state.summary = updatedSummary;
+      }
+      state.chatMessages = piReplayAccumulator.slice();
+    };
+
     try {
-      await piAgentRuntime.agent.prompt(promptMessage);
-    } catch (error) {
-      promptError = error;
+      await promptPiAgent();
     } finally {
-      abortController.signal.removeEventListener('abort', onAbort);
       subscription();
       await subscriptionWork;
-    }
-
-    if (subscriptionError) {
-      throw subscriptionError;
-    }
-    if (promptError) {
-      throw promptError;
     }
 
     piReplayMessages = piReplayAccumulator.slice();
@@ -1814,10 +1894,80 @@ export async function runChatCompletionCore(
           : 'aborted';
       finalPiSdkMessage = resolvedPiMessage;
     } else if (resolvedPiMessage?.stopReason === 'error') {
-      throw new ChatRunError(
-        'upstream_error',
-        resolvedPiMessage.errorMessage || 'Chat backend error',
-      );
+      if (
+        overflowRecoveryAttempted ||
+        !isPiContextOverflow(resolvedPiMessage, resolvedModel.model.contextWindow)
+      ) {
+        throw new ChatRunError(
+          'upstream_error',
+          resolvedPiMessage.errorMessage || 'Chat backend error',
+        );
+      }
+
+      overflowRecoveryAttempted = true;
+      try {
+        await persistPiContextBeforeOverflowCompaction();
+        const compacted = await sessionHub.compactSession({
+          sessionId,
+          reason: 'overflow',
+          allowActiveRun: true,
+        });
+        state.summary = compacted.summary;
+        const retryMessages =
+          (await loadCanonicalPiReplayMessages({
+            summary: state.summary,
+          })) ?? state.chatMessages;
+        piReplayMessages = [
+          ...(systemMessage && retryMessages[0]?.role !== 'system' ? [systemMessage] : []),
+          ...retryMessages,
+        ];
+        piBaseReplayMessages = piReplayMessages.slice();
+        piReplayAccumulator = piReplayMessages.slice();
+        lastPiSdkMessage = undefined;
+        finalPiSdkMessage = undefined;
+        fullText = '';
+        if (state.activeChatRun) {
+          state.activeChatRun.accumulatedText = '';
+        }
+        toolIterationCount = 0;
+        hitToolIterationLimit = false;
+        configurePiAgentContext(piReplayMessages);
+
+        const retrySubscription = subscribePiAgentEvents();
+        try {
+          await promptPiAgent();
+        } finally {
+          retrySubscription();
+          await subscriptionWork;
+        }
+      } catch (error) {
+        throw new ChatRunError('upstream_error', PI_CONTEXT_OVERFLOW_RECOVERY_MESSAGE, {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+
+      piReplayMessages = piReplayAccumulator.slice();
+      const retryPiMessage = (finalPiSdkMessage ?? lastPiSdkMessage) as PiSdkMessage | undefined;
+      if (retryPiMessage?.role !== 'assistant') {
+        finalPiSdkMessage = retryPiMessage;
+      } else if (retryPiMessage.stopReason === 'aborted' || abortController.signal.aborted) {
+        aborted = true;
+        abortReason =
+          abortController.signal.reason === 'timeout' || retryPiMessage.errorMessage === 'timeout'
+            ? 'timeout'
+            : 'aborted';
+        finalPiSdkMessage = retryPiMessage;
+      } else if (retryPiMessage.stopReason === 'error') {
+        if (isPiContextOverflow(retryPiMessage, resolvedModel.model.contextWindow)) {
+          throw new ChatRunError('upstream_error', PI_CONTEXT_OVERFLOW_RECOVERY_MESSAGE);
+        }
+        throw new ChatRunError(
+          'upstream_error',
+          retryPiMessage.errorMessage || 'Chat backend error',
+        );
+      } else {
+        finalPiSdkMessage = retryPiMessage;
+      }
     } else {
       finalPiSdkMessage = resolvedPiMessage;
     }

--- a/packages/agent-server/src/chatRunCore.ts
+++ b/packages/agent-server/src/chatRunCore.ts
@@ -1911,6 +1911,7 @@ export async function runChatCompletionCore(
           sessionId,
           reason: 'overflow',
           allowActiveRun: true,
+          signal: abortController.signal,
         });
         state.summary = compacted.summary;
         const retryMessages =

--- a/packages/agent-server/src/chatRunCore.ts
+++ b/packages/agent-server/src/chatRunCore.ts
@@ -24,7 +24,7 @@ import {
   type AgentEvent,
   type AgentMessage,
   type ThinkingLevel as PiAgentThinkingLevel,
-} from '@mariozechner/pi-agent-core';
+} from '@earendil-works/pi-agent-core';
 import {
   type AssistantMessage,
   type AssistantMessageEvent,
@@ -33,7 +33,7 @@ import {
   type TextContent,
   type ToolCall,
   type ToolResultMessage,
-} from '@mariozechner/pi-ai';
+} from '@earendil-works/pi-ai';
 import type { EnvConfig } from './envConfig';
 import type { EventStore } from './events';
 import {
@@ -74,13 +74,13 @@ import type { AgentTool as NativeAgentTool } from './tools';
 
 type ChatProvider = 'pi' | 'claude-cli' | 'codex-cli' | 'pi-cli';
 type OutputModeValue = 'text' | 'speech' | 'both';
-type PiAiModule = typeof import('@mariozechner/pi-ai');
+type PiAiModule = typeof import('@earendil-works/pi-ai');
 
 let piAiModulePromise: Promise<PiAiModule> | null = null;
 
 async function loadPiAiModule(): Promise<PiAiModule> {
   if (!piAiModulePromise) {
-    piAiModulePromise = import('@mariozechner/pi-ai');
+    piAiModulePromise = import('@earendil-works/pi-ai');
   }
   return piAiModulePromise;
 }

--- a/packages/agent-server/src/chatRunCore.ts
+++ b/packages/agent-server/src/chatRunCore.ts
@@ -180,6 +180,7 @@ export interface ChatRunCoreResult {
   piSdkMessage?: PiSdkMessage;
   piReplayMessages?: ChatCompletionMessage[];
   piBaseReplayMessages?: ChatCompletionMessage[];
+  piContextWindow?: number;
 }
 
 export class ChatRunError extends Error {
@@ -730,7 +731,9 @@ function parseToolResultErrorState(content: string): boolean {
   return false;
 }
 
-function getMessageTimestampMs(message: Exclude<ChatCompletionMessage, { role: 'system' }>): number {
+function getMessageTimestampMs(
+  message: Exclude<ChatCompletionMessage, { role: 'system' }>,
+): number {
   return message.historyTimestampMs ?? Date.now();
 }
 
@@ -826,8 +829,12 @@ function buildPiAgentContext(options: {
 } {
   const { messages, text, model } = options;
   const systemPrompt = messages[0]?.role === 'system' ? messages[0].content : '';
-  const nonSystemMessages = (messages[0]?.role === 'system' ? messages.slice(1) : messages.slice())
-    .filter((message): message is Exclude<ChatCompletionMessage, { role: 'system' }> => message.role !== 'system');
+  const nonSystemMessages = (
+    messages[0]?.role === 'system' ? messages.slice(1) : messages.slice()
+  ).filter(
+    (message): message is Exclude<ChatCompletionMessage, { role: 'system' }> =>
+      message.role !== 'system',
+  );
   const lastMessage = nonSystemMessages[nonSystemMessages.length - 1];
   const toolNameIndex = buildToolNameIndex(nonSystemMessages);
   const promptSource =
@@ -957,6 +964,7 @@ export async function runChatCompletionCore(
   let lastPiSdkMessage: PiSdkMessage | undefined;
   let piReplayMessages: ChatCompletionMessage[] | undefined;
   let piBaseReplayMessages: ChatCompletionMessage[] | undefined;
+  let piContextWindow: number | undefined;
 
   if (provider === 'claude-cli') {
     const claudeConfig = resolveCliRuntimeConfig(
@@ -1190,9 +1198,7 @@ export async function runChatCompletionCore(
         ...(typeof rawSessionId === 'string' && rawSessionId.trim().length > 0
           ? { sessionId: rawSessionId.trim() }
           : {}),
-        ...(typeof rawCwd === 'string' && rawCwd.trim().length > 0
-          ? { cwd: rawCwd.trim() }
-          : {}),
+        ...(typeof rawCwd === 'string' && rawCwd.trim().length > 0 ? { cwd: rawCwd.trim() } : {}),
       };
     }
     const resumeSessionId = storedPiSession?.sessionId;
@@ -1329,8 +1335,9 @@ export async function runChatCompletionCore(
       providerId: resolvedModel.providerId,
       log,
     });
-    const apiKey =
-      providerMatchesConfig ? piConfig?.apiKey ?? piAgentAuthApiKey : piAgentAuthApiKey;
+    const apiKey = providerMatchesConfig
+      ? (piConfig?.apiKey ?? piAgentAuthApiKey)
+      : piAgentAuthApiKey;
     const baseUrl = providerMatchesConfig ? piConfig?.baseUrl : undefined;
     const headers = providerMatchesConfig ? piConfig?.headers : undefined;
     const canonicalReplayMessages = await loadCanonicalPiReplayMessages({
@@ -1365,6 +1372,7 @@ export async function runChatCompletionCore(
       ...(baseUrl ? { baseUrl } : {}),
       ...(headers ? { headers } : {}),
     };
+    piContextWindow = agentModel.contextWindow;
     type PiRuntimeConfig = {
       apiKey?: string;
       temperature?: number;
@@ -1378,7 +1386,7 @@ export async function runChatCompletionCore(
     };
     const piAgentRuntime =
       state.piAgentRuntime ??
-      (() => {
+      ((() => {
         const runtime: PiRuntimeState = {
           requestConfig: {},
           onPayload: undefined,
@@ -1411,7 +1419,7 @@ export async function runChatCompletionCore(
         });
         state.piAgentRuntime = runtime as LogicalSessionState['piAgentRuntime'];
         return runtime;
-      })() as PiRuntimeState;
+      })() as PiRuntimeState);
     piAgentRuntime.requestConfig = {
       ...(apiKey ? { apiKey } : {}),
       ...(piConfig?.temperature !== undefined ? { temperature: piConfig.temperature } : {}),
@@ -1576,7 +1584,9 @@ export async function runChatCompletionCore(
             } else if (assistantEvent.type === 'thinking_end') {
               const block = partial.content[assistantEvent.contentIndex];
               await streamHandlers.emitThinkingDone(
-                block && block.type === 'thinking' ? block.thinking : streamHandlers.getThinkingText(),
+                block && block.type === 'thinking'
+                  ? block.thinking
+                  : streamHandlers.getThinkingText(),
               );
             }
           } else if (assistantEvent.type === 'toolcall_start') {
@@ -1812,10 +1822,7 @@ export async function runChatCompletionCore(
       finalPiSdkMessage = resolvedPiMessage;
     }
   } else {
-    throw new ChatRunError(
-      'agent_config_error',
-      `Unsupported chat provider "${provider}"`,
-    );
+    throw new ChatRunError('agent_config_error', `Unsupported chat provider "${provider}"`);
   }
 
   const resolvedPiSdkMessage = finalPiSdkMessage ?? lastPiSdkMessage;
@@ -1826,10 +1833,9 @@ export async function runChatCompletionCore(
     provider,
     aborted,
     ...(abortReason ? { abortReason } : {}),
-    ...(provider === 'pi' && resolvedPiSdkMessage
-      ? { piSdkMessage: resolvedPiSdkMessage }
-      : {}),
+    ...(provider === 'pi' && resolvedPiSdkMessage ? { piSdkMessage: resolvedPiSdkMessage } : {}),
     ...(provider === 'pi' && piReplayMessages ? { piReplayMessages } : {}),
     ...(provider === 'pi' && piBaseReplayMessages ? { piBaseReplayMessages } : {}),
+    ...(provider === 'pi' && typeof piContextWindow === 'number' ? { piContextWindow } : {}),
   };
 }

--- a/packages/agent-server/src/config.test.ts
+++ b/packages/agent-server/src/config.test.ts
@@ -781,6 +781,11 @@ describe('loadConfig', () => {
               contextWindow: 65536,
               temperature: 0.7,
               maxToolIterations: 25,
+              compaction: {
+                enabled: true,
+                reserveTokens: 8192,
+                keepRecentTokens: 12000,
+              },
             },
           },
         },
@@ -813,6 +818,11 @@ describe('loadConfig', () => {
         contextWindow: 65536,
         temperature: 0.7,
         maxToolIterations: 25,
+        compaction: {
+          enabled: true,
+          reserveTokens: 8192,
+          keepRecentTokens: 12000,
+        },
       },
     });
   });

--- a/packages/agent-server/src/config.ts
+++ b/packages/agent-server/src/config.ts
@@ -220,6 +220,13 @@ const PiSdkChatConfigSchema = z.object({
   contextWindow: z.number().int().min(1).optional(),
   temperature: z.number().min(0).max(2).optional(),
   maxToolIterations: z.number().int().min(1).optional(),
+  compaction: z
+    .object({
+      enabled: z.boolean().optional(),
+      reserveTokens: z.number().int().min(1).optional(),
+      keepRecentTokens: z.number().int().min(1).optional(),
+    })
+    .optional(),
 });
 
 const ChatConfigSchema = z.object({
@@ -426,6 +433,20 @@ export const AgentConfigSchema = RawAgentConfigSchema.transform((value) => {
         rawChat.config !== undefined && rawChat.config !== null
           ? PiSdkChatConfigSchema.parse(rawChat.config)
           : undefined;
+      const compaction =
+        config?.compaction !== undefined
+          ? {
+              ...(config.compaction.enabled !== undefined
+                ? { enabled: config.compaction.enabled }
+                : {}),
+              ...(config.compaction.reserveTokens !== undefined
+                ? { reserveTokens: config.compaction.reserveTokens }
+                : {}),
+              ...(config.compaction.keepRecentTokens !== undefined
+                ? { keepRecentTokens: config.compaction.keepRecentTokens }
+                : {}),
+            }
+          : undefined;
 
       base.chat = {
         provider: 'pi',
@@ -447,6 +468,7 @@ export const AgentConfigSchema = RawAgentConfigSchema.transform((value) => {
                 ...(config.maxToolIterations !== undefined
                   ? { maxToolIterations: config.maxToolIterations }
                   : {}),
+                ...(compaction ? { compaction } : {}),
               },
             }
           : {}),

--- a/packages/agent-server/src/contextUsage.test.ts
+++ b/packages/agent-server/src/contextUsage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { AssistantMessage } from '@mariozechner/pi-ai';
+import type { AssistantMessage } from '@earendil-works/pi-ai';
 
 import {
   buildSessionContextUsage,

--- a/packages/agent-server/src/contextUsage.ts
+++ b/packages/agent-server/src/contextUsage.ts
@@ -1,4 +1,4 @@
-import type { AssistantMessage, Usage } from '@mariozechner/pi-ai';
+import type { AssistantMessage, Usage } from '@earendil-works/pi-ai';
 import type { SessionContextUsage, TokenUsageBreakdown } from '@assistant/shared';
 
 export function calculateContextTokens(usage: Pick<Usage, 'totalTokens' | 'input' | 'output' | 'cacheRead' | 'cacheWrite'>): number {

--- a/packages/agent-server/src/history/piCompaction.test.ts
+++ b/packages/agent-server/src/history/piCompaction.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_PI_COMPACTION_SETTINGS,
+  estimatePiMessageTokens,
+  preparePiCompaction,
+  shouldCompactPiContext,
+} from './piCompaction';
+
+describe('piCompaction', () => {
+  it('uses the Pi threshold rule', () => {
+    expect(
+      shouldCompactPiContext({
+        contextTokens: 112,
+        contextWindow: 128,
+        settings: { ...DEFAULT_PI_COMPACTION_SETTINGS, reserveTokens: 16 },
+      }),
+    ).toBe(false);
+    expect(
+      shouldCompactPiContext({
+        contextTokens: 113,
+        contextWindow: 128,
+        settings: { ...DEFAULT_PI_COMPACTION_SETTINGS, reserveTokens: 16 },
+      }),
+    ).toBe(true);
+  });
+
+  it('selects a kept entry and previous summary for later compactions', () => {
+    const entries = [
+      {
+        type: 'message' as const,
+        id: 'old',
+        parentId: null,
+        timestamp: '2026-05-10T00:00:00.000Z',
+        message: {
+          role: 'user' as const,
+          content: [{ type: 'text' as const, text: 'old request '.repeat(100) }],
+          timestamp: 1,
+        },
+      },
+      {
+        type: 'compaction' as const,
+        id: 'compact-1',
+        parentId: 'old',
+        timestamp: '2026-05-10T00:00:01.000Z',
+        summary: 'Previous summary.',
+        firstKeptEntryId: 'old',
+        tokensBefore: 400,
+        details: { readFiles: ['a.ts'], modifiedFiles: [] },
+      },
+      {
+        type: 'message' as const,
+        id: 'summarized',
+        parentId: 'compact-1',
+        timestamp: '2026-05-10T00:00:02.000Z',
+        message: {
+          role: 'user' as const,
+          content: [{ type: 'text' as const, text: 'middle request '.repeat(100) }],
+          timestamp: 2,
+        },
+      },
+      {
+        type: 'message' as const,
+        id: 'kept',
+        parentId: 'summarized',
+        timestamp: '2026-05-10T00:00:03.000Z',
+        message: {
+          role: 'user' as const,
+          content: [{ type: 'text' as const, text: 'recent' }],
+          timestamp: 3,
+        },
+      },
+    ];
+
+    const preparation = preparePiCompaction(entries, {
+      enabled: true,
+      reserveTokens: 16,
+      keepRecentTokens: 2,
+    });
+
+    expect(preparation).toMatchObject({
+      firstKeptEntryId: 'kept',
+      previousSummary: 'Previous summary.',
+    });
+    expect(preparation?.messagesToSummarize).toHaveLength(1);
+    expect(estimatePiMessageTokens(entries[0]!.message!)).toBeGreaterThan(0);
+  });
+});

--- a/packages/agent-server/src/history/piCompaction.ts
+++ b/packages/agent-server/src/history/piCompaction.ts
@@ -43,6 +43,12 @@ export type PiCompactionEntryLike = {
   fromHook?: boolean;
 };
 
+export type PiSessionEntryRecordLike = Record<string, unknown> & {
+  type: string;
+  id: string;
+  parentId: string | null;
+};
+
 export type PiCustomAgentMessage = {
   role: 'custom';
   customType: string;
@@ -206,6 +212,10 @@ Be concise. Focus on what's needed to understand the kept suffix.`;
 
 const TOOL_RESULT_MAX_CHARS = 2000;
 
+function getString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
@@ -306,6 +316,69 @@ function createCompactionSummaryMessage(entry: PiCompactionEntryLike): PiCompact
     tokensBefore: entry.tokensBefore,
     timestamp: new Date(entry.timestamp).getTime(),
   };
+}
+
+export function buildPiSessionEntryPath<T extends PiSessionEntryRecordLike>(entries: T[]): T[] {
+  const byId = new Map<string, T>();
+  for (const entry of entries) {
+    byId.set(entry.id, entry);
+  }
+  const leaf = entries[entries.length - 1];
+  if (!leaf) {
+    return [];
+  }
+  const pathEntries: T[] = [];
+  const seen = new Set<string>();
+  let current: T | undefined = leaf;
+  while (current) {
+    if (seen.has(current.id)) {
+      break;
+    }
+    seen.add(current.id);
+    pathEntries.unshift(current);
+    current = current.parentId ? byId.get(current.parentId) : undefined;
+  }
+  return pathEntries;
+}
+
+export function buildEffectivePiSessionEntryPath<T extends PiSessionEntryRecordLike>(
+  entries: T[],
+  options: {
+    createCompactionSummaryEntry?: (compaction: T) => T | undefined;
+    includeRawCompactionEntry?: boolean;
+  } = {},
+): T[] {
+  const pathEntries = buildPiSessionEntryPath(entries);
+  let compactionIndex = -1;
+  for (let i = pathEntries.length - 1; i >= 0; i -= 1) {
+    if (pathEntries[i]?.type === 'compaction') {
+      compactionIndex = i;
+      break;
+    }
+  }
+  if (compactionIndex === -1) {
+    return pathEntries;
+  }
+
+  const compaction = pathEntries[compactionIndex]!;
+  const summaryEntry = options.createCompactionSummaryEntry?.(compaction);
+  const effective: T[] =
+    summaryEntry || options.includeRawCompactionEntry !== false ? [summaryEntry ?? compaction] : [];
+  const firstKeptEntryId = getString(compaction['firstKeptEntryId']);
+  let foundFirstKept = false;
+  for (let i = 0; i < compactionIndex; i += 1) {
+    const entry = pathEntries[i]!;
+    if (entry.id === firstKeptEntryId) {
+      foundFirstKept = true;
+    }
+    if (foundFirstKept) {
+      effective.push(entry);
+    }
+  }
+  for (let i = compactionIndex + 1; i < pathEntries.length; i += 1) {
+    effective.push(pathEntries[i]!);
+  }
+  return effective;
 }
 
 function getMessageFromEntry(entry: PiSessionPathEntry): PiCompactionAgentMessage | undefined {

--- a/packages/agent-server/src/history/piCompaction.ts
+++ b/packages/agent-server/src/history/piCompaction.ts
@@ -1,10 +1,10 @@
-import type { AgentMessage } from '@mariozechner/pi-agent-core';
-import type { Api, Model, Usage } from '@mariozechner/pi-ai';
+import type { AgentMessage } from '@earendil-works/pi-agent-core';
+import type { Api, Model, Usage } from '@earendil-works/pi-ai';
 
 import { calculateContextTokens } from '../contextUsage';
 
 /*
- * Adapted from @mariozechner/pi-coding-agent 0.62.0 compaction helpers
+ * Adapted from @earendil-works/pi-coding-agent 0.62.0 compaction helpers
  * (packages/coding-agent/src/core/compaction). Kept local so assistant does
  * not depend on package internals.
  */
@@ -212,12 +212,12 @@ Be concise. Focus on what's needed to understand the kept suffix.`;
 
 const TOOL_RESULT_MAX_CHARS = 2000;
 
-type PiAiModule = typeof import('@mariozechner/pi-ai');
+type PiAiModule = typeof import('@earendil-works/pi-ai');
 let piAiModulePromise: Promise<PiAiModule> | null = null;
 
 async function loadPiAiModule(): Promise<PiAiModule> {
   if (!piAiModulePromise) {
-    piAiModulePromise = import('@mariozechner/pi-ai');
+    piAiModulePromise = import('@earendil-works/pi-ai');
   }
   return piAiModulePromise;
 }

--- a/packages/agent-server/src/history/piCompaction.ts
+++ b/packages/agent-server/src/history/piCompaction.ts
@@ -3,6 +3,12 @@ import { completeSimple, type Api, type Model, type Usage } from '@mariozechner/
 
 import { calculateContextTokens } from '../contextUsage';
 
+/*
+ * Adapted from @mariozechner/pi-coding-agent 0.62.0 compaction helpers
+ * (packages/coding-agent/src/core/compaction). Kept local so assistant does
+ * not depend on package internals.
+ */
+
 export const COMPACTION_SUMMARY_PREFIX =
   'The conversation history before this point was compacted into the following summary:\n\n<summary>\n';
 export const COMPACTION_SUMMARY_SUFFIX = '\n</summary>';

--- a/packages/agent-server/src/history/piCompaction.ts
+++ b/packages/agent-server/src/history/piCompaction.ts
@@ -1,5 +1,5 @@
 import type { AgentMessage } from '@mariozechner/pi-agent-core';
-import { completeSimple, type Api, type Model, type Usage } from '@mariozechner/pi-ai';
+import type { Api, Model, Usage } from '@mariozechner/pi-ai';
 
 import { calculateContextTokens } from '../contextUsage';
 
@@ -211,6 +211,16 @@ Summarize the prefix to provide context for the retained suffix:
 Be concise. Focus on what's needed to understand the kept suffix.`;
 
 const TOOL_RESULT_MAX_CHARS = 2000;
+
+type PiAiModule = typeof import('@mariozechner/pi-ai');
+let piAiModulePromise: Promise<PiAiModule> | null = null;
+
+async function loadPiAiModule(): Promise<PiAiModule> {
+  if (!piAiModulePromise) {
+    piAiModulePromise = import('@mariozechner/pi-ai');
+  }
+  return piAiModulePromise;
+}
 
 function getString(value: unknown): string {
   return typeof value === 'string' ? value : '';
@@ -735,6 +745,7 @@ async function generateSummary(options: {
     promptText += `<previous-summary>\n${previousSummary}\n</previous-summary>\n\n`;
   }
   promptText += basePrompt;
+  const { completeSimple } = await loadPiAiModule();
   const response = await completeSimple(
     model,
     {

--- a/packages/agent-server/src/history/piCompaction.ts
+++ b/packages/agent-server/src/history/piCompaction.ts
@@ -43,6 +43,27 @@ export type PiCompactionEntryLike = {
   fromHook?: boolean;
 };
 
+export type PiCustomAgentMessage = {
+  role: 'custom';
+  customType: string;
+  content: string | unknown[];
+  display: boolean;
+  details?: unknown;
+  timestamp: number;
+};
+
+export type PiCompactionSummaryMessage = {
+  role: 'compactionSummary';
+  summary: string;
+  tokensBefore: number;
+  timestamp: number;
+};
+
+export type PiCompactionAgentMessage =
+  | AgentMessage
+  | PiCustomAgentMessage
+  | PiCompactionSummaryMessage;
+
 export type PiSessionPathEntry =
   | {
       type: 'message';
@@ -72,8 +93,8 @@ export type PiSessionPathEntry =
 
 export type PiCompactionPreparation = {
   firstKeptEntryId: string;
-  messagesToSummarize: AgentMessage[];
-  turnPrefixMessages: AgentMessage[];
+  messagesToSummarize: PiCompactionAgentMessage[];
+  turnPrefixMessages: PiCompactionAgentMessage[];
   isSplitTurn: boolean;
   tokensBefore: number;
   previousSummary?: string;
@@ -219,7 +240,10 @@ function extractTextBlocks(content: unknown): string {
     .join('');
 }
 
-function extractFileOpsFromMessage(message: AgentMessage, fileOps: FileOperations): void {
+function extractFileOpsFromMessage(
+  message: PiCompactionAgentMessage,
+  fileOps: FileOperations,
+): void {
   if (message.role !== 'assistant' || !Array.isArray(message.content)) {
     return;
   }
@@ -264,27 +288,27 @@ function formatFileOperations(details: PiCompactionDetails): string {
 
 function createCustomMessage(
   entry: Extract<PiSessionPathEntry, { type: 'custom_message' }>,
-): AgentMessage {
+): PiCustomAgentMessage {
   return {
     role: 'custom',
     customType: entry.customType,
-    content: entry.content as never,
+    content: entry.content,
     display: entry.display,
     details: entry.details,
     timestamp: new Date(entry.timestamp).getTime(),
-  } as AgentMessage;
+  };
 }
 
-function createCompactionSummaryMessage(entry: PiCompactionEntryLike): AgentMessage {
+function createCompactionSummaryMessage(entry: PiCompactionEntryLike): PiCompactionSummaryMessage {
   return {
     role: 'compactionSummary',
     summary: entry.summary,
     tokensBefore: entry.tokensBefore,
     timestamp: new Date(entry.timestamp).getTime(),
-  } as AgentMessage;
+  };
 }
 
-function getMessageFromEntry(entry: PiSessionPathEntry): AgentMessage | undefined {
+function getMessageFromEntry(entry: PiSessionPathEntry): PiCompactionAgentMessage | undefined {
   if (entry.type === 'message') {
     return (entry as Extract<PiSessionPathEntry, { type: 'message' }>).message;
   }
@@ -297,7 +321,7 @@ function getMessageFromEntry(entry: PiSessionPathEntry): AgentMessage | undefine
   return undefined;
 }
 
-function estimateUsageTokensFromMessage(message: AgentMessage): Usage | undefined {
+function estimateUsageTokensFromMessage(message: PiCompactionAgentMessage): Usage | undefined {
   if (message.role !== 'assistant') {
     return undefined;
   }
@@ -311,7 +335,7 @@ function estimateUsageTokensFromMessage(message: AgentMessage): Usage | undefine
   return assistant.usage;
 }
 
-export function estimatePiMessageTokens(message: AgentMessage): number {
+export function estimatePiMessageTokens(message: PiCompactionAgentMessage): number {
   let chars = 0;
   if (message.role === 'user') {
     chars = extractTextBlocks((message as { content?: unknown }).content).length;
@@ -331,15 +355,15 @@ export function estimatePiMessageTokens(message: AgentMessage): number {
     }
   } else if (message.role === 'toolResult') {
     chars = extractTextBlocks((message as { content?: unknown }).content).length;
-  } else if ((message as { role?: string }).role === 'compactionSummary') {
-    chars = String((message as { summary?: unknown }).summary ?? '').length;
-  } else if ((message as { role?: string }).role === 'custom') {
-    chars = extractTextBlocks((message as { content?: unknown }).content).length;
+  } else if (message.role === 'compactionSummary') {
+    chars = message.summary.length;
+  } else if (message.role === 'custom') {
+    chars = extractTextBlocks(message.content).length;
   }
   return Math.ceil(chars / 4);
 }
 
-export function estimatePiContextTokens(messages: AgentMessage[]): number {
+export function estimatePiContextTokens(messages: PiCompactionAgentMessage[]): number {
   for (let i = messages.length - 1; i >= 0; i -= 1) {
     const usage = estimateUsageTokensFromMessage(messages[i]!);
     if (usage) {
@@ -435,7 +459,7 @@ function findCutPoint(
 }
 
 function extractFileOperations(
-  messages: AgentMessage[],
+  messages: PiCompactionAgentMessage[],
   entries: PiSessionPathEntry[],
   prevCompactionIndex: number,
 ): FileOperations {
@@ -497,7 +521,7 @@ export function preparePiCompaction(
 
   const boundaryStart = prevCompactionIndex + 1;
   const boundaryEnd = pathEntries.length;
-  const usageMessages: AgentMessage[] = [];
+  const usageMessages: PiCompactionAgentMessage[] = [];
   for (let i = prevCompactionIndex >= 0 ? prevCompactionIndex : 0; i < boundaryEnd; i += 1) {
     const message = getMessageFromEntry(pathEntries[i]!);
     if (message) {
@@ -512,7 +536,7 @@ export function preparePiCompaction(
   }
 
   const historyEnd = cutPoint.isSplitTurn ? cutPoint.turnStartIndex : cutPoint.firstKeptEntryIndex;
-  const messagesToSummarize: AgentMessage[] = [];
+  const messagesToSummarize: PiCompactionAgentMessage[] = [];
   for (let i = boundaryStart; i < historyEnd; i += 1) {
     const message = getMessageFromEntry(pathEntries[i]!);
     if (message) {
@@ -520,7 +544,7 @@ export function preparePiCompaction(
     }
   }
 
-  const turnPrefixMessages: AgentMessage[] = [];
+  const turnPrefixMessages: PiCompactionAgentMessage[] = [];
   if (cutPoint.isSplitTurn) {
     for (let i = cutPoint.turnStartIndex; i < cutPoint.firstKeptEntryIndex; i += 1) {
       const message = getMessageFromEntry(pathEntries[i]!);
@@ -551,7 +575,7 @@ export function preparePiCompaction(
   };
 }
 
-function serializeConversation(messages: AgentMessage[]): string {
+function serializeConversation(messages: PiCompactionAgentMessage[]): string {
   const parts: string[] = [];
   for (const message of messages) {
     if (message.role === 'user') {
@@ -593,13 +617,13 @@ function serializeConversation(messages: AgentMessage[]): string {
       if (content) {
         parts.push(`[Tool result]: ${truncateForSummary(content, TOOL_RESULT_MAX_CHARS)}`);
       }
-    } else if ((message as { role?: string }).role === 'custom') {
-      const content = extractTextBlocks((message as { content?: unknown }).content);
+    } else if (message.role === 'custom') {
+      const content = extractTextBlocks(message.content);
       if (content) {
         parts.push(`[User]: ${content}`);
       }
-    } else if ((message as { role?: string }).role === 'compactionSummary') {
-      const summary = String((message as { summary?: unknown }).summary ?? '').trim();
+    } else if (message.role === 'compactionSummary') {
+      const summary = message.summary.trim();
       if (summary) {
         parts.push(`[Compaction summary]: ${summary}`);
       }
@@ -609,7 +633,7 @@ function serializeConversation(messages: AgentMessage[]): string {
 }
 
 async function generateSummary(options: {
-  messages: AgentMessage[];
+  messages: PiCompactionAgentMessage[];
   model: Model<Api>;
   reserveTokens: number;
   apiKey?: string;

--- a/packages/agent-server/src/history/piCompaction.ts
+++ b/packages/agent-server/src/history/piCompaction.ts
@@ -1,0 +1,721 @@
+import type { AgentMessage } from '@mariozechner/pi-agent-core';
+import { completeSimple, type Api, type Model, type Usage } from '@mariozechner/pi-ai';
+
+import { calculateContextTokens } from '../contextUsage';
+
+export const COMPACTION_SUMMARY_PREFIX =
+  'The conversation history before this point was compacted into the following summary:\n\n<summary>\n';
+export const COMPACTION_SUMMARY_SUFFIX = '\n</summary>';
+
+export type PiCompactionSettings = {
+  enabled: boolean;
+  reserveTokens: number;
+  keepRecentTokens: number;
+};
+
+export type PiCompactionDetails = {
+  readFiles: string[];
+  modifiedFiles: string[];
+};
+
+export type PiCompactionResult = {
+  summary: string;
+  firstKeptEntryId: string;
+  tokensBefore: number;
+  details?: PiCompactionDetails;
+};
+
+export type PiCompactionEntryLike = {
+  type: 'compaction';
+  id: string;
+  parentId: string | null;
+  timestamp: string;
+  summary: string;
+  firstKeptEntryId: string;
+  tokensBefore: number;
+  details?: unknown;
+  fromHook?: boolean;
+};
+
+export type PiSessionPathEntry =
+  | {
+      type: 'message';
+      id: string;
+      parentId: string | null;
+      timestamp: string;
+      message: AgentMessage;
+    }
+  | {
+      type: 'custom_message';
+      id: string;
+      parentId: string | null;
+      timestamp: string;
+      customType: string;
+      content: string | unknown[];
+      details?: unknown;
+      display: boolean;
+    }
+  | PiCompactionEntryLike
+  | {
+      type: Exclude<string, 'message' | 'custom_message' | 'compaction'>;
+      id: string;
+      parentId: string | null;
+      timestamp?: string;
+      [key: string]: unknown;
+    };
+
+export type PiCompactionPreparation = {
+  firstKeptEntryId: string;
+  messagesToSummarize: AgentMessage[];
+  turnPrefixMessages: AgentMessage[];
+  isSplitTurn: boolean;
+  tokensBefore: number;
+  previousSummary?: string;
+  fileOps: FileOperations;
+  settings: PiCompactionSettings;
+};
+
+type FileOperations = {
+  read: Set<string>;
+  written: Set<string>;
+  edited: Set<string>;
+};
+
+export const DEFAULT_PI_COMPACTION_SETTINGS: PiCompactionSettings = {
+  enabled: true,
+  reserveTokens: 16384,
+  keepRecentTokens: 20000,
+};
+
+const SUMMARIZATION_SYSTEM_PROMPT =
+  'You are a context summarization assistant. Your task is to read a conversation between a user and an AI coding assistant, then produce a structured summary following the exact format specified.\n\nDo NOT continue the conversation. Do NOT respond to any questions in the conversation. ONLY output the structured summary.';
+
+const SUMMARIZATION_PROMPT = `The messages above are a conversation to summarize. Create a structured context checkpoint summary that another LLM will use to continue the work.
+
+Use this EXACT format:
+
+## Goal
+[What is the user trying to accomplish? Can be multiple items if the session covers different tasks.]
+
+## Constraints & Preferences
+- [Any constraints, preferences, or requirements mentioned by user]
+- [Or "(none)" if none were mentioned]
+
+## Progress
+### Done
+- [x] [Completed tasks/changes]
+
+### In Progress
+- [ ] [Current work]
+
+### Blocked
+- [Issues preventing progress, if any]
+
+## Key Decisions
+- **[Decision]**: [Brief rationale]
+
+## Next Steps
+1. [Ordered list of what should happen next]
+
+## Critical Context
+- [Any data, examples, or references needed to continue]
+- [Or "(none)" if not applicable]
+
+Keep each section concise. Preserve exact file paths, function names, and error messages.`;
+
+const UPDATE_SUMMARIZATION_PROMPT = `The messages above are NEW conversation messages to incorporate into the existing summary provided in <previous-summary> tags.
+
+Update the existing structured summary with new information. RULES:
+- PRESERVE all existing information from the previous summary
+- ADD new progress, decisions, and context from the new messages
+- UPDATE the Progress section: move items from "In Progress" to "Done" when completed
+- UPDATE "Next Steps" based on what was accomplished
+- PRESERVE exact file paths, function names, and error messages
+- If something is no longer relevant, you may remove it
+
+Use this EXACT format:
+
+## Goal
+[Preserve existing goals, add new ones if the task expanded]
+
+## Constraints & Preferences
+- [Preserve existing, add new ones discovered]
+
+## Progress
+### Done
+- [x] [Include previously done items AND newly completed items]
+
+### In Progress
+- [ ] [Current work - update based on progress]
+
+### Blocked
+- [Current blockers - remove if resolved]
+
+## Key Decisions
+- **[Decision]**: [Brief rationale] (preserve all previous, add new)
+
+## Next Steps
+1. [Update based on current state]
+
+## Critical Context
+- [Preserve important context, add new if needed]
+
+Keep each section concise. Preserve exact file paths, function names, and error messages.`;
+
+const TURN_PREFIX_SUMMARIZATION_PROMPT = `This is the PREFIX of a turn that was too large to keep. The SUFFIX (recent work) is retained.
+
+Summarize the prefix to provide context for the retained suffix:
+
+## Original Request
+[What did the user ask for in this turn?]
+
+## Early Progress
+- [Key decisions and work done in the prefix]
+
+## Context for Suffix
+- [Information needed to understand the retained recent work]
+
+Be concise. Focus on what's needed to understand the kept suffix.`;
+
+const TOOL_RESULT_MAX_CHARS = 2000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function createFileOps(): FileOperations {
+  return {
+    read: new Set<string>(),
+    written: new Set<string>(),
+    edited: new Set<string>(),
+  };
+}
+
+function truncateForSummary(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return `${text.slice(0, maxChars)}\n\n[... ${text.length - maxChars} more characters truncated]`;
+}
+
+function extractTextBlocks(content: unknown): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return '';
+  }
+  return content
+    .filter(
+      (block) => isRecord(block) && block['type'] === 'text' && typeof block['text'] === 'string',
+    )
+    .map((block) => (block as { text: string }).text)
+    .join('');
+}
+
+function extractFileOpsFromMessage(message: AgentMessage, fileOps: FileOperations): void {
+  if (message.role !== 'assistant' || !Array.isArray(message.content)) {
+    return;
+  }
+  for (const block of message.content) {
+    if (!isRecord(block) || block['type'] !== 'toolCall') {
+      continue;
+    }
+    const args = isRecord(block['arguments']) ? block['arguments'] : null;
+    const filePath = typeof args?.['path'] === 'string' ? args['path'] : undefined;
+    const name = typeof block['name'] === 'string' ? block['name'] : '';
+    if (!filePath) {
+      continue;
+    }
+    if (name === 'read') {
+      fileOps.read.add(filePath);
+    } else if (name === 'write') {
+      fileOps.written.add(filePath);
+    } else if (name === 'edit') {
+      fileOps.edited.add(filePath);
+    }
+  }
+}
+
+function computeFileLists(fileOps: FileOperations): PiCompactionDetails {
+  const modified = new Set([...fileOps.edited, ...fileOps.written]);
+  return {
+    readFiles: [...fileOps.read].filter((filePath) => !modified.has(filePath)).sort(),
+    modifiedFiles: [...modified].sort(),
+  };
+}
+
+function formatFileOperations(details: PiCompactionDetails): string {
+  const sections: string[] = [];
+  if (details.readFiles.length > 0) {
+    sections.push(`<read-files>\n${details.readFiles.join('\n')}\n</read-files>`);
+  }
+  if (details.modifiedFiles.length > 0) {
+    sections.push(`<modified-files>\n${details.modifiedFiles.join('\n')}\n</modified-files>`);
+  }
+  return sections.length > 0 ? `\n\n${sections.join('\n\n')}` : '';
+}
+
+function createCustomMessage(
+  entry: Extract<PiSessionPathEntry, { type: 'custom_message' }>,
+): AgentMessage {
+  return {
+    role: 'custom',
+    customType: entry.customType,
+    content: entry.content as never,
+    display: entry.display,
+    details: entry.details,
+    timestamp: new Date(entry.timestamp).getTime(),
+  } as AgentMessage;
+}
+
+function createCompactionSummaryMessage(entry: PiCompactionEntryLike): AgentMessage {
+  return {
+    role: 'compactionSummary',
+    summary: entry.summary,
+    tokensBefore: entry.tokensBefore,
+    timestamp: new Date(entry.timestamp).getTime(),
+  } as AgentMessage;
+}
+
+function getMessageFromEntry(entry: PiSessionPathEntry): AgentMessage | undefined {
+  if (entry.type === 'message') {
+    return (entry as Extract<PiSessionPathEntry, { type: 'message' }>).message;
+  }
+  if (entry.type === 'custom_message') {
+    return createCustomMessage(entry as Extract<PiSessionPathEntry, { type: 'custom_message' }>);
+  }
+  if (entry.type === 'compaction') {
+    return createCompactionSummaryMessage(entry as PiCompactionEntryLike);
+  }
+  return undefined;
+}
+
+function estimateUsageTokensFromMessage(message: AgentMessage): Usage | undefined {
+  if (message.role !== 'assistant') {
+    return undefined;
+  }
+  const assistant = message as AgentMessage & {
+    stopReason?: string;
+    usage?: Usage;
+  };
+  if (assistant.stopReason === 'aborted' || assistant.stopReason === 'error') {
+    return undefined;
+  }
+  return assistant.usage;
+}
+
+export function estimatePiMessageTokens(message: AgentMessage): number {
+  let chars = 0;
+  if (message.role === 'user') {
+    chars = extractTextBlocks((message as { content?: unknown }).content).length;
+  } else if (message.role === 'assistant') {
+    for (const block of (message as { content?: unknown[] }).content ?? []) {
+      if (!isRecord(block)) {
+        continue;
+      }
+      if (block['type'] === 'text' && typeof block['text'] === 'string') {
+        chars += block['text'].length;
+      } else if (block['type'] === 'thinking' && typeof block['thinking'] === 'string') {
+        chars += block['thinking'].length;
+      } else if (block['type'] === 'toolCall') {
+        chars +=
+          String(block['name'] ?? '').length + JSON.stringify(block['arguments'] ?? {}).length;
+      }
+    }
+  } else if (message.role === 'toolResult') {
+    chars = extractTextBlocks((message as { content?: unknown }).content).length;
+  } else if ((message as { role?: string }).role === 'compactionSummary') {
+    chars = String((message as { summary?: unknown }).summary ?? '').length;
+  } else if ((message as { role?: string }).role === 'custom') {
+    chars = extractTextBlocks((message as { content?: unknown }).content).length;
+  }
+  return Math.ceil(chars / 4);
+}
+
+export function estimatePiContextTokens(messages: AgentMessage[]): number {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const usage = estimateUsageTokensFromMessage(messages[i]!);
+    if (usage) {
+      let trailingTokens = 0;
+      for (let j = i + 1; j < messages.length; j += 1) {
+        trailingTokens += estimatePiMessageTokens(messages[j]!);
+      }
+      return calculateContextTokens(usage) + trailingTokens;
+    }
+  }
+  return messages.reduce((total, message) => total + estimatePiMessageTokens(message), 0);
+}
+
+function findValidCutPoints(
+  entries: PiSessionPathEntry[],
+  startIndex: number,
+  endIndex: number,
+): number[] {
+  const cutPoints: number[] = [];
+  for (let i = startIndex; i < endIndex; i += 1) {
+    const entry = entries[i]!;
+    if (entry.type === 'message') {
+      const role = (entry.message as { role?: string }).role;
+      if (role === 'user' || role === 'assistant') {
+        cutPoints.push(i);
+      }
+    } else if (entry.type === 'custom_message') {
+      cutPoints.push(i);
+    }
+  }
+  return cutPoints;
+}
+
+function findTurnStartIndex(
+  entries: PiSessionPathEntry[],
+  entryIndex: number,
+  startIndex: number,
+): number {
+  for (let i = entryIndex; i >= startIndex; i -= 1) {
+    const entry = entries[i]!;
+    if (entry.type === 'custom_message') {
+      return i;
+    }
+    if (entry.type === 'message' && (entry.message as { role?: string }).role === 'user') {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function findCutPoint(
+  entries: PiSessionPathEntry[],
+  startIndex: number,
+  endIndex: number,
+  keepRecentTokens: number,
+): { firstKeptEntryIndex: number; turnStartIndex: number; isSplitTurn: boolean } {
+  const cutPoints = findValidCutPoints(entries, startIndex, endIndex);
+  if (cutPoints.length === 0) {
+    return { firstKeptEntryIndex: startIndex, turnStartIndex: -1, isSplitTurn: false };
+  }
+
+  let accumulatedTokens = 0;
+  let cutIndex = cutPoints[0]!;
+  for (let i = endIndex - 1; i >= startIndex; i -= 1) {
+    const message = getMessageFromEntry(entries[i]!);
+    if (!message) {
+      continue;
+    }
+    accumulatedTokens += estimatePiMessageTokens(message);
+    if (accumulatedTokens >= keepRecentTokens) {
+      cutIndex = cutPoints.find((candidate) => candidate >= i) ?? cutIndex;
+      break;
+    }
+  }
+
+  while (cutIndex > startIndex) {
+    const previous = entries[cutIndex - 1]!;
+    if (previous.type === 'compaction' || previous.type === 'message') {
+      break;
+    }
+    cutIndex -= 1;
+  }
+
+  const cutEntry = entries[cutIndex]!;
+  const isUserMessage =
+    cutEntry.type === 'message' && (cutEntry.message as { role?: string }).role === 'user';
+  const turnStartIndex = isUserMessage ? -1 : findTurnStartIndex(entries, cutIndex, startIndex);
+  return {
+    firstKeptEntryIndex: cutIndex,
+    turnStartIndex,
+    isSplitTurn: !isUserMessage && turnStartIndex !== -1,
+  };
+}
+
+function extractFileOperations(
+  messages: AgentMessage[],
+  entries: PiSessionPathEntry[],
+  prevCompactionIndex: number,
+): FileOperations {
+  const fileOps = createFileOps();
+  if (prevCompactionIndex >= 0) {
+    const previous = entries[prevCompactionIndex]!;
+    if (previous.type === 'compaction' && !previous.fromHook && isRecord(previous.details)) {
+      const readFiles = previous.details['readFiles'];
+      const modifiedFiles = previous.details['modifiedFiles'];
+      if (Array.isArray(readFiles)) {
+        for (const filePath of readFiles) {
+          if (typeof filePath === 'string') {
+            fileOps.read.add(filePath);
+          }
+        }
+      }
+      if (Array.isArray(modifiedFiles)) {
+        for (const filePath of modifiedFiles) {
+          if (typeof filePath === 'string') {
+            fileOps.edited.add(filePath);
+          }
+        }
+      }
+    }
+  }
+  for (const message of messages) {
+    extractFileOpsFromMessage(message, fileOps);
+  }
+  return fileOps;
+}
+
+export function shouldCompactPiContext(options: {
+  contextTokens: number;
+  contextWindow: number;
+  settings: PiCompactionSettings;
+}): boolean {
+  const { contextTokens, contextWindow, settings } = options;
+  if (!settings.enabled || !Number.isFinite(contextWindow) || contextWindow <= 0) {
+    return false;
+  }
+  return contextTokens > contextWindow - settings.reserveTokens;
+}
+
+export function preparePiCompaction(
+  pathEntries: PiSessionPathEntry[],
+  settings: PiCompactionSettings,
+): PiCompactionPreparation | undefined {
+  if (pathEntries.length === 0 || pathEntries[pathEntries.length - 1]?.type === 'compaction') {
+    return undefined;
+  }
+
+  let prevCompactionIndex = -1;
+  for (let i = pathEntries.length - 1; i >= 0; i -= 1) {
+    if (pathEntries[i]?.type === 'compaction') {
+      prevCompactionIndex = i;
+      break;
+    }
+  }
+
+  const boundaryStart = prevCompactionIndex + 1;
+  const boundaryEnd = pathEntries.length;
+  const usageMessages: AgentMessage[] = [];
+  for (let i = prevCompactionIndex >= 0 ? prevCompactionIndex : 0; i < boundaryEnd; i += 1) {
+    const message = getMessageFromEntry(pathEntries[i]!);
+    if (message) {
+      usageMessages.push(message);
+    }
+  }
+  const tokensBefore = estimatePiContextTokens(usageMessages);
+  const cutPoint = findCutPoint(pathEntries, boundaryStart, boundaryEnd, settings.keepRecentTokens);
+  const firstKeptEntry = pathEntries[cutPoint.firstKeptEntryIndex];
+  if (!firstKeptEntry?.id) {
+    return undefined;
+  }
+
+  const historyEnd = cutPoint.isSplitTurn ? cutPoint.turnStartIndex : cutPoint.firstKeptEntryIndex;
+  const messagesToSummarize: AgentMessage[] = [];
+  for (let i = boundaryStart; i < historyEnd; i += 1) {
+    const message = getMessageFromEntry(pathEntries[i]!);
+    if (message) {
+      messagesToSummarize.push(message);
+    }
+  }
+
+  const turnPrefixMessages: AgentMessage[] = [];
+  if (cutPoint.isSplitTurn) {
+    for (let i = cutPoint.turnStartIndex; i < cutPoint.firstKeptEntryIndex; i += 1) {
+      const message = getMessageFromEntry(pathEntries[i]!);
+      if (message) {
+        turnPrefixMessages.push(message);
+      }
+    }
+  }
+
+  const previousSummary =
+    prevCompactionIndex >= 0 && pathEntries[prevCompactionIndex]?.type === 'compaction'
+      ? (pathEntries[prevCompactionIndex] as PiCompactionEntryLike).summary
+      : undefined;
+  const fileOps = extractFileOperations(messagesToSummarize, pathEntries, prevCompactionIndex);
+  for (const message of turnPrefixMessages) {
+    extractFileOpsFromMessage(message, fileOps);
+  }
+
+  return {
+    firstKeptEntryId: firstKeptEntry.id,
+    messagesToSummarize,
+    turnPrefixMessages,
+    isSplitTurn: cutPoint.isSplitTurn,
+    tokensBefore,
+    ...(previousSummary ? { previousSummary } : {}),
+    fileOps,
+    settings,
+  };
+}
+
+function serializeConversation(messages: AgentMessage[]): string {
+  const parts: string[] = [];
+  for (const message of messages) {
+    if (message.role === 'user') {
+      const content = extractTextBlocks((message as { content?: unknown }).content);
+      if (content) {
+        parts.push(`[User]: ${content}`);
+      }
+    } else if (message.role === 'assistant') {
+      const textParts: string[] = [];
+      const thinkingParts: string[] = [];
+      const toolCalls: string[] = [];
+      for (const block of (message as { content?: unknown[] }).content ?? []) {
+        if (!isRecord(block)) {
+          continue;
+        }
+        if (block['type'] === 'text' && typeof block['text'] === 'string') {
+          textParts.push(block['text']);
+        } else if (block['type'] === 'thinking' && typeof block['thinking'] === 'string') {
+          thinkingParts.push(block['thinking']);
+        } else if (block['type'] === 'toolCall') {
+          const args = isRecord(block['arguments']) ? block['arguments'] : {};
+          const argsText = Object.entries(args)
+            .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
+            .join(', ');
+          toolCalls.push(`${String(block['name'] ?? 'tool')}(${argsText})`);
+        }
+      }
+      if (thinkingParts.length > 0) {
+        parts.push(`[Assistant thinking]: ${thinkingParts.join('\n')}`);
+      }
+      if (textParts.length > 0) {
+        parts.push(`[Assistant]: ${textParts.join('\n')}`);
+      }
+      if (toolCalls.length > 0) {
+        parts.push(`[Assistant tool calls]: ${toolCalls.join('; ')}`);
+      }
+    } else if (message.role === 'toolResult') {
+      const content = extractTextBlocks((message as { content?: unknown }).content);
+      if (content) {
+        parts.push(`[Tool result]: ${truncateForSummary(content, TOOL_RESULT_MAX_CHARS)}`);
+      }
+    } else if ((message as { role?: string }).role === 'custom') {
+      const content = extractTextBlocks((message as { content?: unknown }).content);
+      if (content) {
+        parts.push(`[User]: ${content}`);
+      }
+    } else if ((message as { role?: string }).role === 'compactionSummary') {
+      const summary = String((message as { summary?: unknown }).summary ?? '').trim();
+      if (summary) {
+        parts.push(`[Compaction summary]: ${summary}`);
+      }
+    }
+  }
+  return parts.join('\n\n');
+}
+
+async function generateSummary(options: {
+  messages: AgentMessage[];
+  model: Model<Api>;
+  reserveTokens: number;
+  apiKey?: string;
+  signal?: AbortSignal;
+  customInstructions?: string;
+  previousSummary?: string;
+  prompt?: string;
+}): Promise<string> {
+  const {
+    messages,
+    model,
+    reserveTokens,
+    apiKey,
+    signal,
+    customInstructions,
+    previousSummary,
+    prompt,
+  } = options;
+  const maxTokens = Math.floor(0.8 * reserveTokens);
+  let basePrompt = prompt ?? (previousSummary ? UPDATE_SUMMARIZATION_PROMPT : SUMMARIZATION_PROMPT);
+  if (customInstructions) {
+    basePrompt = `${basePrompt}\n\nAdditional focus: ${customInstructions}`;
+  }
+  let promptText = `<conversation>\n${serializeConversation(messages)}\n</conversation>\n\n`;
+  if (previousSummary) {
+    promptText += `<previous-summary>\n${previousSummary}\n</previous-summary>\n\n`;
+  }
+  promptText += basePrompt;
+  const response = await completeSimple(
+    model,
+    {
+      systemPrompt: SUMMARIZATION_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: promptText }],
+          timestamp: Date.now(),
+        },
+      ],
+    },
+    {
+      maxTokens,
+      ...(signal ? { signal } : {}),
+      ...(apiKey ? { apiKey } : {}),
+      ...(model.reasoning ? { reasoning: 'high' as const } : {}),
+    },
+  );
+  if (response.stopReason === 'error') {
+    throw new Error(`Summarization failed: ${response.errorMessage || 'Unknown error'}`);
+  }
+  return response.content
+    .filter((content) => content.type === 'text')
+    .map((content) => content.text)
+    .join('\n');
+}
+
+export async function compactPiMessages(options: {
+  preparation: PiCompactionPreparation;
+  model: Model<Api>;
+  apiKey?: string;
+  customInstructions?: string;
+  signal?: AbortSignal;
+}): Promise<PiCompactionResult> {
+  const { preparation, model, apiKey, customInstructions, signal } = options;
+  let summary: string;
+  if (preparation.isSplitTurn && preparation.turnPrefixMessages.length > 0) {
+    const [historyResult, turnPrefixResult] = await Promise.all([
+      preparation.messagesToSummarize.length > 0
+        ? generateSummary({
+            messages: preparation.messagesToSummarize,
+            model,
+            reserveTokens: preparation.settings.reserveTokens,
+            ...(apiKey ? { apiKey } : {}),
+            ...(signal ? { signal } : {}),
+            ...(customInstructions ? { customInstructions } : {}),
+            ...(preparation.previousSummary
+              ? { previousSummary: preparation.previousSummary }
+              : {}),
+          })
+        : Promise.resolve('No prior history.'),
+      generateSummary({
+        messages: preparation.turnPrefixMessages,
+        model,
+        reserveTokens: Math.floor(preparation.settings.reserveTokens * 0.5),
+        ...(apiKey ? { apiKey } : {}),
+        ...(signal ? { signal } : {}),
+        prompt: TURN_PREFIX_SUMMARIZATION_PROMPT,
+      }),
+    ]);
+    summary = `${historyResult}\n\n---\n\n**Turn Context (split turn):**\n\n${turnPrefixResult}`;
+  } else {
+    summary = await generateSummary({
+      messages: preparation.messagesToSummarize,
+      model,
+      reserveTokens: preparation.settings.reserveTokens,
+      ...(apiKey ? { apiKey } : {}),
+      ...(signal ? { signal } : {}),
+      ...(customInstructions ? { customInstructions } : {}),
+      ...(preparation.previousSummary ? { previousSummary: preparation.previousSummary } : {}),
+    });
+  }
+
+  const details = computeFileLists(preparation.fileOps);
+  summary += formatFileOperations(details);
+  return {
+    summary,
+    firstKeptEntryId: preparation.firstKeptEntryId,
+    tokensBefore: preparation.tokensBefore,
+    details,
+  };
+}
+
+export function buildCompactionSummaryText(summary: string): string {
+  return `${COMPACTION_SUMMARY_PREFIX}${summary}${COMPACTION_SUMMARY_SUFFIX}`;
+}

--- a/packages/agent-server/src/history/piSessionReplay.test.ts
+++ b/packages/agent-server/src/history/piSessionReplay.test.ts
@@ -224,4 +224,95 @@ describe('buildCanonicalPiReplayMessages', () => {
       historyTimestampMs: 5,
     });
   });
+
+  it('rebuilds effective context from the latest compaction entry', () => {
+    const content = [
+      JSON.stringify({
+        type: 'session',
+        version: 3,
+        id: 'pi-session',
+        timestamp: '2026-03-26T00:00:00.000Z',
+        cwd: '/tmp/example',
+      }),
+      JSON.stringify({
+        type: 'message',
+        id: 'old-user',
+        parentId: null,
+        timestamp: '2026-03-26T00:00:01.000Z',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Discarded request' }],
+          timestamp: 1,
+        },
+      }),
+      JSON.stringify({
+        type: 'message',
+        id: 'kept-user',
+        parentId: 'old-user',
+        timestamp: '2026-03-26T00:00:02.000Z',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Kept request' }],
+          timestamp: 2,
+        },
+      }),
+      JSON.stringify({
+        type: 'message',
+        id: 'kept-assistant',
+        parentId: 'kept-user',
+        timestamp: '2026-03-26T00:00:03.000Z',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Kept answer' }],
+          api: 'openai-responses',
+          provider: 'openai-codex',
+          model: 'gpt-5.4',
+          usage: {
+            input: 1,
+            output: 1,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 2,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: 'stop',
+          timestamp: 3,
+        },
+      }),
+      JSON.stringify({
+        type: 'compaction',
+        id: 'compact-1',
+        parentId: 'kept-assistant',
+        timestamp: '2026-03-26T00:00:04.000Z',
+        summary: 'Older work summary.',
+        firstKeptEntryId: 'kept-user',
+        tokensBefore: 1000,
+        details: { readFiles: [], modifiedFiles: [] },
+        fromHook: false,
+      }),
+      JSON.stringify({
+        type: 'message',
+        id: 'post-user',
+        parentId: 'compact-1',
+        timestamp: '2026-03-26T00:00:05.000Z',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Post-compaction request' }],
+          timestamp: 5,
+        },
+      }),
+    ].join('\n');
+
+    const messages = buildCanonicalPiReplayMessages(content);
+
+    expect(messages.map((message) => message.role)).toEqual(['user', 'user', 'assistant', 'user']);
+    expect(messages[0]).toMatchObject({
+      role: 'user',
+      content:
+        'The conversation history before this point was compacted into the following summary:\n\n<summary>\nOlder work summary.\n</summary>',
+    });
+    expect(messages[1]).toMatchObject({ role: 'user', content: 'Kept request' });
+    expect(messages[2]).toMatchObject({ role: 'assistant', content: 'Kept answer' });
+    expect(messages[3]).toMatchObject({ role: 'user', content: 'Post-compaction request' });
+  });
 });

--- a/packages/agent-server/src/history/piSessionReplay.ts
+++ b/packages/agent-server/src/history/piSessionReplay.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import type { Message as PiSdkMessage } from '@mariozechner/pi-ai';
+import type { Message as PiSdkMessage } from '@earendil-works/pi-ai';
 
 import type { ChatCompletionMessage, ChatCompletionMessageMeta } from '../chatCompletionTypes';
 import type { SessionSummary } from '../sessionIndex';

--- a/packages/agent-server/src/history/piSessionReplay.ts
+++ b/packages/agent-server/src/history/piSessionReplay.ts
@@ -9,11 +9,17 @@ import type { ChatCompletionMessage, ChatCompletionMessageMeta } from '../chatCo
 import type { SessionSummary } from '../sessionIndex';
 import { extractAssistantTextBlocksFromPiMessage } from '../llm/piSdkProvider';
 import { getProviderAttributes } from './providerAttributes';
-import { buildCompactionSummaryText } from './piCompaction';
+import { buildCompactionSummaryText, buildEffectivePiSessionEntryPath } from './piCompaction';
 
 type PiSessionInfo = {
   sessionId: string;
   cwd: string;
+};
+
+type PiReplayEntryRecord = Record<string, unknown> & {
+  type: string;
+  id: string;
+  parentId: string | null;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -43,83 +49,56 @@ function parseJsonLines(content: string): Array<Record<string, unknown>> {
     });
 }
 
-function buildEntryPath(entries: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
-  const sessionEntries = entries.filter((entry) => getString(entry['type']) !== 'session');
-  const byId = new Map<string, Record<string, unknown>>();
-  for (const entry of sessionEntries) {
+function normalizeReplayEntries(entries: Array<Record<string, unknown>>): PiReplayEntryRecord[] {
+  return entries.flatMap((entry) => {
+    const type = getString(entry['type']);
+    if (!type || type === 'session') {
+      return [];
+    }
     const id = getString(entry['id']);
-    if (id) {
-      byId.set(id, entry);
+    if (!id) {
+      return [];
     }
+    const parentId = getString(entry['parentId']);
+    return [
+      {
+        ...entry,
+        type,
+        id,
+        parentId: parentId || null,
+      },
+    ];
+  });
+}
+
+function createCompactionSummaryReplayEntry(
+  compaction: PiReplayEntryRecord,
+): PiReplayEntryRecord | undefined {
+  const summary = getString(compaction['summary']);
+  if (!summary) {
+    return undefined;
   }
-  const leaf = sessionEntries[sessionEntries.length - 1];
-  if (!leaf) {
-    return [];
-  }
-  const pathEntries: Array<Record<string, unknown>> = [];
-  const seen = new Set<string>();
-  let current: Record<string, unknown> | undefined = leaf;
-  while (current) {
-    const id = getString(current['id']);
-    if (!id || seen.has(id)) {
-      break;
-    }
-    seen.add(id);
-    pathEntries.unshift(current);
-    const parentId: unknown = current['parentId'];
-    current = typeof parentId === 'string' ? byId.get(parentId) : undefined;
-  }
-  return pathEntries;
+  return {
+    type: 'message',
+    id: `${compaction.id || 'compaction'}:summary`,
+    parentId: null,
+    timestamp: compaction['timestamp'],
+    message: {
+      role: 'user',
+      content: [{ type: 'text', text: buildCompactionSummaryText(summary) }],
+      timestamp: resolveTimestamp(compaction) ?? Date.now(),
+      meta: { source: 'user' },
+    },
+  };
 }
 
 function buildEffectivePiReplayEntries(
   entries: Array<Record<string, unknown>>,
-): Array<Record<string, unknown>> {
-  const pathEntries = buildEntryPath(entries);
-  let compactionIndex = -1;
-  for (let i = pathEntries.length - 1; i >= 0; i -= 1) {
-    if (getString(pathEntries[i]?.['type']) === 'compaction') {
-      compactionIndex = i;
-      break;
-    }
-  }
-  if (compactionIndex === -1) {
-    return pathEntries;
-  }
-
-  const compaction = pathEntries[compactionIndex]!;
-  const firstKeptEntryId = getString(compaction['firstKeptEntryId']);
-  const effective: Array<Record<string, unknown>> = [];
-  const summary = getString(compaction['summary']);
-  if (summary) {
-    effective.push({
-      type: 'message',
-      id: `${getString(compaction['id']) || 'compaction'}:summary`,
-      parentId: null,
-      timestamp: compaction['timestamp'],
-      message: {
-        role: 'user',
-        content: [{ type: 'text', text: buildCompactionSummaryText(summary) }],
-        timestamp: resolveTimestamp(compaction) ?? Date.now(),
-        meta: { source: 'user' },
-      },
-    });
-  }
-
-  let foundFirstKept = false;
-  for (let i = 0; i < compactionIndex; i += 1) {
-    const entry = pathEntries[i]!;
-    if (getString(entry['id']) === firstKeptEntryId) {
-      foundFirstKept = true;
-    }
-    if (foundFirstKept) {
-      effective.push(entry);
-    }
-  }
-  for (let i = compactionIndex + 1; i < pathEntries.length; i += 1) {
-    effective.push(pathEntries[i]!);
-  }
-  return effective;
+): PiReplayEntryRecord[] {
+  return buildEffectivePiSessionEntryPath(normalizeReplayEntries(entries), {
+    createCompactionSummaryEntry: createCompactionSummaryReplayEntry,
+    includeRawCompactionEntry: false,
+  });
 }
 
 function encodePiCwd(cwd: string): string | null {

--- a/packages/agent-server/src/history/piSessionReplay.ts
+++ b/packages/agent-server/src/history/piSessionReplay.ts
@@ -9,6 +9,7 @@ import type { ChatCompletionMessage, ChatCompletionMessageMeta } from '../chatCo
 import type { SessionSummary } from '../sessionIndex';
 import { extractAssistantTextBlocksFromPiMessage } from '../llm/piSdkProvider';
 import { getProviderAttributes } from './providerAttributes';
+import { buildCompactionSummaryText } from './piCompaction';
 
 type PiSessionInfo = {
   sessionId: string;
@@ -40,6 +41,85 @@ function parseJsonLines(content: string): Array<Record<string, unknown>> {
         return [];
       }
     });
+}
+
+function buildEntryPath(entries: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  const sessionEntries = entries.filter((entry) => getString(entry['type']) !== 'session');
+  const byId = new Map<string, Record<string, unknown>>();
+  for (const entry of sessionEntries) {
+    const id = getString(entry['id']);
+    if (id) {
+      byId.set(id, entry);
+    }
+  }
+  const leaf = sessionEntries[sessionEntries.length - 1];
+  if (!leaf) {
+    return [];
+  }
+  const pathEntries: Array<Record<string, unknown>> = [];
+  const seen = new Set<string>();
+  let current: Record<string, unknown> | undefined = leaf;
+  while (current) {
+    const id = getString(current['id']);
+    if (!id || seen.has(id)) {
+      break;
+    }
+    seen.add(id);
+    pathEntries.unshift(current);
+    const parentId: unknown = current['parentId'];
+    current = typeof parentId === 'string' ? byId.get(parentId) : undefined;
+  }
+  return pathEntries;
+}
+
+function buildEffectivePiReplayEntries(
+  entries: Array<Record<string, unknown>>,
+): Array<Record<string, unknown>> {
+  const pathEntries = buildEntryPath(entries);
+  let compactionIndex = -1;
+  for (let i = pathEntries.length - 1; i >= 0; i -= 1) {
+    if (getString(pathEntries[i]?.['type']) === 'compaction') {
+      compactionIndex = i;
+      break;
+    }
+  }
+  if (compactionIndex === -1) {
+    return pathEntries;
+  }
+
+  const compaction = pathEntries[compactionIndex]!;
+  const firstKeptEntryId = getString(compaction['firstKeptEntryId']);
+  const effective: Array<Record<string, unknown>> = [];
+  const summary = getString(compaction['summary']);
+  if (summary) {
+    effective.push({
+      type: 'message',
+      id: `${getString(compaction['id']) || 'compaction'}:summary`,
+      parentId: null,
+      timestamp: compaction['timestamp'],
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: buildCompactionSummaryText(summary) }],
+        timestamp: resolveTimestamp(compaction) ?? Date.now(),
+        meta: { source: 'user' },
+      },
+    });
+  }
+
+  let foundFirstKept = false;
+  for (let i = 0; i < compactionIndex; i += 1) {
+    const entry = pathEntries[i]!;
+    if (getString(entry['id']) === firstKeptEntryId) {
+      foundFirstKept = true;
+    }
+    if (foundFirstKept) {
+      effective.push(entry);
+    }
+  }
+  for (let i = compactionIndex + 1; i < pathEntries.length; i += 1) {
+    effective.push(pathEntries[i]!);
+  }
+  return effective;
 }
 
 function encodePiCwd(cwd: string): string | null {
@@ -77,13 +157,13 @@ function extractTextValue(value: unknown): string {
     return getString(value['refusal']);
   }
   if (type === 'thinking' || type === 'reasoning' || type === 'analysis') {
-    return getString(value['thinking']) || getString(value['text']) || extractTextValue(value['content']);
+    return (
+      getString(value['thinking']) || getString(value['text']) || extractTextValue(value['content'])
+    );
   }
   if ('text' in value || 'content' in value || 'thinking' in value) {
     return (
-      getString(value['text']) ||
-      getString(value['thinking']) ||
-      extractTextValue(value['content'])
+      getString(value['text']) || getString(value['thinking']) || extractTextValue(value['content'])
     );
   }
   return '';
@@ -165,7 +245,9 @@ async function findPiSessionFile(
   return path.join(sessionDir, matches[matches.length - 1]!);
 }
 
-function toUserMetaFromMessage(message: Record<string, unknown>): ChatCompletionMessageMeta | undefined {
+function toUserMetaFromMessage(
+  message: Record<string, unknown>,
+): ChatCompletionMessageMeta | undefined {
   const meta = isRecord(message['meta']) ? message['meta'] : null;
   if (!meta) {
     return undefined;
@@ -191,7 +273,7 @@ function toUserMetaFromMessage(message: Record<string, unknown>): ChatCompletion
 }
 
 export function buildCanonicalPiReplayMessages(content: string): ChatCompletionMessage[] {
-  const entries = parseJsonLines(content);
+  const entries = buildEffectivePiReplayEntries(parseJsonLines(content));
   const messages: ChatCompletionMessage[] = [];
 
   for (const entry of entries) {

--- a/packages/agent-server/src/history/piSessionSync.test.ts
+++ b/packages/agent-server/src/history/piSessionSync.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, expect, it } from 'vitest';
 
-import type { Message as PiSdkMessage } from '@mariozechner/pi-ai';
+import type { Message as PiSdkMessage } from '@earendil-works/pi-ai';
 
 import type { ChatCompletionMessage } from '../chatCompletionTypes';
 import {

--- a/packages/agent-server/src/history/piSessionSync.ts
+++ b/packages/agent-server/src/history/piSessionSync.ts
@@ -1,4 +1,4 @@
-import type { Message as PiSdkMessage } from '@mariozechner/pi-ai';
+import type { Message as PiSdkMessage } from '@earendil-works/pi-ai';
 
 import type { ChatCompletionMessage } from '../chatCompletionTypes';
 

--- a/packages/agent-server/src/history/piSessionWriter.test.ts
+++ b/packages/agent-server/src/history/piSessionWriter.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import type { AssistantMessage } from '@mariozechner/pi-ai';
+import type { AssistantMessage } from '@earendil-works/pi-ai';
 
 import type { ChatCompletionMessage } from '../chatCompletionTypes';
 import type { SessionSummary } from '../sessionIndex';

--- a/packages/agent-server/src/history/piSessionWriter.ts
+++ b/packages/agent-server/src/history/piSessionWriter.ts
@@ -11,6 +11,8 @@ import type {
   ToolCall,
   ToolResultMessage,
   Usage,
+  Api,
+  Model,
 } from '@mariozechner/pi-ai';
 
 import type { ChatCompletionMessage, ChatCompletionMessageMeta } from '../chatCompletionTypes';
@@ -22,6 +24,15 @@ import {
   getNextPiTranscriptRevision,
   getPiTranscriptRevision,
 } from './piTranscriptRevision';
+import {
+  compactPiMessages,
+  buildCompactionSummaryText,
+  type PiCompactionDetails,
+  type PiCompactionResult,
+  type PiCompactionSettings,
+  preparePiCompaction,
+  type PiSessionPathEntry,
+} from './piCompaction';
 
 type PiThinkingLevel = 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
 
@@ -83,13 +94,23 @@ type PiSessionCustomMessageEntry = PiSessionEntryBase & {
   label?: string;
 };
 
+type PiSessionCompactionEntry = PiSessionEntryBase & {
+  type: 'compaction';
+  summary: string;
+  firstKeptEntryId: string;
+  tokensBefore: number;
+  details?: PiCompactionDetails;
+  fromHook?: false;
+};
+
 type PiSessionEntry =
   | PiSessionMessageEntry
   | PiSessionModelChangeEntry
   | PiSessionThinkingChangeEntry
   | PiSessionInfoEntry
   | PiSessionCustomEntry
-  | PiSessionCustomMessageEntry;
+  | PiSessionCustomMessageEntry
+  | PiSessionCompactionEntry;
 
 type PiSessionWriterState = {
   sessionId: string;
@@ -357,7 +378,9 @@ function collectToolCallIdsFromPiMessage(message: PiSdkMessage): string[] {
   return ids;
 }
 
-function collectToolCallIdsFromAssistantMessage(message: ChatCompletionMessage & { role: 'assistant' }): string[] {
+function collectToolCallIdsFromAssistantMessage(
+  message: ChatCompletionMessage & { role: 'assistant' },
+): string[] {
   const piSdkMessage = message.piSdkMessage;
   if (piSdkMessage) {
     return collectToolCallIdsFromPiMessage(piSdkMessage);
@@ -423,7 +446,9 @@ function normalizePiContentBlockForSignature(block: unknown): unknown {
         ...(typeof block['thinkingSignature'] === 'string'
           ? { thinkingSignature: block['thinkingSignature'] }
           : {}),
-        ...(block['summary'] !== undefined ? { summary: stableNormalizeJson(block['summary']) } : {}),
+        ...(block['summary'] !== undefined
+          ? { summary: stableNormalizeJson(block['summary']) }
+          : {}),
       };
     default:
       return stableNormalizeJson(block);
@@ -602,8 +627,20 @@ function resolveMessageSyncAlignment(options: {
   const maxOverlap = Math.min(persistedSignatures.length, currentSignatures.length);
   for (let overlap = maxOverlap; overlap > 0; overlap -= 1) {
     const persistedStart = persistedSignatures.length - overlap;
-    for (let currentStart = currentSignatures.length - overlap; currentStart >= 0; currentStart -= 1) {
-      if (signaturesEqual(persistedSignatures, persistedStart, currentSignatures, currentStart, overlap)) {
+    for (
+      let currentStart = currentSignatures.length - overlap;
+      currentStart >= 0;
+      currentStart -= 1
+    ) {
+      if (
+        signaturesEqual(
+          persistedSignatures,
+          persistedStart,
+          currentSignatures,
+          currentStart,
+          overlap,
+        )
+      ) {
         return {
           startIndex: currentStart + overlap,
           matchedCount: overlap,
@@ -673,7 +710,8 @@ function normalizePiUserMeta(value: unknown): ChatCompletionMessageMeta | undefi
     return undefined;
   }
   const visibilityRaw = typeof value['visibility'] === 'string' ? value['visibility'].trim() : '';
-  const visibility = visibilityRaw === 'visible' || visibilityRaw === 'hidden' ? visibilityRaw : undefined;
+  const visibility =
+    visibilityRaw === 'visible' || visibilityRaw === 'hidden' ? visibilityRaw : undefined;
   return {
     source,
     ...(typeof value['fromAgentId'] === 'string' && value['fromAgentId'].trim().length > 0
@@ -776,9 +814,7 @@ function buildToolResultMessage(options: {
   };
 }
 
-async function loadExistingPiSessionState(
-  filePath: string,
-): Promise<{
+async function loadExistingPiSessionState(filePath: string): Promise<{
   leafId: string | null;
   messageCount: number;
   messageSignatures: string[];
@@ -999,16 +1035,156 @@ async function loadPiSessionFileRecords(filePath: string): Promise<PiSessionFile
   return { header, entries };
 }
 
-function getRequestBoundaryRecord(
-  entry: PiSessionEntryRecord,
-):
-  | {
-      kind: 'start' | 'end';
-      requestId: string;
-      status?: PiTurnStatus;
-      trigger?: PiTurnTrigger;
+function buildCurrentEntryPath(entries: PiSessionEntryRecord[]): PiSessionEntryRecord[] {
+  const byId = new Map<string, PiSessionEntryRecord>();
+  for (const entry of entries) {
+    byId.set(entry.id, entry);
+  }
+  const leaf = entries[entries.length - 1];
+  if (!leaf) {
+    return [];
+  }
+  const pathEntries: PiSessionEntryRecord[] = [];
+  const seen = new Set<string>();
+  let current: PiSessionEntryRecord | undefined = leaf;
+  while (current) {
+    if (seen.has(current.id)) {
+      break;
     }
-  | null {
+    seen.add(current.id);
+    pathEntries.unshift(current);
+    current = current.parentId ? byId.get(current.parentId) : undefined;
+  }
+  return pathEntries;
+}
+
+function toPiCompactionPathEntry(entry: PiSessionEntryRecord): PiSessionPathEntry | null {
+  if (entry.type === 'message' && isRecord(entry['message'])) {
+    return {
+      type: 'message',
+      id: entry.id,
+      parentId: entry.parentId,
+      timestamp: getString(entry['timestamp']),
+      message: entry['message'] as never,
+    };
+  }
+  if (entry.type === 'custom_message') {
+    return {
+      type: 'custom_message',
+      id: entry.id,
+      parentId: entry.parentId,
+      timestamp: getString(entry['timestamp']),
+      customType: getString(entry['customType']),
+      content:
+        typeof entry['content'] === 'string' || Array.isArray(entry['content'])
+          ? (entry['content'] as string | unknown[])
+          : '',
+      details: entry['details'],
+      display: entry['display'] === true,
+    };
+  }
+  if (entry.type === 'compaction') {
+    return {
+      type: 'compaction',
+      id: entry.id,
+      parentId: entry.parentId,
+      timestamp: getString(entry['timestamp']),
+      summary: getString(entry['summary']),
+      firstKeptEntryId: getString(entry['firstKeptEntryId']),
+      tokensBefore:
+        typeof entry['tokensBefore'] === 'number' && Number.isFinite(entry['tokensBefore'])
+          ? Math.max(0, Math.floor(entry['tokensBefore']))
+          : 0,
+      details: entry['details'],
+      ...(entry['fromHook'] === true ? { fromHook: true } : {}),
+    };
+  }
+  return {
+    ...entry,
+    timestamp: getString(entry['timestamp']),
+  } as PiSessionPathEntry;
+}
+
+function buildEffectiveMessageSignatureEntries(
+  entries: PiSessionEntryRecord[],
+): PiSessionEntryRecord[] {
+  const pathEntries = buildCurrentEntryPath(entries);
+  let compactionIndex = -1;
+  for (let i = pathEntries.length - 1; i >= 0; i -= 1) {
+    if (pathEntries[i]?.type === 'compaction') {
+      compactionIndex = i;
+      break;
+    }
+  }
+  if (compactionIndex === -1) {
+    return pathEntries;
+  }
+
+  const compaction = pathEntries[compactionIndex]!;
+  const firstKeptEntryId = getString(compaction['firstKeptEntryId']);
+  const effective: PiSessionEntryRecord[] = [compaction];
+  let foundFirstKept = false;
+  for (let i = 0; i < compactionIndex; i += 1) {
+    const entry = pathEntries[i]!;
+    if (entry.id === firstKeptEntryId) {
+      foundFirstKept = true;
+    }
+    if (foundFirstKept) {
+      effective.push(entry);
+    }
+  }
+  for (let i = compactionIndex + 1; i < pathEntries.length; i += 1) {
+    effective.push(pathEntries[i]!);
+  }
+  return effective;
+}
+
+function buildEffectiveMessageSignatures(entries: PiSessionEntryRecord[]): string[] {
+  return buildEffectiveMessageSignatureEntries(entries).flatMap((entry) => {
+    if (entry.type === 'compaction') {
+      const summary = getString(entry['summary']);
+      if (!summary) {
+        return [];
+      }
+      return [
+        signatureFromPiMessage({
+          role: 'user',
+          content: [{ type: 'text', text: buildCompactionSummaryText(summary) }],
+          timestamp:
+            typeof entry['timestamp'] === 'string' ? Date.parse(entry['timestamp']) || 0 : 0,
+          meta: { source: 'user' },
+        }),
+      ];
+    }
+    if (entry.type === 'message') {
+      return [signatureFromPiMessage(entry['message'])];
+    }
+    if (entry.type === 'custom_message') {
+      const customType = getString(entry['customType']);
+      if (customType === ORPHAN_TOOL_RESULT_CUSTOM_TYPE) {
+        return [
+          signatureFromCustomMessageEntry({
+            customType,
+            content:
+              typeof entry['content'] === 'string' || Array.isArray(entry['content'])
+                ? (entry['content'] as string | unknown[])
+                : '',
+            details: entry['details'],
+            display: entry['display'] === true,
+          }),
+        ];
+      }
+    }
+    return [];
+  });
+}
+
+function getRequestBoundaryRecord(entry: PiSessionEntryRecord): {
+  kind: 'start' | 'end';
+  requestId: string;
+  status?: PiTurnStatus;
+  trigger?: PiTurnTrigger;
+} | null {
   if (entry.type !== 'custom') {
     return null;
   }
@@ -1021,20 +1197,16 @@ function getRequestBoundaryRecord(
   }
   const data = isRecord(entry['data']) ? entry['data'] : null;
   const requestId =
-    data &&
-    typeof data['requestId'] === 'string' &&
-    data['requestId'].trim().length > 0
+    data && typeof data['requestId'] === 'string' && data['requestId'].trim().length > 0
       ? data['requestId'].trim()
       : '';
   if (!requestId) {
     return null;
   }
   const triggerRaw = data?.['trigger'];
-  const trigger =
-    triggerRaw === 'user' || triggerRaw === 'callback' ? triggerRaw : undefined;
+  const trigger = triggerRaw === 'user' || triggerRaw === 'callback' ? triggerRaw : undefined;
   const statusRaw = data?.['status'];
-  const status =
-    statusRaw === 'completed' || statusRaw === 'interrupted' ? statusRaw : undefined;
+  const status = statusRaw === 'completed' || statusRaw === 'interrupted' ? statusRaw : undefined;
   return {
     kind: customType === ASSISTANT_REQUEST_START_CUSTOM_TYPE ? 'start' : 'end',
     requestId,
@@ -1148,7 +1320,8 @@ function getSyntheticRequestTrigger(entry: PiSessionEntryRecord): PiTurnTrigger 
 }
 
 function resolveEntryTimestamp(entry: PiSessionEntryRecord | undefined, fallback: string): string {
-  const timestamp = entry && typeof entry['timestamp'] === 'string' ? entry['timestamp'].trim() : '';
+  const timestamp =
+    entry && typeof entry['timestamp'] === 'string' ? entry['timestamp'].trim() : '';
   return timestamp || fallback;
 }
 
@@ -1164,7 +1337,9 @@ function materializeExplicitRequestBoundaries(options: {
 
   const materialized: PiSessionEntryRecord[] = [];
   for (const span of spans) {
-    const spanEntries = entries.slice(span.startIndex, span.endIndex + 1).map((entry) => cloneJson(entry));
+    const spanEntries = entries
+      .slice(span.startIndex, span.endIndex + 1)
+      .map((entry) => cloneJson(entry));
     if (spanEntries.length === 0) {
       continue;
     }
@@ -1323,9 +1498,7 @@ export class PiSessionWriter {
 
   async clearSession(options: {
     summary: SessionSummary;
-    updateAttributes?: (
-      patch: SessionAttributesPatch,
-    ) => Promise<SessionSummary | undefined>;
+    updateAttributes?: (patch: SessionAttributesPatch) => Promise<SessionSummary | undefined>;
   }): Promise<SessionSummary | undefined> {
     const { summary, updateAttributes } = options;
     const providerInfo = getProviderAttributes(summary.attributes, 'pi', ['pi-cli']);
@@ -1385,9 +1558,7 @@ export class PiSessionWriter {
     summary: SessionSummary;
     action: PiRequestHistoryAction;
     requestId: string;
-    updateAttributes?: (
-      patch: SessionAttributesPatch,
-    ) => Promise<SessionSummary | undefined>;
+    updateAttributes?: (patch: SessionAttributesPatch) => Promise<SessionSummary | undefined>;
   }): Promise<{ summary: SessionSummary; changed: boolean; droppedRequestIds: string[] }> {
     const { summary, action, requestId, updateAttributes } = options;
     const trimmedRequestId = requestId.trim();
@@ -1420,32 +1591,30 @@ export class PiSessionWriter {
 
     const filteredEntriesRaw =
       action === 'trim_after'
-        ? records.entries
-            .slice(0, droppedRanges[0]!.startIndex)
-            .map((entry) => cloneJson(entry))
+        ? records.entries.slice(0, droppedRanges[0]!.startIndex).map((entry) => cloneJson(entry))
         : filterEntriesByDroppedRanges(records.entries, droppedRanges);
-    const filteredEntries =
-      hadExplicitRequestSpans
-        ? filterConversationalEntriesOutsideRanges(
-            filteredEntriesRaw,
-            collectExplicitRequestSpans(filteredEntriesRaw),
-          )
-        : filteredEntriesRaw;
-    const keptEntries =
-      hadExplicitRequestSpans
-        ? rechainEntries(filteredEntries)
-        : rechainEntries(
-            materializeExplicitRequestBoundaries({
-              entries: filteredEntries,
-              spans: collectSyntheticRequestSpans(filteredEntries),
-              fallbackTimestamp: this.now().toISOString(),
-            }),
-          );
+    const filteredEntries = hadExplicitRequestSpans
+      ? filterConversationalEntriesOutsideRanges(
+          filteredEntriesRaw,
+          collectExplicitRequestSpans(filteredEntriesRaw),
+        )
+      : filteredEntriesRaw;
+    const keptEntries = hadExplicitRequestSpans
+      ? rechainEntries(filteredEntries)
+      : rechainEntries(
+          materializeExplicitRequestBoundaries({
+            entries: filteredEntries,
+            spans: collectSyntheticRequestSpans(filteredEntries),
+            fallbackTimestamp: this.now().toISOString(),
+          }),
+        );
     const tempFilePath = `${state.sessionFile}.tmp-${randomUUID()}`;
 
     await this.queueWrite(state, async () => {
       await fs.mkdir(state.sessionDir, { recursive: true });
-      const payload = [records.header, ...keptEntries].map((entry) => JSON.stringify(entry)).join('\n');
+      const payload = [records.header, ...keptEntries]
+        .map((entry) => JSON.stringify(entry))
+        .join('\n');
       await fs.writeFile(tempFilePath, `${payload}\n`, 'utf8');
       await fs.rename(tempFilePath, state.sessionFile);
     });
@@ -1469,15 +1638,99 @@ export class PiSessionWriter {
     return { summary: currentSummary, changed: true, droppedRequestIds };
   }
 
+  async compact(options: {
+    summary: SessionSummary;
+    settings: PiCompactionSettings;
+    model: Model<Api>;
+    apiKey?: string;
+    customInstructions?: string;
+    updateAttributes?: (patch: SessionAttributesPatch) => Promise<SessionSummary | undefined>;
+  }): Promise<{ summary: SessionSummary; result: PiCompactionResult }> {
+    const { summary, settings, model, apiKey, customInstructions, updateAttributes } = options;
+    const stateInfo = await this.ensureSessionState({
+      summary,
+      ...(updateAttributes ? { updateAttributes } : {}),
+    });
+    const state = stateInfo.state;
+    const records = await loadPiSessionFileRecords(state.sessionFile);
+    if (!records) {
+      throw new Error('Pi session history is unavailable');
+    }
+    const pathEntries = buildCurrentEntryPath(records.entries)
+      .map((entry) => toPiCompactionPathEntry(entry))
+      .filter((entry): entry is PiSessionPathEntry => !!entry);
+    const preparation = preparePiCompaction(pathEntries, settings);
+    if (!preparation) {
+      throw new Error('Already compacted');
+    }
+    if (
+      preparation.messagesToSummarize.length === 0 &&
+      preparation.turnPrefixMessages.length === 0
+    ) {
+      throw new Error('Nothing to compact (session too small)');
+    }
+    const result = await compactPiMessages({
+      preparation,
+      model,
+      ...(apiKey ? { apiKey } : {}),
+      ...(customInstructions ? { customInstructions } : {}),
+    });
+    if (!result.summary.trim()) {
+      throw new Error('Nothing to compact (session too small)');
+    }
+
+    const entry: PiSessionCompactionEntry = {
+      type: 'compaction',
+      id: generateEntryId(),
+      parentId: state.leafId,
+      timestamp: this.now().toISOString(),
+      summary: result.summary,
+      firstKeptEntryId: result.firstKeptEntryId,
+      tokensBefore: result.tokensBefore,
+      ...(result.details ? { details: result.details } : {}),
+      fromHook: false,
+    };
+
+    await this.queueWrite(state, async () => {
+      if (!state.flushed) {
+        await this.ensureSessionFile(state);
+      }
+      await this.appendEntries(state, [entry]);
+    });
+
+    state.leafId = entry.id;
+    const updatedRecords = await loadPiSessionFileRecords(state.sessionFile);
+    if (updatedRecords) {
+      state.messageSignatures = buildEffectiveMessageSignatures(updatedRecords.entries);
+      state.writtenMessageCount = state.messageSignatures.length;
+    }
+
+    let currentSummary = stateInfo.summary;
+    if (updateAttributes) {
+      try {
+        const updated = await updateAttributes(
+          buildPiTranscriptRevisionPatch({
+            revision: getNextPiTranscriptRevision(currentSummary.attributes),
+          }),
+        );
+        if (updated) {
+          currentSummary = updated;
+        }
+      } catch (err) {
+        this.log('Failed to update Pi transcript revision after compaction', err);
+      }
+    }
+
+    return { summary: currentSummary, result };
+  }
+
   async sync(options: {
     summary: SessionSummary;
     messages: ChatCompletionMessage[];
     modelSpec?: string;
     defaultProvider?: string;
     thinkingLevel?: string;
-    updateAttributes?: (
-      patch: SessionAttributesPatch,
-    ) => Promise<SessionSummary | undefined>;
+    updateAttributes?: (patch: SessionAttributesPatch) => Promise<SessionSummary | undefined>;
   }): Promise<SessionSummary | undefined> {
     const { summary, messages, modelSpec, defaultProvider, thinkingLevel, updateAttributes } =
       options;
@@ -1500,7 +1753,11 @@ export class PiSessionWriter {
       currentSignatures,
     });
 
-    if (alignment.mode === 'none' && state.messageSignatures.length > 0 && currentSignatures.length > 0) {
+    if (
+      alignment.mode === 'none' &&
+      state.messageSignatures.length > 0 &&
+      currentSignatures.length > 0
+    ) {
       this.log('Pi session sync skipped due to unreconcilable message alignment', {
         sessionId: summary.sessionId,
         piSessionId: state.piSessionId,
@@ -1540,7 +1797,12 @@ export class PiSessionWriter {
 
     const entries: PiSessionEntry[] = [];
 
-    if (modelInfo && (!state.lastModel || state.lastModel.modelId !== modelInfo.modelId || state.lastModel.provider !== modelInfo.provider)) {
+    if (
+      modelInfo &&
+      (!state.lastModel ||
+        state.lastModel.modelId !== modelInfo.modelId ||
+        state.lastModel.provider !== modelInfo.provider)
+    ) {
       const modelEntry: PiSessionModelChangeEntry = {
         type: 'model_change',
         id: generateEntryId(),
@@ -1569,7 +1831,8 @@ export class PiSessionWriter {
 
     for (const message of newMessages) {
       const messageTimestampValue =
-        typeof message.historyTimestampMs === 'number' && Number.isFinite(message.historyTimestampMs)
+        typeof message.historyTimestampMs === 'number' &&
+        Number.isFinite(message.historyTimestampMs)
           ? message.historyTimestampMs
           : this.now().getTime();
       if (message.role === 'user') {
@@ -1680,9 +1943,7 @@ export class PiSessionWriter {
     payload: unknown;
     turnId?: string;
     responseId?: string;
-    updateAttributes?: (
-      patch: SessionAttributesPatch,
-    ) => Promise<SessionSummary | undefined>;
+    updateAttributes?: (patch: SessionAttributesPatch) => Promise<SessionSummary | undefined>;
   }): Promise<SessionSummary | undefined> {
     const { summary, eventType, payload, turnId, responseId, updateAttributes } = options;
 
@@ -1727,9 +1988,7 @@ export class PiSessionWriter {
     summary: SessionSummary;
     turnId: string;
     trigger: PiTurnTrigger;
-    updateAttributes?: (
-      patch: SessionAttributesPatch,
-    ) => Promise<SessionSummary | undefined>;
+    updateAttributes?: (patch: SessionAttributesPatch) => Promise<SessionSummary | undefined>;
   }): Promise<SessionSummary | undefined> {
     const { summary, turnId, trigger, updateAttributes } = options;
     const trimmedTurnId = turnId.trim();
@@ -1744,7 +2003,8 @@ export class PiSessionWriter {
     });
     currentSummary = stateInfo.summary;
     const state = stateInfo.state;
-    const openRequestId = state.openRequestId ?? (await resolveOpenRequestIdFromFile(state.sessionFile));
+    const openRequestId =
+      state.openRequestId ?? (await resolveOpenRequestIdFromFile(state.sessionFile));
 
     const entries: PiSessionEntry[] = [];
     let nextParentId = state.leafId;
@@ -1794,9 +2054,7 @@ export class PiSessionWriter {
     summary: SessionSummary;
     turnId: string;
     status: PiTurnStatus;
-    updateAttributes?: (
-      patch: SessionAttributesPatch,
-    ) => Promise<SessionSummary | undefined>;
+    updateAttributes?: (patch: SessionAttributesPatch) => Promise<SessionSummary | undefined>;
   }): Promise<SessionSummary | undefined> {
     const { summary, turnId, status, updateAttributes } = options;
     const trimmedTurnId = turnId.trim();
@@ -1812,7 +2070,8 @@ export class PiSessionWriter {
     currentSummary = stateInfo.summary;
     const state = stateInfo.state;
 
-    const targetRequestId = state.openRequestId ?? (await resolveOpenRequestIdFromFile(state.sessionFile));
+    const targetRequestId =
+      state.openRequestId ?? (await resolveOpenRequestIdFromFile(state.sessionFile));
     if (!targetRequestId) {
       return currentSummary === summary ? undefined : currentSummary;
     }
@@ -1840,9 +2099,7 @@ export class PiSessionWriter {
   async appendSessionInfo(options: {
     summary: SessionSummary;
     name: string;
-    updateAttributes?: (
-      patch: SessionAttributesPatch,
-    ) => Promise<SessionSummary | undefined>;
+    updateAttributes?: (patch: SessionAttributesPatch) => Promise<SessionSummary | undefined>;
   }): Promise<SessionSummary | undefined> {
     const { summary, name, updateAttributes } = options;
 
@@ -1903,12 +2160,17 @@ export class PiSessionWriter {
     details?: unknown;
     display?: boolean;
     label?: string;
-    updateAttributes?: (
-      patch: SessionAttributesPatch,
-    ) => Promise<SessionSummary | undefined>;
+    updateAttributes?: (patch: SessionAttributesPatch) => Promise<SessionSummary | undefined>;
   }): Promise<SessionSummary | undefined> {
-    const { summary, customType, content, details, display = true, label, updateAttributes } =
-      options;
+    const {
+      summary,
+      customType,
+      content,
+      details,
+      display = true,
+      label,
+      updateAttributes,
+    } = options;
 
     const trimmedCustomType = customType.trim();
     if (!trimmedCustomType) {
@@ -1950,9 +2212,7 @@ export class PiSessionWriter {
 
   private async ensureSessionState(options: {
     summary: SessionSummary;
-    updateAttributes?: (
-      patch: SessionAttributesPatch,
-    ) => Promise<SessionSummary | undefined>;
+    updateAttributes?: (patch: SessionAttributesPatch) => Promise<SessionSummary | undefined>;
   }): Promise<{ summary: SessionSummary; state: PiSessionWriterState }> {
     const { summary, updateAttributes } = options;
     const existing = this.sessions.get(summary.sessionId);
@@ -2020,6 +2280,11 @@ export class PiSessionWriter {
           leafId = existingState.leafId;
           messageCount = existingState.messageCount;
           messageSignatures = existingState.messageSignatures;
+          const records = await loadPiSessionFileRecords(sessionFile);
+          if (records) {
+            messageSignatures = buildEffectiveMessageSignatures(records.entries);
+            messageCount = messageSignatures.length;
+          }
           hasAssistant = existingState.hasAssistant;
           toolCallIds = existingState.toolCallIds;
           lastModel = existingState.lastModel;
@@ -2072,10 +2337,7 @@ export class PiSessionWriter {
     return { summary: currentSummary, state };
   }
 
-  private async queueWrite(
-    state: PiSessionWriterState,
-    task: () => Promise<void>,
-  ): Promise<void> {
+  private async queueWrite(state: PiSessionWriterState, task: () => Promise<void>): Promise<void> {
     state.writeQueue = state.writeQueue.then(task).catch((err) => {
       this.log('Pi session write failed', err);
     });
@@ -2092,7 +2354,10 @@ export class PiSessionWriter {
     state.flushed = true;
   }
 
-  private async appendEntries(state: PiSessionWriterState, entries: PiSessionEntry[]): Promise<void> {
+  private async appendEntries(
+    state: PiSessionWriterState,
+    entries: PiSessionEntry[],
+  ): Promise<void> {
     if (entries.length === 0) {
       return;
     }

--- a/packages/agent-server/src/history/piSessionWriter.ts
+++ b/packages/agent-server/src/history/piSessionWriter.ts
@@ -1644,9 +1644,11 @@ export class PiSessionWriter {
     model: Model<Api>;
     apiKey?: string;
     customInstructions?: string;
+    signal?: AbortSignal;
     updateAttributes?: (patch: SessionAttributesPatch) => Promise<SessionSummary | undefined>;
   }): Promise<{ summary: SessionSummary; result: PiCompactionResult }> {
-    const { summary, settings, model, apiKey, customInstructions, updateAttributes } = options;
+    const { summary, settings, model, apiKey, customInstructions, signal, updateAttributes } =
+      options;
     const stateInfo = await this.ensureSessionState({
       summary,
       ...(updateAttributes ? { updateAttributes } : {}),
@@ -1674,6 +1676,7 @@ export class PiSessionWriter {
       model,
       ...(apiKey ? { apiKey } : {}),
       ...(customInstructions ? { customInstructions } : {}),
+      ...(signal ? { signal } : {}),
     });
     if (!result.summary.trim()) {
       throw new Error('Nothing to compact (session too small)');

--- a/packages/agent-server/src/history/piSessionWriter.ts
+++ b/packages/agent-server/src/history/piSessionWriter.ts
@@ -13,7 +13,7 @@ import type {
   Usage,
   Api,
   Model,
-} from '@mariozechner/pi-ai';
+} from '@earendil-works/pi-ai';
 
 import type { ChatCompletionMessage, ChatCompletionMessageMeta } from '../chatCompletionTypes';
 import type { SessionSummary } from '../sessionIndex';

--- a/packages/agent-server/src/history/piSessionWriter.ts
+++ b/packages/agent-server/src/history/piSessionWriter.ts
@@ -100,7 +100,7 @@ type PiSessionCompactionEntry = PiSessionEntryBase & {
   firstKeptEntryId: string;
   tokensBefore: number;
   details?: PiCompactionDetails;
-  fromHook?: false;
+  fromHook?: boolean;
 };
 
 type PiSessionEntry =

--- a/packages/agent-server/src/history/piSessionWriter.ts
+++ b/packages/agent-server/src/history/piSessionWriter.ts
@@ -27,6 +27,8 @@ import {
 import {
   compactPiMessages,
   buildCompactionSummaryText,
+  buildEffectivePiSessionEntryPath,
+  buildPiSessionEntryPath,
   type PiCompactionDetails,
   type PiCompactionResult,
   type PiCompactionSettings,
@@ -1035,29 +1037,6 @@ async function loadPiSessionFileRecords(filePath: string): Promise<PiSessionFile
   return { header, entries };
 }
 
-function buildCurrentEntryPath(entries: PiSessionEntryRecord[]): PiSessionEntryRecord[] {
-  const byId = new Map<string, PiSessionEntryRecord>();
-  for (const entry of entries) {
-    byId.set(entry.id, entry);
-  }
-  const leaf = entries[entries.length - 1];
-  if (!leaf) {
-    return [];
-  }
-  const pathEntries: PiSessionEntryRecord[] = [];
-  const seen = new Set<string>();
-  let current: PiSessionEntryRecord | undefined = leaf;
-  while (current) {
-    if (seen.has(current.id)) {
-      break;
-    }
-    seen.add(current.id);
-    pathEntries.unshift(current);
-    current = current.parentId ? byId.get(current.parentId) : undefined;
-  }
-  return pathEntries;
-}
-
 function toPiCompactionPathEntry(entry: PiSessionEntryRecord): PiSessionPathEntry | null {
   if (entry.type === 'message' && isRecord(entry['message'])) {
     return {
@@ -1108,35 +1087,7 @@ function toPiCompactionPathEntry(entry: PiSessionEntryRecord): PiSessionPathEntr
 function buildEffectiveMessageSignatureEntries(
   entries: PiSessionEntryRecord[],
 ): PiSessionEntryRecord[] {
-  const pathEntries = buildCurrentEntryPath(entries);
-  let compactionIndex = -1;
-  for (let i = pathEntries.length - 1; i >= 0; i -= 1) {
-    if (pathEntries[i]?.type === 'compaction') {
-      compactionIndex = i;
-      break;
-    }
-  }
-  if (compactionIndex === -1) {
-    return pathEntries;
-  }
-
-  const compaction = pathEntries[compactionIndex]!;
-  const firstKeptEntryId = getString(compaction['firstKeptEntryId']);
-  const effective: PiSessionEntryRecord[] = [compaction];
-  let foundFirstKept = false;
-  for (let i = 0; i < compactionIndex; i += 1) {
-    const entry = pathEntries[i]!;
-    if (entry.id === firstKeptEntryId) {
-      foundFirstKept = true;
-    }
-    if (foundFirstKept) {
-      effective.push(entry);
-    }
-  }
-  for (let i = compactionIndex + 1; i < pathEntries.length; i += 1) {
-    effective.push(pathEntries[i]!);
-  }
-  return effective;
+  return buildEffectivePiSessionEntryPath(entries);
 }
 
 function buildEffectiveMessageSignatures(entries: PiSessionEntryRecord[]): string[] {
@@ -1658,7 +1609,7 @@ export class PiSessionWriter {
     if (!records) {
       throw new Error('Pi session history is unavailable');
     }
-    const pathEntries = buildCurrentEntryPath(records.entries)
+    const pathEntries = buildPiSessionEntryPath(records.entries)
       .map((entry) => toPiCompactionPathEntry(entry))
       .filter((entry): entry is PiSessionPathEntry => !!entry);
     const preparation = preparePiCompaction(pathEntries, settings);

--- a/packages/agent-server/src/llm/piAgentAuth.ts
+++ b/packages/agent-server/src/llm/piAgentAuth.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import type { OAuthCredentials } from '@mariozechner/pi-ai';
+import type { OAuthCredentials } from '@earendil-works/pi-ai';
 
 type StoredOAuthCredential = { type: 'oauth' } & OAuthCredentials & Record<string, unknown>;
 type StoredApiKeyCredential = { type: 'api_key'; key: string };
@@ -10,12 +10,12 @@ type StoredCredential = StoredOAuthCredential | StoredApiKeyCredential;
 
 type AuthFileData = Record<string, StoredCredential>;
 
-type PiAiOAuthModule = typeof import('@mariozechner/pi-ai/oauth');
+type PiAiOAuthModule = typeof import('@earendil-works/pi-ai/oauth');
 let oauthModulePromise: Promise<PiAiOAuthModule> | null = null;
 
 async function loadOAuthModule(): Promise<PiAiOAuthModule> {
   if (!oauthModulePromise) {
-    oauthModulePromise = import('@mariozechner/pi-ai/oauth');
+    oauthModulePromise = import('@earendil-works/pi-ai/oauth');
   }
   return oauthModulePromise;
 }
@@ -136,7 +136,10 @@ export async function resolvePiAgentAuthApiKey(options: {
 
   try {
     const { getOAuthApiKey } = await loadOAuthModule();
-    const resolved = await getOAuthApiKey(providerLower as any, credsByProvider as any);
+    const resolved = await getOAuthApiKey(
+      providerLower as Parameters<typeof getOAuthApiKey>[0],
+      credsByProvider,
+    );
     if (!resolved) {
       return undefined;
     }

--- a/packages/agent-server/src/llm/piSdkProvider.test.ts
+++ b/packages/agent-server/src/llm/piSdkProvider.test.ts
@@ -4,18 +4,18 @@ import path from 'node:path';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('@mariozechner/pi-ai', () => ({
+vi.mock('@earendil-works/pi-ai', () => ({
   getModels: vi.fn(),
   getProviders: vi.fn(),
   streamSimple: vi.fn(),
 }));
 
-vi.mock('@mariozechner/pi-ai/oauth', () => ({
+vi.mock('@earendil-works/pi-ai/oauth', () => ({
   getOAuthApiKey: vi.fn(),
 }));
 
-import { getModels, getProviders, streamSimple } from '@mariozechner/pi-ai';
-import { getOAuthApiKey } from '@mariozechner/pi-ai/oauth';
+import { getModels, getProviders, streamSimple } from '@earendil-works/pi-ai';
+import { getOAuthApiKey } from '@earendil-works/pi-ai/oauth';
 
 import type { ChatCompletionMessage } from '../chatCompletionTypes';
 import {

--- a/packages/agent-server/src/llm/piSdkProvider.ts
+++ b/packages/agent-server/src/llm/piSdkProvider.ts
@@ -12,7 +12,7 @@ import type {
   ToolCall,
   ToolResultMessage,
   Usage,
-} from '@mariozechner/pi-ai';
+} from '@earendil-works/pi-ai';
 import type { AssistantTextPhase } from '@assistant/shared';
 
 import type { ChatCompletionMessage, ChatCompletionToolCallState } from '../chatCompletionTypes';
@@ -42,12 +42,12 @@ export interface PiAssistantTextBlock {
   textSignature?: string;
 }
 
-type PiAiModule = typeof import('@mariozechner/pi-ai');
+type PiAiModule = typeof import('@earendil-works/pi-ai');
 let piAiModulePromise: Promise<PiAiModule> | null = null;
 
 async function loadPiAiModule(): Promise<PiAiModule> {
   if (!piAiModulePromise) {
-    piAiModulePromise = import('@mariozechner/pi-ai');
+    piAiModulePromise = import('@earendil-works/pi-ai');
   }
   return piAiModulePromise;
 }
@@ -160,8 +160,29 @@ export async function resolvePiSdkModel(options: {
     throw new Error(`Pi chat provider "${providerRaw}" is not available`);
   }
 
-  const { getModels } = await loadPiAiModule();
-  const models = getModels(providerId as any);
+  const { getModels, getProviders } = await loadPiAiModule();
+  const knownProvider = getProviders().find(
+    (provider) => provider.toLowerCase() === providerId.toLowerCase(),
+  );
+  if (!knownProvider) {
+    if (typeof baseUrl === 'string' && baseUrl.trim().length > 0) {
+      const modelId = modelIdRaw.trim();
+      const syntheticModel = buildSyntheticPiSdkModel({
+        providerId,
+        modelId,
+        baseUrl: baseUrl.trim(),
+        ...(contextWindow !== undefined ? { contextWindow } : {}),
+      });
+      return {
+        model: syntheticModel,
+        providerId,
+        modelId: syntheticModel.id,
+      };
+    }
+    throw new Error(`No Pi models found for provider "${providerId}"`);
+  }
+
+  const models = getModels(knownProvider);
   if (!models || models.length === 0) {
     if (typeof baseUrl === 'string' && baseUrl.trim().length > 0) {
       const modelId = modelIdRaw.trim();

--- a/packages/agent-server/src/piAssistantText.ts
+++ b/packages/agent-server/src/piAssistantText.ts
@@ -1,4 +1,4 @@
-import type { Message as PiSdkMessage } from '@mariozechner/pi-ai';
+import type { Message as PiSdkMessage } from '@earendil-works/pi-ai';
 
 import { extractAssistantTextBlocksFromPiMessage } from './llm/piSdkProvider';
 

--- a/packages/agent-server/src/sessionHub.test.ts
+++ b/packages/agent-server/src/sessionHub.test.ts
@@ -176,10 +176,7 @@ describe('SessionHub clearSession', () => {
     const encoded = encodePiCwd('/home/kevin');
     const sessionDir = path.join(baseDir, encoded);
     await fs.mkdir(sessionDir, { recursive: true });
-    const sessionFile = path.join(
-      sessionDir,
-      `2026-02-04T00-00-00-000Z_pi-session-1.jsonl`,
-    );
+    const sessionFile = path.join(sessionDir, `2026-02-04T00-00-00-000Z_pi-session-1.jsonl`);
     await fs.writeFile(sessionFile, '{"type":"session"}\n', 'utf8');
 
     const sessionHub = new SessionHub({
@@ -219,10 +216,7 @@ describe('SessionHub clearSession', () => {
     const encoded = encodePiCwd('/home/kevin');
     const sessionDir = path.join(baseDir, encoded);
     await fs.mkdir(sessionDir, { recursive: true });
-    const sessionFile = path.join(
-      sessionDir,
-      '2026-02-04T00-00-00-000Z_pi-session-delete-1.jsonl',
-    );
+    const sessionFile = path.join(sessionDir, '2026-02-04T00-00-00-000Z_pi-session-delete-1.jsonl');
     await fs.writeFile(sessionFile, '{"type":"session"}\n', 'utf8');
 
     const sessionHub = new SessionHub({
@@ -278,8 +272,7 @@ describe('SessionHub clearSession', () => {
       piSessionWriter,
     });
 
-    let summary =
-      (await sessionIndex.getSession(session.sessionId)) ?? summaryWithDir;
+    let summary = (await sessionIndex.getSession(session.sessionId)) ?? summaryWithDir;
 
     await piSessionWriter.appendTurnStart({
       summary,
@@ -514,13 +507,139 @@ describe('SessionHub clearSession', () => {
     });
 
     expect(result.droppedRequestIds).toEqual(['turn-1']);
-    expect(await attachmentStore.getAttachment(session.sessionId, kept.attachmentId)).not.toBeNull();
+    expect(
+      await attachmentStore.getAttachment(session.sessionId, kept.attachmentId),
+    ).not.toBeNull();
     const metadataPath = path.join(attachmentDir, session.sessionId, 'metadata.json');
     const metadata = JSON.parse(await fs.readFile(metadataPath, 'utf8')) as {
       attachments: Array<{ requestId: string }>;
     };
     expect(metadata.attachments).toHaveLength(1);
     expect(metadata.attachments[0]?.requestId).toBe('turn-2');
+  });
+});
+
+describe('SessionHub compactSession guards', () => {
+  it('rejects missing sessions', async () => {
+    const sessionHub = new SessionHub({
+      sessionIndex: new SessionIndex(createTempFile('session-hub-compact-missing')),
+      agentRegistry: new AgentRegistry([]),
+      eventStore: createTestEventStore(),
+    });
+
+    await expect(
+      sessionHub.compactSession({ sessionId: 'missing-session', reason: 'manual' }),
+    ).rejects.toThrow('Session not found: missing-session');
+  });
+
+  it('rejects deleted sessions', async () => {
+    const sessionHub = new SessionHub({
+      sessionIndex: {
+        getSession: async () => ({
+          sessionId: 'deleted-session',
+          agentId: 'pi',
+          createdAt: '',
+          updatedAt: '',
+          deleted: true,
+        }),
+      } as unknown as SessionIndex,
+      agentRegistry: new AgentRegistry([]),
+      eventStore: createTestEventStore(),
+    });
+
+    await expect(
+      sessionHub.compactSession({ sessionId: 'deleted-session', reason: 'manual' }),
+    ).rejects.toThrow('Cannot compact deleted session: deleted-session');
+  });
+
+  it('rejects active sessions unless active runs are allowed', async () => {
+    const sessionIndex = new SessionIndex(createTempFile('session-hub-compact-active'));
+    const sessionHub = new SessionHub({
+      sessionIndex,
+      agentRegistry: new AgentRegistry([
+        {
+          agentId: 'pi',
+          displayName: 'Pi',
+          description: 'Pi',
+          chat: { provider: 'pi', models: ['openai-codex/gpt-5.4'] },
+        },
+      ]),
+      eventStore: createTestEventStore(),
+    });
+    await sessionIndex.createSession({ sessionId: 'active-session', agentId: 'pi' });
+    const state = await sessionHub.ensureSessionState('active-session');
+    state.activeChatRun = {
+      responseId: 'response-1',
+      abortController: new AbortController(),
+    } as never;
+
+    await expect(
+      sessionHub.compactSession({ sessionId: 'active-session', reason: 'manual' }),
+    ).rejects.toThrow('Cannot compact context while the session is running');
+  });
+
+  it('rejects non-Pi sessions', async () => {
+    const sessionIndex = new SessionIndex(createTempFile('session-hub-compact-non-pi'));
+    const sessionHub = new SessionHub({
+      sessionIndex,
+      agentRegistry: new AgentRegistry([
+        {
+          agentId: 'codex',
+          displayName: 'Codex',
+          description: 'Codex',
+          chat: { provider: 'codex-cli' },
+        },
+      ]),
+      eventStore: createTestEventStore(),
+    });
+    await sessionIndex.createSession({ sessionId: 'codex-session', agentId: 'codex' });
+
+    await expect(
+      sessionHub.compactSession({ sessionId: 'codex-session', reason: 'manual' }),
+    ).rejects.toThrow('Context compaction is only supported for Pi-backed sessions');
+  });
+
+  it('rejects Pi sessions when the writer is unavailable', async () => {
+    const sessionIndex = new SessionIndex(createTempFile('session-hub-compact-no-writer'));
+    const sessionHub = new SessionHub({
+      sessionIndex,
+      agentRegistry: new AgentRegistry([
+        {
+          agentId: 'pi',
+          displayName: 'Pi',
+          description: 'Pi',
+          chat: { provider: 'pi', models: ['openai-codex/gpt-5.4'] },
+        },
+      ]),
+      eventStore: createTestEventStore(),
+    });
+    await sessionIndex.createSession({ sessionId: 'pi-session', agentId: 'pi' });
+
+    await expect(
+      sessionHub.compactSession({ sessionId: 'pi-session', reason: 'manual' }),
+    ).rejects.toThrow('Pi session writer is unavailable');
+  });
+
+  it('rejects Pi sessions without a compactable model', async () => {
+    const sessionIndex = new SessionIndex(createTempFile('session-hub-compact-no-model'));
+    const sessionHub = new SessionHub({
+      sessionIndex,
+      agentRegistry: new AgentRegistry([
+        {
+          agentId: 'pi',
+          displayName: 'Pi',
+          description: 'Pi',
+          chat: { provider: 'pi' },
+        },
+      ]),
+      eventStore: createTestEventStore(),
+      piSessionWriter: {} as PiSessionWriter,
+    });
+    await sessionIndex.createSession({ sessionId: 'pi-no-model-session', agentId: 'pi' });
+
+    await expect(
+      sessionHub.compactSession({ sessionId: 'pi-no-model-session', reason: 'manual' }),
+    ).rejects.toThrow('Pi chat requires at least one model to compact context');
   });
 });
 
@@ -584,7 +703,11 @@ describe('SessionHub loadSessionMessages', () => {
       throw new Error('Expected session summary to exist');
     }
 
-    const state = await sessionHub.ensureSessionState(reloadedSummary.sessionId, reloadedSummary, true);
+    const state = await sessionHub.ensureSessionState(
+      reloadedSummary.sessionId,
+      reloadedSummary,
+      true,
+    );
     const messages = state.chatMessages;
 
     expect(messages).toEqual([

--- a/packages/agent-server/src/sessionHub.ts
+++ b/packages/agent-server/src/sessionHub.ts
@@ -38,7 +38,7 @@ import type { AttachmentStore } from './attachments/store';
 import { getSelectedSessionSkillIds } from './sessionConfig';
 import { SessionConnectionRegistry } from './sessionConnectionRegistry';
 import { InteractionRegistry } from './ws/interactionRegistry';
-import type { Agent as PiAgent } from '@mariozechner/pi-agent-core';
+import type { Agent as PiAgent } from '@earendil-works/pi-agent-core';
 import { resetLiveTranscriptSessionState } from './events/chatEventUtils';
 import { syncSessionNotificationTitles } from '../../plugins/core/notifications/server/service';
 import {

--- a/packages/agent-server/src/sessionHub.ts
+++ b/packages/agent-server/src/sessionHub.ts
@@ -702,13 +702,14 @@ export class SessionHub {
     sessionId: string;
     reason: 'manual' | 'threshold' | 'overflow';
     allowActiveRun?: boolean;
+    signal?: AbortSignal;
   }): Promise<{
     summary: SessionSummary;
     compacted: true;
     reason: 'manual' | 'threshold' | 'overflow';
     result: PiCompactionResult;
   }> {
-    const { sessionId, reason, allowActiveRun = false } = options;
+    const { sessionId, reason, allowActiveRun = false, signal } = options;
     const existing = await this.sessionIndex.getSession(sessionId);
     if (!existing) {
       throw new Error(`Session not found: ${sessionId}`);
@@ -743,6 +744,7 @@ export class SessionHub {
       !configProvider || configProvider.toLowerCase() === resolvedModel.providerId.toLowerCase();
     const authApiKey = await resolvePiSdkAuthApiKey({ providerId: resolvedModel.providerId });
     const apiKey = providerMatchesConfig ? (piConfig?.apiKey ?? authApiKey) : authApiKey;
+    const compactSignal = signal ?? state?.activeChatRun?.abortController.signal;
     const result = await this.piSessionWriter.compact({
       summary: existing,
       settings: this.resolvePiCompactionSettings(piConfig),
@@ -752,6 +754,7 @@ export class SessionHub {
         ...(providerMatchesConfig && piConfig?.headers ? { headers: piConfig.headers } : {}),
       },
       ...(apiKey ? { apiKey } : {}),
+      ...(compactSignal ? { signal: compactSignal } : {}),
       updateAttributes: (patch) => this.updateSessionAttributes(sessionId, patch),
     });
 

--- a/packages/agent-server/src/sessionHub.ts
+++ b/packages/agent-server/src/sessionHub.ts
@@ -761,34 +761,6 @@ export class SessionHub {
       const chatMessages = await this.resolveChatMessages(summary, true);
       currentState.summary = summary;
       currentState.chatMessages = chatMessages;
-      if (currentState.piAgentRuntime) {
-        currentState.piAgentRuntime.agent.state.messages = chatMessages
-          .filter((message) => message.role !== 'system')
-          .map((message) => {
-            if (message.role === 'user') {
-              return {
-                role: 'user',
-                content: message.content,
-                timestamp: message.historyTimestampMs ?? Date.now(),
-              };
-            }
-            if (message.role === 'assistant' && message.piSdkMessage) {
-              return message.piSdkMessage as never;
-            }
-            if (message.role === 'tool') {
-              return {
-                role: 'toolResult',
-                toolCallId: message.tool_call_id,
-                toolName: 'tool',
-                content: [{ type: 'text', text: message.content }],
-                isError: false,
-                timestamp: message.historyTimestampMs ?? Date.now(),
-              };
-            }
-            return null;
-          })
-          .filter((message): message is never => message !== null);
-      }
     }
 
     const usageSummary = await this.updateSessionContextUsage(sessionId, null);

--- a/packages/agent-server/src/sessionHub.ts
+++ b/packages/agent-server/src/sessionHub.ts
@@ -27,6 +27,11 @@ import type { ChatCompletionMessage } from './chatCompletionTypes';
 import type { TtsStreamingSession } from './tts/types';
 import type { SessionConnection } from './ws/sessionConnection';
 import type { PiSessionWriter, PiRequestHistoryAction } from './history/piSessionWriter';
+import {
+  DEFAULT_PI_COMPACTION_SETTINGS,
+  type PiCompactionSettings,
+  type PiCompactionResult,
+} from './history/piCompaction';
 import { buildChatMessagesFromEvents } from './sessionChatMessages';
 import { isSessionContextUsageEqual } from './contextUsage';
 import type { AttachmentStore } from './attachments/store';
@@ -41,6 +46,9 @@ import {
   type CliToolCallMatchOptions,
   type CliToolCallRecord,
 } from './ws/cliToolCallRendezvous';
+import { resolveSessionModelForRun } from './sessionModel';
+import { resolvePiSdkAuthApiKey, resolvePiSdkModel } from './llm/piSdkProvider';
+import type { PiSdkChatConfig } from './agents';
 
 export interface LogicalSessionState {
   summary: SessionSummary;
@@ -59,76 +67,76 @@ export interface LogicalSessionState {
     | undefined;
   activeChatRun?:
     | {
-      /**
-       * Identifier for the current outer assistant request group.
-       * This is the visible transcript boundary and can span multiple turns.
-       */
-      requestId?: string;
-      /**
-       * Identifier for the current turn. Used to group
-       * chat events (user message, assistant response,
-       * tools, callbacks) in the unified event log.
-       */
-      turnId?: string;
-      responseId: string;
-      abortController: AbortController;
-      ttsSession?: TtsStreamingSession;
-      /**
-       * Optional identifier used to group streaming messages and tool
-       * calls that belong to a single agent-to-agent exchange initiated
-       * via agents_message.
-       *
-       * When present, this value is propagated to server messages so
-       * clients can render the entire exchange inside a single tool
-       * block.
-       */
-      agentExchangeId?: string;
-      /**
-       * Approximate playback offset (in ms) where the client
-       * requested output cancellation for the current response.
-       */
-      audioTruncatedAtMs?: number;
-      /**
-       * Accumulated text from the streaming response so far. Used to
-       * save partial text when the response is interrupted.
-       */
-      accumulatedText: string;
-      /**
-       * True once any assistant output begins (thinking/text/tool).
-       * Used to distinguish "cancel before output" from real interruptions.
-       */
-      outputStarted?: boolean;
-      /**
-       * Timestamp of the first text delta. Used to ensure interrupted
-       * assistant messages are logged with correct ordering.
-       */
-      textStartedAt?: string;
-      /**
-       * Tool calls that have started during this chat run but have not
-       * yet completed. Used so that output cancellation can mark them
-       * as interrupted in the conversation log.
-       */
-      activeToolCalls?: Map<
-        string,
-        {
-          callId: string;
-          toolName: string;
-          argsJson: string;
-        }
-      >;
-      /**
-       * True when this chat run was cancelled via an explicit output
-       * cancel control message. This is used to distinguish user
-       * interrupts from other abort reasons (for example, session
-       * switching) so that only user cancels mark tool calls as
-       * interrupted.
-       */
-      outputCancelled?: boolean;
-      /**
-       * Prevents duplicate interrupt/error/turn_end persistence when
-       * multiple terminal paths race with each other.
-       */
-      terminalEventsFinalized?: boolean;
+        /**
+         * Identifier for the current outer assistant request group.
+         * This is the visible transcript boundary and can span multiple turns.
+         */
+        requestId?: string;
+        /**
+         * Identifier for the current turn. Used to group
+         * chat events (user message, assistant response,
+         * tools, callbacks) in the unified event log.
+         */
+        turnId?: string;
+        responseId: string;
+        abortController: AbortController;
+        ttsSession?: TtsStreamingSession;
+        /**
+         * Optional identifier used to group streaming messages and tool
+         * calls that belong to a single agent-to-agent exchange initiated
+         * via agents_message.
+         *
+         * When present, this value is propagated to server messages so
+         * clients can render the entire exchange inside a single tool
+         * block.
+         */
+        agentExchangeId?: string;
+        /**
+         * Approximate playback offset (in ms) where the client
+         * requested output cancellation for the current response.
+         */
+        audioTruncatedAtMs?: number;
+        /**
+         * Accumulated text from the streaming response so far. Used to
+         * save partial text when the response is interrupted.
+         */
+        accumulatedText: string;
+        /**
+         * True once any assistant output begins (thinking/text/tool).
+         * Used to distinguish "cancel before output" from real interruptions.
+         */
+        outputStarted?: boolean;
+        /**
+         * Timestamp of the first text delta. Used to ensure interrupted
+         * assistant messages are logged with correct ordering.
+         */
+        textStartedAt?: string;
+        /**
+         * Tool calls that have started during this chat run but have not
+         * yet completed. Used so that output cancellation can mark them
+         * as interrupted in the conversation log.
+         */
+        activeToolCalls?: Map<
+          string,
+          {
+            callId: string;
+            toolName: string;
+            argsJson: string;
+          }
+        >;
+        /**
+         * True when this chat run was cancelled via an explicit output
+         * cancel control message. This is used to distinguish user
+         * interrupts from other abort reasons (for example, session
+         * switching) so that only user cancels mark tool calls as
+         * interrupted.
+         */
+        outputCancelled?: boolean;
+        /**
+         * Prevents duplicate interrupt/error/turn_end persistence when
+         * multiple terminal paths race with each other.
+         */
+        terminalEventsFinalized?: boolean;
       }
     | undefined;
   deleted?: boolean;
@@ -680,6 +688,128 @@ export class SessionHub {
     return { summary, changed: true, droppedRequestIds: result.droppedRequestIds };
   }
 
+  private resolvePiCompactionSettings(config: PiSdkChatConfig | undefined): PiCompactionSettings {
+    const compaction = config?.compaction;
+    return {
+      enabled: compaction?.enabled ?? DEFAULT_PI_COMPACTION_SETTINGS.enabled,
+      reserveTokens: compaction?.reserveTokens ?? DEFAULT_PI_COMPACTION_SETTINGS.reserveTokens,
+      keepRecentTokens:
+        compaction?.keepRecentTokens ?? DEFAULT_PI_COMPACTION_SETTINGS.keepRecentTokens,
+    };
+  }
+
+  async compactSession(options: {
+    sessionId: string;
+    reason: 'manual' | 'threshold' | 'overflow';
+    allowActiveRun?: boolean;
+  }): Promise<{
+    summary: SessionSummary;
+    compacted: true;
+    reason: 'manual' | 'threshold' | 'overflow';
+    result: PiCompactionResult;
+  }> {
+    const { sessionId, reason, allowActiveRun = false } = options;
+    const existing = await this.sessionIndex.getSession(sessionId);
+    if (!existing) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+    if (existing.deleted) {
+      throw new Error(`Cannot compact deleted session: ${sessionId}`);
+    }
+    const state = this.sessions.get(sessionId);
+    if (state?.activeChatRun && !allowActiveRun) {
+      throw new Error('Cannot compact context while the session is running');
+    }
+    const agent = existing.agentId ? this.agentRegistry.getAgent(existing.agentId) : undefined;
+    if (agent?.chat?.provider !== 'pi') {
+      throw new Error('Context compaction is only supported for Pi-backed sessions');
+    }
+    if (!this.piSessionWriter) {
+      throw new Error('Pi session writer is unavailable');
+    }
+    const piConfig = agent.chat.config as PiSdkChatConfig | undefined;
+    const modelSpec = resolveSessionModelForRun({ agent, summary: existing });
+    if (!modelSpec) {
+      throw new Error('Pi chat requires at least one model to compact context');
+    }
+    const resolvedModel = await resolvePiSdkModel({
+      modelSpec,
+      ...(piConfig?.provider ? { defaultProvider: piConfig.provider } : {}),
+      ...(piConfig?.baseUrl ? { baseUrl: piConfig.baseUrl } : {}),
+      ...(piConfig?.contextWindow !== undefined ? { contextWindow: piConfig.contextWindow } : {}),
+    });
+    const configProvider = piConfig?.provider?.trim();
+    const providerMatchesConfig =
+      !configProvider || configProvider.toLowerCase() === resolvedModel.providerId.toLowerCase();
+    const authApiKey = await resolvePiSdkAuthApiKey({ providerId: resolvedModel.providerId });
+    const apiKey = providerMatchesConfig ? (piConfig?.apiKey ?? authApiKey) : authApiKey;
+    const result = await this.piSessionWriter.compact({
+      summary: existing,
+      settings: this.resolvePiCompactionSettings(piConfig),
+      model: {
+        ...resolvedModel.model,
+        ...(providerMatchesConfig && piConfig?.baseUrl ? { baseUrl: piConfig.baseUrl } : {}),
+        ...(providerMatchesConfig && piConfig?.headers ? { headers: piConfig.headers } : {}),
+      },
+      ...(apiKey ? { apiKey } : {}),
+      updateAttributes: (patch) => this.updateSessionAttributes(sessionId, patch),
+    });
+
+    let summary = (await this.sessionIndex.markSessionActivity(sessionId)) ?? result.summary;
+    const currentState = this.sessions.get(sessionId);
+    if (currentState) {
+      const chatMessages = await this.resolveChatMessages(summary, true);
+      currentState.summary = summary;
+      currentState.chatMessages = chatMessages;
+      if (currentState.piAgentRuntime) {
+        currentState.piAgentRuntime.agent.state.messages = chatMessages
+          .filter((message) => message.role !== 'system')
+          .map((message) => {
+            if (message.role === 'user') {
+              return {
+                role: 'user',
+                content: message.content,
+                timestamp: message.historyTimestampMs ?? Date.now(),
+              };
+            }
+            if (message.role === 'assistant' && message.piSdkMessage) {
+              return message.piSdkMessage as never;
+            }
+            if (message.role === 'tool') {
+              return {
+                role: 'toolResult',
+                toolCallId: message.tool_call_id,
+                toolName: 'tool',
+                content: [{ type: 'text', text: message.content }],
+                isError: false,
+                timestamp: message.historyTimestampMs ?? Date.now(),
+              };
+            }
+            return null;
+          })
+          .filter((message): message is never => message !== null);
+      }
+    }
+
+    const usageSummary = await this.updateSessionContextUsage(sessionId, null);
+    if (usageSummary) {
+      summary = usageSummary;
+      const currentStateAfterUsage = this.sessions.get(sessionId);
+      if (currentStateAfterUsage) {
+        currentStateAfterUsage.summary = usageSummary;
+      }
+    }
+    this.broadcastSessionUpdated(summary, { includeAttributes: true, contextUsage: null });
+    const changedMessage: ServerSessionHistoryChangedMessage = {
+      type: 'session_history_changed',
+      sessionId,
+      updatedAt: summary.updatedAt,
+      revision: summary.revision,
+    };
+    this.connections.broadcastToSession(sessionId, changedMessage);
+    return { summary, compacted: true, reason, result: result.result };
+  }
+
   async touchSession(sessionId: string): Promise<SessionSummary | undefined> {
     const summary = await this.sessionIndex.touchSession(sessionId);
     if (!summary) {
@@ -828,10 +958,7 @@ export class SessionHub {
     );
   }
 
-  async loadSessionEvents(
-    summary: SessionSummary,
-    forceReload?: boolean,
-  ): Promise<ChatEvent[]> {
+  async loadSessionEvents(summary: SessionSummary, forceReload?: boolean): Promise<ChatEvent[]> {
     const agentId = summary.agentId;
     const agent = agentId ? this.agentRegistry.getAgent(agentId) : undefined;
     const providerId = agent?.chat?.provider;

--- a/packages/agent-server/src/tools/codingToolHost.test.ts
+++ b/packages/agent-server/src/tools/codingToolHost.test.ts
@@ -11,7 +11,7 @@ import type {
   createLsTool as createLsToolType,
   createReadTool as createReadToolType,
   createWriteTool as createWriteToolType,
-} from '@mariozechner/pi-coding-agent';
+} from '@earendil-works/pi-coding-agent';
 
 import type { ToolContext } from './types';
 import { CodingToolHost } from './codingToolHost';
@@ -27,7 +27,7 @@ type CodingAgentModule = {
 };
 
 async function loadCodingAgentModule(): Promise<CodingAgentModule> {
-  return (await import('@mariozechner/pi-coding-agent')) as CodingAgentModule;
+  return (await import('@earendil-works/pi-coding-agent')) as CodingAgentModule;
 }
 
 function createTempDir(prefix: string): string {

--- a/packages/agent-server/src/tools/codingToolHost.ts
+++ b/packages/agent-server/src/tools/codingToolHost.ts
@@ -10,7 +10,7 @@ import type {
   createLsTool as createLsToolType,
   createReadTool as createReadToolType,
   createWriteTool as createWriteToolType,
-} from '@mariozechner/pi-coding-agent';
+} from '@earendil-works/pi-coding-agent';
 
 import type { AgentTool, Tool, ToolContext, ToolHost } from './types';
 import { ToolError } from './errors';
@@ -104,7 +104,7 @@ let codingAgentModulePromise: Promise<CodingAgentModule> | null = null;
 
 async function loadCodingAgentModule(): Promise<CodingAgentModule> {
   if (!codingAgentModulePromise) {
-    codingAgentModulePromise = import('@mariozechner/pi-coding-agent').then(
+    codingAgentModulePromise = import('@earendil-works/pi-coding-agent').then(
       (module) => module as CodingAgentModule,
     );
   }

--- a/packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts
+++ b/packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts
@@ -330,7 +330,6 @@ describe('handleTextInputWithChatCompletions (pi)', () => {
               : result.assistantMessage.content,
         };
         if (!sawTextDelta) {
-          let textSoFar = '';
           for (const [index, block] of assistantMessage.content.entries()) {
             if (
               block.type !== 'text' ||
@@ -340,7 +339,6 @@ describe('handleTextInputWithChatCompletions (pi)', () => {
             ) {
               continue;
             }
-            textSoFar += block.text;
             await emit({
               type: 'message_update',
               message: assistantMessage,
@@ -744,6 +742,7 @@ describe('handleTextInputWithChatCompletions (pi)', () => {
       messageQueue: [],
     } as unknown as LogicalSessionState;
     const compactSession = vi.fn(async () => {
+      expect(JSON.stringify(state.chatMessages)).not.toContain('context_length_exceeded');
       state.chatMessages = [
         {
           role: 'user',
@@ -968,7 +967,7 @@ describe('handleTextInputWithChatCompletions (pi)', () => {
         provider: 'openai-codex',
         model: 'gpt-5.4',
         api: 'openai-responses',
-      }) as any,
+      }) as never,
     }));
 
     const recordSessionActivity = vi.fn(async () => ({

--- a/packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts
+++ b/packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts
@@ -815,6 +815,7 @@ describe('handleTextInputWithChatCompletions (pi)', () => {
       sessionId: 's1',
       reason: 'overflow',
       allowActiveRun: true,
+      signal: expect.any(AbortSignal),
     });
     expect(runPiSdkChatCompletionIteration).toHaveBeenCalledTimes(2);
     expect(retryMessageSets[1]).toMatchObject([

--- a/packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts
+++ b/packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts
@@ -39,9 +39,9 @@ const mockPiAgentPrompt = vi.fn<
   }) => Promise<void>
 >();
 
-vi.mock('@mariozechner/pi-agent-core', async () => {
-  const actual = await vi.importActual<typeof import('@mariozechner/pi-agent-core')>(
-    '@mariozechner/pi-agent-core',
+vi.mock('@earendil-works/pi-agent-core', async () => {
+  const actual = await vi.importActual<typeof import('@earendil-works/pi-agent-core')>(
+    '@earendil-works/pi-agent-core',
   );
   class MockAgent {
     state = {

--- a/packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts
+++ b/packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts
@@ -100,7 +100,8 @@ vi.mock('@mariozechner/pi-agent-core', async () => {
 });
 
 vi.mock('../llm/piSdkProvider', async () => {
-  const actual = await vi.importActual<typeof import('../llm/piSdkProvider')>('../llm/piSdkProvider');
+  const actual =
+    await vi.importActual<typeof import('../llm/piSdkProvider')>('../llm/piSdkProvider');
   return {
     ...actual,
     resolvePiSdkModel: vi.fn(),
@@ -323,12 +324,10 @@ describe('handleTextInputWithChatCompletions (pi)', () => {
                     id: call.id,
                     name: call.name,
                     arguments:
-                      call.argumentsJson.trim().length > 0
-                        ? JSON.parse(call.argumentsJson)
-                        : {},
+                      call.argumentsJson.trim().length > 0 ? JSON.parse(call.argumentsJson) : {},
                   })),
-              ]
-            : result.assistantMessage.content,
+                ]
+              : result.assistantMessage.content,
         };
         if (!sawTextDelta) {
           let textSoFar = '';
@@ -657,6 +656,184 @@ describe('handleTextInputWithChatCompletions (pi)', () => {
     });
   });
 
+  it('compacts and retries once when a Pi run hits context overflow', async () => {
+    vi.mocked(resolvePiSdkModel).mockResolvedValue({
+      model: {
+        id: 'gpt-5.4',
+        provider: 'openai-codex',
+        api: 'openai-responses',
+        contextWindow: 100,
+      } as never,
+      providerId: 'openai-codex',
+      modelId: 'gpt-5.4',
+    });
+
+    const retryMessageSets: unknown[][] = [];
+    vi.mocked(runPiSdkChatCompletionIteration)
+      .mockImplementationOnce(async (options) => {
+        retryMessageSets.push(structuredClone(options.messages));
+        return {
+          text: '',
+          toolCalls: [],
+          aborted: false,
+          assistantMessage: {
+            role: 'assistant',
+            content: [],
+            api: 'openai-responses',
+            provider: 'openai-codex',
+            model: 'gpt-5.4',
+            usage: {
+              input: 100,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 100,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: 'error',
+            errorMessage: 'context_length_exceeded: maximum context length exceeded',
+            timestamp: Date.now(),
+          } as never,
+        };
+      })
+      .mockImplementationOnce(async (options) => {
+        retryMessageSets.push(structuredClone(options.messages));
+        return {
+          text: 'Recovered answer',
+          toolCalls: [],
+          aborted: false,
+          assistantMessage: {
+            role: 'assistant',
+            content: [
+              {
+                type: 'text',
+                text: 'Recovered answer',
+                textSignature: '{"v":1,"id":"msg-final","phase":"final_answer"}',
+              },
+            ],
+            api: 'openai-responses',
+            provider: 'openai-codex',
+            model: 'gpt-5.4',
+            usage: {
+              input: 40,
+              output: 5,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 45,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: 'stop',
+            timestamp: Date.now(),
+          } as never,
+        };
+      });
+
+    const broadcast: ServerMessage[] = [];
+    const sendError = vi.fn();
+    const state: LogicalSessionState = {
+      summary: {
+        sessionId: 's1',
+        title: 'Test',
+        createdAt: '',
+        updatedAt: '',
+        deleted: false,
+        agentId: 'pi',
+        attributes: {},
+      },
+      chatMessages: [{ role: 'user', content: 'Earlier request' }],
+      messageQueue: [],
+    } as unknown as LogicalSessionState;
+    const compactSession = vi.fn(async () => {
+      state.chatMessages = [
+        {
+          role: 'user',
+          content:
+            'The conversation history before this point was compacted into the following summary:\n\n<summary>\nEarlier work summary\n</summary>',
+        },
+        { role: 'user', content: 'Current request' },
+      ];
+      return {
+        summary: {
+          ...state.summary,
+          updatedAt: 'after-compact',
+        },
+        compacted: true as const,
+        reason: 'overflow' as const,
+        result: {
+          summary: 'Earlier work summary',
+          firstKeptEntryId: 'current-user',
+          tokensBefore: 100,
+        },
+      };
+    });
+    const sessionHub: SessionHub = {
+      getAgentRegistry: () =>
+        new AgentRegistry([
+          {
+            agentId: 'pi',
+            displayName: 'Pi',
+            description: 'Pi',
+            chat: { provider: 'pi', models: ['openai-codex/gpt-5.4'] },
+          },
+        ]),
+      broadcastToSession: (_sessionId: string, message: ServerMessage) => {
+        broadcast.push(message);
+      },
+      broadcastToSessionExcluding: () => undefined,
+      updateSessionAttributes: async () => undefined,
+      updateSessionContextUsage: vi.fn(async () => undefined),
+      recordSessionActivity: vi.fn(async () => undefined),
+      queueMessage: async () => {
+        throw new Error('queueMessage should not be called in this test');
+      },
+      dequeueMessageById: async () => undefined,
+      processNextQueuedMessage: async () => false,
+      getPiSessionWriter: () => undefined,
+      compactSession,
+    } as unknown as SessionHub;
+
+    await handleTextInputWithChatCompletions({
+      message: { type: 'text_input', text: 'Current request', sessionId: 's1' },
+      state,
+      sessionId: 's1',
+      connection: {} as never,
+      sessionHub,
+      config: createEnvConfig(),
+      chatCompletionTools: [],
+      outputMode: 'text',
+      clientAudioCapabilities: undefined,
+      ttsBackendFactory: null,
+      handleChatToolCalls: async () => undefined,
+      setActiveRunState: () => undefined,
+      clearActiveRunState: () => undefined,
+      sendError,
+      log: () => undefined,
+      eventStore: createTestEventStore(),
+    });
+
+    expect(compactSession).toHaveBeenCalledWith({
+      sessionId: 's1',
+      reason: 'overflow',
+      allowActiveRun: true,
+    });
+    expect(runPiSdkChatCompletionIteration).toHaveBeenCalledTimes(2);
+    expect(retryMessageSets[1]).toMatchObject([
+      {
+        role: 'user',
+        content: expect.stringContaining('Earlier work summary'),
+      },
+      { role: 'user', content: 'Current request' },
+    ]);
+    expect(JSON.stringify(retryMessageSets[1])).not.toContain('context_length_exceeded');
+    expect(sendError).not.toHaveBeenCalled();
+    expect(
+      broadcast.find(
+        (message): message is Extract<ServerMessage, { type: 'text_done' }> =>
+          message.type === 'text_done',
+      )?.text,
+    ).toBe('Recovered answer');
+  });
+
   it('broadcasts live transcript events for Pi assistant output without an EventStore', async () => {
     vi.mocked(resolvePiSdkModel).mockResolvedValue({
       model: { id: 'gpt-5.4', provider: 'openai-codex', api: 'openai-responses' } as never,
@@ -850,7 +1027,8 @@ describe('handleTextInputWithChatCompletions (pi)', () => {
       }),
     );
     expect(recordSessionActivity.mock.invocationCallOrder[0]).toBeLessThan(
-      vi.mocked(publishFinalResponseNotification).mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+      vi.mocked(publishFinalResponseNotification).mock.invocationCallOrder[0] ??
+        Number.POSITIVE_INFINITY,
     );
   });
 
@@ -1008,10 +1186,14 @@ describe('handleTextInputWithChatCompletions (pi)', () => {
     }> = [];
 
     const piSessionWriter = {
-      sync: vi.fn(async (options: { messages: Array<{ role: string; content?: string; piSdkMessage?: unknown }> }) => {
-        syncedMessages.push(...options.messages);
-        return undefined;
-      }),
+      sync: vi.fn(
+        async (options: {
+          messages: Array<{ role: string; content?: string; piSdkMessage?: unknown }>;
+        }) => {
+          syncedMessages.push(...options.messages);
+          return undefined;
+        },
+      ),
     };
 
     const sessionHub: SessionHub = {
@@ -1041,7 +1223,9 @@ describe('handleTextInputWithChatCompletions (pi)', () => {
       chatMessages: [],
     } as unknown as LogicalSessionState;
 
-    let capturedFirstIterationMessages: Array<{ role: string; content?: string | undefined }> | undefined;
+    let capturedFirstIterationMessages:
+      | Array<{ role: string; content?: string | undefined }>
+      | undefined;
 
     vi.mocked(resolvePiSdkModel).mockResolvedValue({
       model: { id: 'gpt-5.4', provider: 'openai-codex', api: 'openai-responses' } as never,
@@ -1396,7 +1580,9 @@ describe('handleTextInputWithChatCompletions (pi)', () => {
         aborted: false,
         assistantMessage: {
           role: 'assistant',
-          content: [{ type: 'toolCall', id: 'call-1', name: 'bash', arguments: { command: 'printf hi' } }],
+          content: [
+            { type: 'toolCall', id: 'call-1', name: 'bash', arguments: { command: 'printf hi' } },
+          ],
           api: 'openai-responses',
           provider: 'openai-codex',
           model: 'gpt-5.4',
@@ -2135,7 +2321,8 @@ describe('handleTextInputWithChatCompletions (pi)', () => {
       .filter(
         (message): message is Extract<ServerMessage, { type: 'transcript_event' }> =>
           message.type === 'transcript_event' &&
-          (message.event.chatEventType === 'tool_call' || message.event.chatEventType === 'tool_result'),
+          (message.event.chatEventType === 'tool_call' ||
+            message.event.chatEventType === 'tool_result'),
       )
       .map((message) => message.event.chatEventType);
 
@@ -2241,7 +2428,7 @@ describe('handleTextInputWithChatCompletions (pi)', () => {
     });
 
     expect(sync).toHaveBeenCalledTimes(1);
-    const syncPayload = ((sync.mock.calls as unknown) as Array<[unknown]>)[0]?.[0];
+    const syncPayload = (sync.mock.calls as unknown as Array<[unknown]>)[0]?.[0];
     expect(syncPayload).toBeDefined();
     expect(syncPayload).toMatchObject({
       summary: state.summary,

--- a/packages/agent-server/src/ws/chatRunLifecycle.ts
+++ b/packages/agent-server/src/ws/chatRunLifecycle.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import type {
   AssistantMessage as PiAssistantMessage,
   Message as PiSdkMessage,
-} from '@mariozechner/pi-ai';
+} from '@earendil-works/pi-ai';
 import type {
   ChatEvent,
   ClientAudioCapabilities,

--- a/packages/plugins/core/sessions/manifest.json
+++ b/packages/plugins/core/sessions/manifest.json
@@ -249,6 +249,21 @@
       "capabilities": ["sessions.write"]
     },
     {
+      "id": "compact",
+      "summary": "Compact Pi-backed session context.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "sessionId": {
+            "type": "string",
+            "description": "Session id."
+          }
+        },
+        "required": ["sessionId"]
+      },
+      "capabilities": ["sessions.write"]
+    },
+    {
       "id": "delete",
       "summary": "Delete a session.",
       "inputSchema": {

--- a/packages/plugins/core/sessions/server/index.test.ts
+++ b/packages/plugins/core/sessions/server/index.test.ts
@@ -185,6 +185,7 @@ describe('sessions plugin operations', () => {
     expect(compactSessionSpy).toHaveBeenCalledWith({
       sessionId: created.sessionId,
       reason: 'manual',
+      signal: ctx.signal,
     });
     expect(result).toEqual({
       sessionId: created.sessionId,
@@ -201,6 +202,43 @@ describe('sessions plugin operations', () => {
           modifiedFiles: [],
         },
       },
+    });
+  });
+
+  it('maps active-run compact failures to session_busy', async () => {
+    const sessionIndex = new SessionIndex(createTempFile('sessions-plugin-compact-busy'));
+    const agentRegistry = new AgentRegistry([
+      {
+        agentId: 'pi-agent',
+        displayName: 'Pi Agent',
+        description: 'Pi-backed agent',
+        chat: { provider: 'pi' },
+      },
+    ]);
+    const sessionHub = new SessionHub({ sessionIndex, agentRegistry });
+    const plugin = createPlugin({ manifest: manifestJson as CombinedPluginManifest });
+
+    const ctx: ToolContext = {
+      sessionId: 'calling-session',
+      signal: new AbortController().signal,
+      sessionHub,
+      sessionIndex,
+      agentRegistry,
+    };
+
+    const created = await sessionIndex.createSession({
+      sessionId: 'compact-busy-target',
+      agentId: 'pi-agent',
+    });
+    vi.spyOn(sessionHub, 'compactSession').mockRejectedValue(
+      new Error('Cannot compact context while the session is running'),
+    );
+
+    await expect(
+      plugin.operations?.compact({ sessionId: created.sessionId }, ctx),
+    ).rejects.toMatchObject({
+      code: 'session_busy',
+      message: 'Cannot compact context while the session is running',
     });
   });
 

--- a/packages/plugins/core/sessions/server/index.test.ts
+++ b/packages/plugins/core/sessions/server/index.test.ts
@@ -140,6 +140,70 @@ describe('sessions plugin operations', () => {
     );
   });
 
+  it('delegates compact operation to SessionHub', async () => {
+    const sessionIndex = new SessionIndex(createTempFile('sessions-plugin-compact'));
+    const agentRegistry = new AgentRegistry([
+      {
+        agentId: 'pi-agent',
+        displayName: 'Pi Agent',
+        description: 'Pi-backed agent',
+        chat: { provider: 'pi' },
+      },
+    ]);
+    const sessionHub = new SessionHub({ sessionIndex, agentRegistry });
+    const plugin = createPlugin({ manifest: manifestJson as CombinedPluginManifest });
+
+    const ctx: ToolContext = {
+      sessionId: 'calling-session',
+      signal: new AbortController().signal,
+      sessionHub,
+      sessionIndex,
+      agentRegistry,
+    };
+
+    const created = await sessionIndex.createSession({
+      sessionId: 'compact-target',
+      agentId: 'pi-agent',
+    });
+    const compactSessionSpy = vi.spyOn(sessionHub, 'compactSession').mockResolvedValue({
+      summary: created,
+      compacted: true,
+      reason: 'manual',
+      result: {
+        summary: 'Compacted history',
+        firstKeptEntryId: 'entry-kept',
+        tokensBefore: 42,
+        details: {
+          readFiles: [],
+          modifiedFiles: [],
+        },
+      },
+    });
+
+    const result = await plugin.operations?.compact({ sessionId: created.sessionId }, ctx);
+
+    expect(compactSessionSpy).toHaveBeenCalledWith({
+      sessionId: created.sessionId,
+      reason: 'manual',
+    });
+    expect(result).toEqual({
+      sessionId: created.sessionId,
+      compacted: true,
+      reason: 'manual',
+      updatedAt: created.updatedAt,
+      revision: getPiTranscriptRevision(created.attributes),
+      result: {
+        summary: 'Compacted history',
+        firstKeptEntryId: 'entry-kept',
+        tokensBefore: 42,
+        details: {
+          readFiles: [],
+          modifiedFiles: [],
+        },
+      },
+    });
+  });
+
   it('persists model, thinking, title, and working dir from sessionConfig', async () => {
     const sessionIndex = new SessionIndex(createTempFile('sessions-plugin-config'));
     const agentRegistry = new AgentRegistry([
@@ -397,7 +461,10 @@ describe('sessions plugin operations', () => {
         agentRegistry,
       };
 
-      const created = (await plugin.operations?.create({ agentId: 'general' }, ctx)) as SessionSummary;
+      const created = (await plugin.operations?.create(
+        { agentId: 'general' },
+        ctx,
+      )) as SessionSummary;
 
       await getNotificationsStore().upsertSessionAttention(
         {
@@ -728,7 +795,10 @@ describe('sessions plugin operations', () => {
       updateAttributes: (patch) => sessionHub.updateSessionAttributes(summary.sessionId, patch),
     });
 
-    const bumpedSummary = await sessionHub.recordSessionActivity(created.sessionId, 'pi replay revision bump');
+    const bumpedSummary = await sessionHub.recordSessionActivity(
+      created.sessionId,
+      'pi replay revision bump',
+    );
     const result = (await plugin.operations?.events(
       { sessionId: created.sessionId, force: true },
       ctx,
@@ -760,7 +830,9 @@ describe('sessions plugin operations', () => {
   });
 
   it('keeps rewritten Pi replay visible when the pi-cli alias only stores transcript revision', async () => {
-    const sessionIndex = new SessionIndex(createTempFile('sessions-plugin-events-pi-delete-middle'));
+    const sessionIndex = new SessionIndex(
+      createTempFile('sessions-plugin-events-pi-delete-middle'),
+    );
     const agentRegistry = new AgentRegistry([
       {
         agentId: 'pi-agent',
@@ -769,7 +841,9 @@ describe('sessions plugin operations', () => {
         chat: { provider: 'pi' },
       },
     ]);
-    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sessions-plugin-events-pi-delete-middle-'));
+    const baseDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'sessions-plugin-events-pi-delete-middle-'),
+    );
     const piSessionWriter = new PiSessionWriter({ baseDir, log: () => undefined });
     const sessionHub = new SessionHub({ sessionIndex, agentRegistry, piSessionWriter });
     const plugin = createPlugin({ manifest: manifestJson as CombinedPluginManifest });
@@ -835,7 +909,11 @@ describe('sessions plugin operations', () => {
           id: 'req-1-assistant-msg',
           parentId: 'req-1-user-msg',
           timestamp: '2026-01-18T00:00:05.000Z',
-          message: { role: 'assistant', id: 'resp-1', content: [{ type: 'text', text: 'first reply' }] },
+          message: {
+            role: 'assistant',
+            id: 'resp-1',
+            content: [{ type: 'text', text: 'first reply' }],
+          },
         }),
         JSON.stringify({
           type: 'custom',
@@ -881,7 +959,11 @@ describe('sessions plugin operations', () => {
           id: 'req-3-assistant-msg',
           parentId: 'req-3-user-msg',
           timestamp: '2026-01-18T00:00:11.000Z',
-          message: { role: 'assistant', id: 'resp-3', content: [{ type: 'text', text: 'third reply' }] },
+          message: {
+            role: 'assistant',
+            id: 'resp-3',
+            content: [{ type: 'text', text: 'third reply' }],
+          },
         }),
         JSON.stringify({
           type: 'custom',
@@ -981,38 +1063,38 @@ describe('sessions plugin operations', () => {
       activeRequestId: 'request-live',
     });
 
-    await appendAndBroadcastChatEvents(
-      { sessionHub, sessionId: created.sessionId },
-      [
-        {
-          id: 'user-live',
-          sessionId: created.sessionId,
-          turnId: 'request-live',
-          timestamp: Date.now(),
-          type: 'user_message',
-          payload: { text: 'stream this reply' },
-        },
-        {
-          id: 'thinking-live',
-          sessionId: created.sessionId,
-          turnId: 'request-live',
-          responseId: 'resp-live',
-          timestamp: Date.now(),
-          type: 'thinking_chunk',
-          payload: { text: 'Thinking…' },
-        },
-        {
-          id: 'assistant-live',
-          sessionId: created.sessionId,
-          turnId: 'request-live',
-          responseId: 'resp-live',
-          timestamp: Date.now(),
-          type: 'assistant_chunk',
-          payload: { text: 'partial reply', phase: 'final_answer' },
-        },
-      ],
+    await appendAndBroadcastChatEvents({ sessionHub, sessionId: created.sessionId }, [
+      {
+        id: 'user-live',
+        sessionId: created.sessionId,
+        turnId: 'request-live',
+        timestamp: Date.now(),
+        type: 'user_message',
+        payload: { text: 'stream this reply' },
+      },
+      {
+        id: 'thinking-live',
+        sessionId: created.sessionId,
+        turnId: 'request-live',
+        responseId: 'resp-live',
+        timestamp: Date.now(),
+        type: 'thinking_chunk',
+        payload: { text: 'Thinking…' },
+      },
+      {
+        id: 'assistant-live',
+        sessionId: created.sessionId,
+        turnId: 'request-live',
+        responseId: 'resp-live',
+        timestamp: Date.now(),
+        type: 'assistant_chunk',
+        payload: { text: 'partial reply', phase: 'final_answer' },
+      },
+    ]);
+    const bumpedSummary = await sessionHub.recordSessionActivity(
+      created.sessionId,
+      'stream this reply',
     );
-    const bumpedSummary = await sessionHub.recordSessionActivity(created.sessionId, 'stream this reply');
     expect(Math.max(0, bumpedSummary?.revision ?? 0)).toBeGreaterThan(liveRevision);
 
     const result = (await plugin.operations?.events(
@@ -1083,7 +1165,10 @@ describe('sessions plugin operations', () => {
       agentRegistry,
     };
 
-    const created = (await plugin.operations?.create({ agentId: 'general' }, ctx)) as SessionSummary;
+    const created = (await plugin.operations?.create(
+      { agentId: 'general' },
+      ctx,
+    )) as SessionSummary;
 
     await expect(
       plugin.operations?.events({ sessionId: created.sessionId, force: true }, ctx),

--- a/packages/plugins/core/sessions/server/index.ts
+++ b/packages/plugins/core/sessions/server/index.ts
@@ -1,6 +1,7 @@
 import type {
   CombinedPluginManifest,
   SessionClearResponse,
+  SessionCompactResponse,
   SessionHistoryEditResponse,
   SessionReplayResponse,
   SessionAttributesPatch,
@@ -32,10 +33,7 @@ import {
   mergeBufferedLiveTranscriptEvents,
   seedLiveTranscriptSessionState,
 } from '../../../../agent-server/src/events/chatEventUtils';
-import {
-  projectTranscriptEvents,
-  sliceProjectedTranscript,
-} from './transcriptProjection';
+import { projectTranscriptEvents, sliceProjectedTranscript } from './transcriptProjection';
 
 type PluginFactoryArgs = { manifest: CombinedPluginManifest };
 
@@ -96,7 +94,10 @@ function getSessionRevision(summary: SessionSummary): number {
   return Math.max(0, summary.revision ?? 0);
 }
 
-function getTranscriptRevision(summary: SessionSummary, providerId: string | null | undefined): number {
+function getTranscriptRevision(
+  summary: SessionSummary,
+  providerId: string | null | undefined,
+): number {
   if (providerId === 'pi' || providerId === 'pi-cli') {
     return getPiTranscriptRevision(summary.attributes);
   }
@@ -683,7 +684,9 @@ export function createPlugin(_options: PluginFactoryArgs): PluginModule {
 
         try {
           const summary = await sessionHub.clearSession(sessionId);
-          const agent = summary.agentId ? requireAgentRegistry(ctx, sessionHub).getAgent(summary.agentId) : undefined;
+          const agent = summary.agentId
+            ? requireAgentRegistry(ctx, sessionHub).getAgent(summary.agentId)
+            : undefined;
           return {
             sessionId,
             cleared: true,
@@ -695,10 +698,7 @@ export function createPlugin(_options: PluginFactoryArgs): PluginModule {
           throw new ToolError('invalid_arguments', message);
         }
       },
-      'history-edit': async (
-        args,
-        ctx,
-      ): Promise<SessionHistoryEditResponse> => {
+      'history-edit': async (args, ctx): Promise<SessionHistoryEditResponse> => {
         const sessionHub = requireSessionHub(ctx);
         const sessionIndex = requireSessionIndex(ctx);
         const parsed = asObject(args);
@@ -717,7 +717,9 @@ export function createPlugin(_options: PluginFactoryArgs): PluginModule {
             action,
             requestId,
           });
-          const agent = summary.agentId ? requireAgentRegistry(ctx, sessionHub).getAgent(summary.agentId) : undefined;
+          const agent = summary.agentId
+            ? requireAgentRegistry(ctx, sessionHub).getAgent(summary.agentId)
+            : undefined;
           return {
             sessionId,
             action,
@@ -728,6 +730,38 @@ export function createPlugin(_options: PluginFactoryArgs): PluginModule {
           };
         } catch (err) {
           const message = err instanceof Error ? err.message : 'Failed to edit session history';
+          throw new ToolError('invalid_arguments', message);
+        }
+      },
+      compact: async (args, ctx): Promise<SessionCompactResponse> => {
+        const sessionHub = requireSessionHub(ctx);
+        const sessionIndex = requireSessionIndex(ctx);
+        const parsed = asObject(args);
+        const sessionId = requireSessionId(parsed['sessionId']);
+
+        const existing = await sessionIndex.getSession(sessionId);
+        if (!existing) {
+          throw new ToolError('session_not_found', 'Session not found');
+        }
+
+        try {
+          const { summary, result } = await sessionHub.compactSession({
+            sessionId,
+            reason: 'manual',
+          });
+          const agent = summary.agentId
+            ? requireAgentRegistry(ctx, sessionHub).getAgent(summary.agentId)
+            : undefined;
+          return {
+            sessionId,
+            compacted: true,
+            reason: 'manual',
+            updatedAt: summary.updatedAt,
+            revision: getTranscriptRevision(summary, agent?.chat?.provider),
+            result,
+          };
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Failed to compact context';
           throw new ToolError('invalid_arguments', message);
         }
       },

--- a/packages/plugins/core/sessions/server/index.ts
+++ b/packages/plugins/core/sessions/server/index.ts
@@ -109,6 +109,12 @@ function requireSessionId(raw: unknown): string {
   return sessionId;
 }
 
+function compactErrorCode(message: string): string {
+  return message === 'Cannot compact context while the session is running'
+    ? 'session_busy'
+    : 'invalid_arguments';
+}
+
 function requireRequestId(raw: unknown): string {
   return requireNonEmptyString(raw, 'requestId');
 }
@@ -748,6 +754,7 @@ export function createPlugin(_options: PluginFactoryArgs): PluginModule {
           const { summary, result } = await sessionHub.compactSession({
             sessionId,
             reason: 'manual',
+            ...(ctx.signal ? { signal: ctx.signal } : {}),
           });
           const agent = summary.agentId
             ? requireAgentRegistry(ctx, sessionHub).getAgent(summary.agentId)
@@ -762,7 +769,7 @@ export function createPlugin(_options: PluginFactoryArgs): PluginModule {
           };
         } catch (err) {
           const message = err instanceof Error ? err.message : 'Failed to compact context';
-          throw new ToolError('invalid_arguments', message);
+          throw new ToolError(compactErrorCode(message), message);
         }
       },
       delete: async (

--- a/packages/shared/src/protocol.test.ts
+++ b/packages/shared/src/protocol.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   CURRENT_PROTOCOL_VERSION,
   PanelDisplayModeSchema,
+  SessionCompactResponseSchema,
   SessionHistoryEditRequestSchema,
   SessionReplayResponseSchema,
   safeValidateClientMessage,
@@ -372,6 +373,33 @@ describe('server message validation', () => {
       },
     };
     expect(validateServerMessage(message)).toEqual(message);
+  });
+});
+
+describe('session operation schemas', () => {
+  it('accepts compact responses with result details', () => {
+    expect(
+      SessionCompactResponseSchema.parse({
+        sessionId: 'session-1',
+        compacted: true,
+        reason: 'manual',
+        updatedAt: '2026-05-10T00:00:00.000Z',
+        revision: 2,
+        result: {
+          summary: 'Summary',
+          firstKeptEntryId: 'entry-1',
+          tokensBefore: 123,
+          details: {
+            readFiles: ['a.ts'],
+            modifiedFiles: ['b.ts'],
+          },
+        },
+      }),
+    ).toMatchObject({
+      sessionId: 'session-1',
+      compacted: true,
+      reason: 'manual',
+    });
   });
 });
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -614,6 +614,28 @@ export const SessionClearResponseSchema = z.object({
 });
 export type SessionClearResponse = z.infer<typeof SessionClearResponseSchema>;
 
+export const SessionCompactResponseSchema = z.object({
+  sessionId: z.string(),
+  compacted: z.boolean(),
+  reason: z.literal('manual'),
+  updatedAt: z.string(),
+  revision: z.number().int().nonnegative(),
+  result: z
+    .object({
+      summary: z.string(),
+      firstKeptEntryId: z.string(),
+      tokensBefore: z.number().int().nonnegative(),
+      details: z
+        .object({
+          readFiles: z.array(z.string()),
+          modifiedFiles: z.array(z.string()),
+        })
+        .optional(),
+    })
+    .optional(),
+});
+export type SessionCompactResponse = z.infer<typeof SessionCompactResponseSchema>;
+
 export const ServerToolCallMessageSchema = z.object({
   type: z.literal('tool_call'),
   sessionId: z.string().optional(),
@@ -872,9 +894,7 @@ export const ServerNotificationEventMessageSchema = z.object({
   id: z.string().optional(),
   notifications: z.array(NotificationRecordSchema).optional(),
 });
-export type ServerNotificationEventMessage = z.infer<
-  typeof ServerNotificationEventMessageSchema
->;
+export type ServerNotificationEventMessage = z.infer<typeof ServerNotificationEventMessageSchema>;
 
 export const ServerMessageSchema = z.discriminatedUnion('type', [
   ServerSessionReadyMessageSchema,

--- a/packages/web-client/src/controllers/sessionManager.ts
+++ b/packages/web-client/src/controllers/sessionManager.ts
@@ -1,7 +1,11 @@
 import type { SessionConfig, SessionHistoryEditAction } from '@assistant/shared';
 
 import { apiFetch } from '../utils/api';
-import { readSessionOperationResult, sessionsOperationPath } from '../utils/sessionsApi';
+import {
+  readSessionOperationError,
+  readSessionOperationResult,
+  sessionsOperationPath,
+} from '../utils/sessionsApi';
 
 export interface SessionManagerOptions {
   getSelectedSessionId: () => string | null;
@@ -159,7 +163,9 @@ export class SessionManager {
         body: JSON.stringify({ sessionId }),
       });
       if (!response.ok) {
-        this.options.setStatus('Failed to compact context');
+        this.options.setStatus(
+          await readSessionOperationError(response, 'Failed to compact context'),
+        );
         return;
       }
 

--- a/packages/web-client/src/controllers/sessionManager.ts
+++ b/packages/web-client/src/controllers/sessionManager.ts
@@ -151,6 +151,25 @@ export class SessionManager {
     }
   }
 
+  async compactSession(sessionId: string): Promise<void> {
+    try {
+      const response = await apiFetch(sessionsOperationPath('compact'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId }),
+      });
+      if (!response.ok) {
+        this.options.setStatus('Failed to compact context');
+        return;
+      }
+
+      await readSessionOperationResult<{ compacted?: boolean }>(response);
+    } catch (err) {
+      console.error('Failed to compact context', err);
+      this.options.setStatus('Failed to compact context');
+    }
+  }
+
   async deleteSession(sessionId: string, fromKeyboard: boolean = false): Promise<void> {
     try {
       let nextSessionId: string | null = null;

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -303,7 +303,8 @@ async function main(): Promise<void> {
       deactivateWindowSlot(WINDOW_ID);
     },
     onResume: () => {
-      const scheme = document.documentElement.getAttribute('data-theme-scheme') === 'dark' ? 'dark' : 'light';
+      const scheme =
+        document.documentElement.getAttribute('data-theme-scheme') === 'dark' ? 'dark' : 'light';
       void syncStatusBarThemeForScheme(scheme, { force: true });
       startHeartbeat();
       ensureConnected('capacitor-resume');
@@ -376,7 +377,9 @@ async function main(): Promise<void> {
   };
   const sessionTranscriptReplayState = new Map<string, SessionTranscriptReplayState>();
 
-  function getOrCreateSessionTranscriptReplayState(sessionId: string): SessionTranscriptReplayState {
+  function getOrCreateSessionTranscriptReplayState(
+    sessionId: string,
+  ): SessionTranscriptReplayState {
     const trimmed = sessionId.trim();
     const existing = sessionTranscriptReplayState.get(trimmed);
     if (existing) {
@@ -961,7 +964,8 @@ async function main(): Promise<void> {
       return null;
     }
     const activePanelId =
-      (panelHostController?.getContext('panel.active') as { panelId?: string } | null)?.panelId ?? null;
+      (panelHostController?.getContext('panel.active') as { panelId?: string } | null)?.panelId ??
+      null;
     if (activePanelId) {
       const activeEntry = entries.find((entry) => entry.panelId === activePanelId);
       if (activeEntry) {
@@ -1181,8 +1185,7 @@ async function main(): Promise<void> {
       return normalizeSessionId(inputSessionId);
     }
     const binding = panelHostController?.getPanelBinding(panelId);
-    const boundSessionId =
-      binding?.mode === 'fixed' ? normalizeSessionId(binding.sessionId) : null;
+    const boundSessionId = binding?.mode === 'fixed' ? normalizeSessionId(binding.sessionId) : null;
     return boundSessionId ?? normalizeSessionId(inputSessionId);
   }
 
@@ -1227,10 +1230,7 @@ async function main(): Promise<void> {
           return nativeVoiceBridge.startManualListen(normalizedTargetSessionId);
         },
         stopVoiceFromFab: () => {
-          if (
-            nativeVoiceRuntimeState === 'speaking' ||
-            nativeVoiceRuntimeState === 'listening'
-          ) {
+          if (nativeVoiceRuntimeState === 'speaking' || nativeVoiceRuntimeState === 'listening') {
             void nativeVoiceBridge.stopCurrentInteraction();
             return true;
           }
@@ -3408,15 +3408,15 @@ async function main(): Promise<void> {
           }
         : action === 'trim_after'
           ? {
-            title: 'Delete After',
-            message: 'Remove this request and all requests after it?',
-            confirmText: 'Delete',
-          }
+              title: 'Delete After',
+              message: 'Remove this request and all requests after it?',
+              confirmText: 'Delete',
+            }
           : {
-            title: 'Delete Request',
-            message: 'Remove this request from the session history?',
-            confirmText: 'Delete',
-          };
+              title: 'Delete Request',
+              message: 'Remove this request from the session history?',
+              confirmText: 'Delete',
+            };
 
     dialogManager.showConfirmDialog({
       ...options,
@@ -3438,6 +3438,21 @@ async function main(): Promise<void> {
       confirmClassName: 'danger',
       onConfirm: () => {
         void clearSession(sessionId);
+      },
+      cancelCloseBehavior: 'remove-only',
+      confirmCloseBehavior: 'remove-only',
+    });
+  }
+
+  function showCompactContextConfirmation(sessionId: string): void {
+    panelWorkspace?.closeHeaderPopover();
+    dialogManager.showConfirmDialog({
+      title: 'Compact Context',
+      message: 'Summarize older Pi session history and keep recent context?',
+      confirmText: 'Compact',
+      confirmClassName: 'primary',
+      onConfirm: () => {
+        void requireSessionManager().compactSession(sessionId);
       },
       cancelCloseBehavior: 'remove-only',
       confirmCloseBehavior: 'remove-only',
@@ -3487,6 +3502,12 @@ async function main(): Promise<void> {
           label: 'Reset Session',
           onClick: () => {
             showResetHistoryConfirmation(sessionId);
+          },
+        },
+        {
+          label: 'Compact Context',
+          onClick: () => {
+            showCompactContextConfirmation(sessionId);
           },
         },
       ],
@@ -4730,9 +4751,7 @@ async function main(): Promise<void> {
           if (projectedEvents.length > 0) {
             chatRenderer.replayProjectedEvents(projectedEvents, {
               reset: true,
-              ...(replayCursorSequence !== null
-                ? { watermarkSequence: replayCursorSequence }
-                : {}),
+              ...(replayCursorSequence !== null ? { watermarkSequence: replayCursorSequence } : {}),
             });
             chatScrollManager.scrollToBottomAfterLayout();
           } else {
@@ -4751,13 +4770,14 @@ async function main(): Promise<void> {
           }
         } else if (projectedEvents.length > 0) {
           chatRenderer.replayProjectedEvents(projectedEvents, {
-            ...(replayCursorSequence !== null
-              ? { watermarkSequence: replayCursorSequence }
-              : {}),
+            ...(replayCursorSequence !== null ? { watermarkSequence: replayCursorSequence } : {}),
           });
           chatScrollManager.scrollToBottomAfterLayout();
         } else if (replayCursorSequence !== null) {
-          chatRenderer.setProjectedTranscriptSequenceWatermark(replay.revision, replayCursorSequence);
+          chatRenderer.setProjectedTranscriptSequenceWatermark(
+            replay.revision,
+            replayCursorSequence,
+          );
         }
 
         replayState.loaded = true;
@@ -4843,9 +4863,7 @@ async function main(): Promise<void> {
     return null;
   };
 
-  const parsePanelCommandMode = (
-    value: unknown,
-  ): 'tab' | 'split' | 'header' | null => {
+  const parsePanelCommandMode = (value: unknown): 'tab' | 'split' | 'header' | null => {
     const mode = normalizeCommandString(value);
     if (!mode) {
       return null;
@@ -4868,14 +4886,13 @@ async function main(): Promise<void> {
       : null;
   };
 
-  const parsePanelCommandSize = (
-    value: unknown,
-  ): PanelPlacement['size'] | undefined => {
+  const parsePanelCommandSize = (value: unknown): PanelPlacement['size'] | undefined => {
     if (!value || typeof value !== 'object' || Array.isArray(value)) {
       return undefined;
     }
     const record = value as Record<string, unknown>;
-    const width = typeof record['width'] === 'number' && record['width'] > 0 ? record['width'] : undefined;
+    const width =
+      typeof record['width'] === 'number' && record['width'] > 0 ? record['width'] : undefined;
     const height =
       typeof record['height'] === 'number' && record['height'] > 0 ? record['height'] : undefined;
     if (width === undefined && height === undefined) {

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -2163,6 +2163,18 @@ async function main(): Promise<void> {
     return provider === 'pi' || provider === 'pi-cli';
   }
 
+  function isSessionPiSdkBacked(sessionId: string | null): boolean {
+    if (!sessionId) {
+      return false;
+    }
+    const session = sessionSummaries.find((summary) => summary.sessionId === sessionId) ?? null;
+    if (!session?.agentId) {
+      return false;
+    }
+    const agent = agentSummaries.find((summary) => summary.agentId === session.agentId) ?? null;
+    return agent?.provider === 'pi';
+  }
+
   function sendSetSessionModel(sessionId: string, model: string): void {
     if (!socket || socket.readyState !== WebSocket.OPEN) {
       return;
@@ -3504,12 +3516,16 @@ async function main(): Promise<void> {
             showResetHistoryConfirmation(sessionId);
           },
         },
-        {
-          label: 'Compact Context',
-          onClick: () => {
-            showCompactContextConfirmation(sessionId);
-          },
-        },
+        ...(isSessionPiSdkBacked(sessionId)
+          ? [
+              {
+                label: 'Compact Context',
+                onClick: () => {
+                  showCompactContextConfirmation(sessionId);
+                },
+              },
+            ]
+          : []),
       ],
     });
   }

--- a/packages/web-client/src/utils/sessionsApi.ts
+++ b/packages/web-client/src/utils/sessionsApi.ts
@@ -15,3 +15,27 @@ export async function readSessionOperationResult<T>(response: Response): Promise
   }
   return data as T;
 }
+
+export async function readSessionOperationError(
+  response: Response,
+  fallback: string,
+): Promise<string> {
+  try {
+    const data = (await response.clone().json()) as unknown;
+    if (data && typeof data === 'object' && 'error' in data) {
+      const error = (data as { error?: unknown }).error;
+      if (typeof error === 'string' && error.trim()) {
+        return error.trim();
+      }
+    }
+  } catch {
+    // Fall through to text response handling.
+  }
+
+  try {
+    const text = (await response.text()).trim();
+    return text || fallback;
+  } catch {
+    return fallback;
+  }
+}


### PR DESCRIPTION
## Summary
- add Pi-backed session context compaction with manual chat menu/API operation, Pi-compatible JSONL compaction entries, effective replay context, threshold auto-compaction, and one-shot overflow recovery
- gate manual Compact Context to Pi-backed sessions and improve compaction error/status behavior
- migrate Pi SDK dependencies from @mariozechner/* to @earendil-works/* at 0.74.0

## Verification
- npm test -- packages/agent-server/src/llm/piSdkProvider.test.ts packages/agent-server/src/tools/codingToolHost.test.ts packages/agent-server/src/chatProcessor.test.ts packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts packages/agent-server/src/history/piCompaction.test.ts packages/agent-server/src/history/piSessionReplay.test.ts packages/agent-server/src/history/piSessionWriter.test.ts packages/agent-server/src/history/piSessionSync.test.ts packages/agent-server/src/sessionHub.test.ts
- npm test -- packages/agent-server/src/llm/piSdkProvider.test.ts
- npm run build -w @assistant/agent-server
- npm run build
- npx eslint packages/agent-server/src/llm/piSdkProvider.ts packages/agent-server/src/llm/piAgentAuth.ts
- deployed to assistant.service and default Android flavor on both connected devices
