### PR TITLE
Include task descriptions in time tracker exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Changed
 
+- Changed time-tracker XLSX exports to include each task description before unique entry-note bullets in the Description column. ([#99](https://github.com/kcosr/assistant/pull/99))
 - Migrated Pi SDK dependencies from `@mariozechner/*` packages to the `@earendil-works/*` scope at `0.74.0`. ([#98](https://github.com/kcosr/assistant/pull/98))
 - Removed startup caches for instruction skills and context files. Skills and context files are now read from disk on every access, ensuring the skills dropdown and system prompt always reflect the current state of files without requiring a server restart. ([#93](https://github.com/kcosr/assistant/pull/93))
 - Moved environment variable substitution to run before Zod validation (previously ran after), enabling `${VAR}` usage in template definitions. ([#93](https://github.com/kcosr/assistant/pull/93))

--- a/docs/design/design-summary-time-tracker-export-task-description.md
+++ b/docs/design/design-summary-time-tracker-export-task-description.md
@@ -1,0 +1,134 @@
+# Time Tracker Export Task Description
+
+## Overview
+
+Enhance the time-tracker XLSX export so each exported task row can include the task description as a leading summary paragraph, followed by entry-level notes when they exist. The export remains grouped by task and keeps the existing XLSX columns, totals, artifact upload, and reported-entry behavior.
+
+## Motivation
+
+The current export Description column is built only from entry notes, so task-level context is omitted unless repeated on each entry. Including the task description makes exported reports more readable while preserving detailed notes as supporting bullets.
+
+## Scope
+
+In scope:
+
+- Build each exported row description from `Task.description` and unique `Entry.note` values.
+- Preserve grouping by task, total-minute aggregation, task-name labels, note normalization, note de-duplication, sorting, and reported-entry marking.
+- Preserve the current `export_xlsx` operation shape and server XLSX generation path.
+- Add or update tests around the combined description format.
+
+Out of scope:
+
+- Database schema changes or migrations.
+- New task or entry fields.
+- New UI controls or export options.
+- Compatibility aliases, fallback readers, or dual-shape operation inputs.
+- Implementing the feature in this design-summary pass.
+
+## Contract
+
+For each exported task row:
+
+- `item` remains the task name from `getTaskById(entry.task_id)`, or `Unknown task` when the task cannot be found.
+- `total_minutes` remains the sum of `entry.duration_minutes` for that task.
+- `description` is constructed as follows:
+  - Trim `task.description`.
+  - Trim each `entry.note`.
+  - Normalize each non-empty note by removing one leading bullet marker from `[-*•–—]` plus following whitespace.
+  - Ignore notes that become empty after normalization.
+  - De-duplicate notes case-insensitively while preserving first observed spelling and order.
+  - If both task description and notes exist, emit:
+
+    ```text
+    <task description>
+
+    Notes:
+    • <note 1>
+    • <note 2>
+    ```
+
+  - If only task description exists, emit just the task description.
+  - If only notes exist, preserve the current notes-only shape:
+
+    ```text
+    • <note 1>
+    • <note 2>
+    ```
+
+  - If neither exists, emit an empty string.
+
+The `export_xlsx` operation continues to accept `rows: [{ item, total_minutes, description }]` and writes the Description column from `row.description` through the existing server formatter. This is a hot-cut behavior change for future exports only.
+
+## Surface Inventory
+
+| Name | Disposition | Layers | Symmetric peers | Removal twin |
+|---|---|---|---|---|
+| XLSX `Description` column | Changed | Web export row builder constructs combined text; server `export_xlsx` writes column E | Task `Description` field and entry `Note` field | None |
+| `Notes:` label inside Description cell | Added | Web export row builder emits it only when a task description and one or more entry notes are both present | Entry notes rendered as bullets below task summary | None |
+
+## Schema
+
+_No schema changes._
+
+The time-tracker store already has `tasks.description` and `entries.note` fields with empty-string defaults.
+
+## Impact Surface
+
+| File | Responsibility | Existing tests |
+|---|---|---|
+| `packages/plugins/official/time-tracker/web/index.ts` | Defines `Task.description`, `Entry.note`, `ExportRow.description`; groups entries by task; currently builds row descriptions from entry notes only; forwards rows to `export_xlsx`; handles mark-reported updates. | `packages/plugins/official/time-tracker/web/index.test.ts` covers panel behavior and operation mocks; it can be extended, or export-row construction can be extracted for focused tests. |
+| `packages/plugins/official/time-tracker/server/index.ts` | Validates export rows, formats Description cell text, writes XLSX columns/formulas/wrapping/row heights, and returns the artifact payload. | `packages/plugins/official/time-tracker/server/index.test.ts` checks XLSX column widths and bullet formatting. |
+| `packages/plugins/official/time-tracker/server/store.ts` | Persists task descriptions and entry notes; confirms no schema migration is required. | `packages/plugins/official/time-tracker/server/store.test.ts` covers task, entry, timer, and note persistence behavior. |
+
+## Higher-Level Implementation Steps
+
+- Update the export row aggregation record in `buildExportRows` to retain trimmed task description alongside item, total minutes, and note map.
+- Reuse `getTaskById(entry.task_id)` to read `task.description`; default to an empty description for unknown tasks.
+- Keep the current `normalizeExportNote` behavior and case-insensitive note de-duplication.
+- Add a small formatter in the web export path that combines task description and note bullets according to the contract.
+- Leave `exportXlsx` and its mark-reported loop unchanged.
+- Leave the server `export_xlsx` input contract unchanged.
+- Add tests for description-plus-notes, description-only, notes-only, duplicate note normalization, and empty cases.
+- Update changelog/docs if this is treated as user-facing export behavior under repository conventions.
+
+## Diagrams
+
+_No diagrams applicable._
+
+## Risks
+
+- Server-side bullet normalization could alter lines that start with bullet-like characters; the task description should be passed as plain text and tests should cover expected multi-line output if necessary.
+- Some existing users may have duplicated task summaries in entry notes. This design de-duplicates notes only against other notes, not against the task description, to avoid silently dropping user-entered detail.
+- Entries whose task cannot be found should keep the current `Unknown task` behavior and simply omit task-description text.
+- Reported-entry marking could regress if row construction is mixed with post-export updates; keep the existing post-export update loop isolated.
+
+## Test Strategy
+
+Recommended tests:
+
+- Web/export row test for task description plus two unique notes:
+  - description appears first,
+  - a blank line separates it from notes,
+  - `Notes:` appears,
+  - notes are `•` bullets.
+- Web/export row test for description-only rows.
+- Web/export row test for notes-only rows preserving the current notes-only bullet shape.
+- Web/export row test for duplicate note normalization and case-insensitive de-duplication.
+- Server XLSX test, if needed, for a multi-line description containing a summary, `Notes:`, and bullets in cell `E2`.
+
+Commands:
+
+```bash
+npm run lint
+npm test -- packages/plugins/official/time-tracker
+npm run build:plugins
+```
+
+Run broader `npm test` if feasible before merging.
+
+## Open Assumptions
+
+- The task description is intended to be the exported high-level summary for a row.
+- `Task.description` is available in the panel state whenever export rows are built.
+- The `Notes:` label should appear only when both a task description and at least one note exist.
+- No migration or compatibility fallback is required because both source fields already exist.

--- a/packages/plugins/official/time-tracker/README.md
+++ b/packages/plugins/official/time-tracker/README.md
@@ -18,7 +18,7 @@ Track time against named tasks with timers, manual entries, and date filters.
 - Instance selection comes from config (`plugins.time-tracker.instances`); the default instance id is `default`.
 - Entries support a `reported` flag and can be filtered with "Show reported".
 - Entries can be filtered client-side by note text for quick search.
-- Export generates an XLSX report from the current view and uploads it to Artifacts.
+- Export generates an XLSX report from the current view and uploads it to Artifacts. Each task row's Description cell includes the trimmed task description first when present, followed by unique entry notes as bullets.
 - Range selection uses a simple click flow: click once for start, click again for end, and click again to reset a new start.
 - Timer starts initiated from the panel include a client-local `entry_date` so "Today" filtering matches the user's local day even when server timezone differs.
 

--- a/packages/plugins/official/time-tracker/SPEC.md
+++ b/packages/plugins/official/time-tracker/SPEC.md
@@ -356,7 +356,8 @@ All operations accept an optional `instance_id` (defaults to `default`).
 
 - Export is initiated from the time-tracker panel and respects the current view filters (instance, task, date range, and "Show reported").
 - The export dialog shows a summary and offers to mark exported entries as reported (default on).
-- The XLSX file includes columns: Item, Hours, Minutes, Hours (Decimal), Description (multi-line notes, each line prefixed with "•").
+- The XLSX file includes columns: Item, Hours, Minutes, Hours (Decimal), Description.
+- Description is built per task row from the trimmed task description followed by `Notes:` and unique normalized entry-note bullets when both are present. Rows with only notes keep the notes-only bullet list, rows with only a task description use that text, and rows with neither leave Description empty.
 - Column widths are fixed for Item (80) and Description (160).
 - A totals row with formulas is appended, and the Hours (Decimal) total cell is highlighted green.
 

--- a/packages/plugins/official/time-tracker/web/index.test.ts
+++ b/packages/plugins/official/time-tracker/web/index.test.ts
@@ -16,8 +16,31 @@ vi.mock('../../../../web-client/src/utils/api', () => ({
 }));
 
 type OperationCall = {
+  plugin: string;
   operation: string;
   body: Record<string, unknown>;
+};
+
+type MockTask = {
+  id: string;
+  name: string;
+  description?: string;
+  created_at?: string;
+  updated_at?: string;
+};
+
+type MockEntry = {
+  id: string;
+  task_id: string;
+  duration_minutes: number;
+  note?: string;
+  entry_date?: string;
+  reported?: boolean;
+  entry_type?: 'manual' | 'timer';
+  start_time?: string | null;
+  end_time?: string | null;
+  created_at?: string;
+  updated_at?: string;
 };
 
 const flushPromises = async (): Promise<void> => {
@@ -37,20 +60,33 @@ describe('time tracker range picker', () => {
   const originalTz = process.env.TZ;
   let panelFactory: PanelFactory | null = null;
   let operationCalls: OperationCall[] = [];
+  let mockTasks: MockTask[] = [];
+  let mockEntries: MockEntry[] = [];
 
   beforeEach(() => {
     panelFactory = null;
     operationCalls = [];
+    mockTasks = [
+      {
+        id: 'task-1',
+        name: 'Task',
+        description: '',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+    ];
+    mockEntries = [];
 
     apiFetch.mockReset();
     apiFetch.mockImplementation(async (url: string, options?: RequestInit) => {
-      const match = /\/api\/plugins\/time-tracker\/operations\/([^/?#]+)/.exec(url);
-      const operation = match?.[1] ?? '';
+      const match = /\/api\/plugins\/([^/]+)\/operations\/([^/?#]+)/.exec(url);
+      const plugin = match?.[1] ?? '';
+      const operation = match?.[2] ?? '';
       const body = options?.body
         ? (JSON.parse(options.body.toString()) as Record<string, unknown>)
         : {};
 
-      operationCalls.push({ operation, body });
+      operationCalls.push({ plugin, operation, body });
 
       const json = (result: unknown) => ({
         ok: true,
@@ -58,25 +94,33 @@ describe('time tracker range picker', () => {
         json: async () => ({ ok: true, result }),
       });
 
+      if (plugin === 'artifacts' && operation === 'instance_list') {
+        return json([{ id: 'default', label: 'Default' }]);
+      }
+      if (plugin === 'artifacts' && operation === 'upload') {
+        return json({ id: 'artifact-1', filename: 'time-report.xlsx' });
+      }
+      if (plugin !== 'time-tracker') {
+        return json(null);
+      }
       if (operation === 'instance_list') {
         return json([{ id: 'default', label: 'Default' }]);
       }
       if (operation === 'task_list') {
-        return json([
-          {
-            id: 'task-1',
-            name: 'Task',
-            description: '',
-            created_at: '2026-01-01T00:00:00.000Z',
-            updated_at: '2026-01-01T00:00:00.000Z',
-          },
-        ]);
+        return json(mockTasks);
       }
       if (operation === 'entry_list') {
-        return json([]);
+        return json(mockEntries);
       }
       if (operation === 'timer_status') {
         return json(null);
+      }
+      if (operation === 'export_xlsx') {
+        return json({
+          filename: 'time-report.xlsx',
+          mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          content: 'dGVzdA==',
+        });
       }
       return json(null);
     });
@@ -176,6 +220,51 @@ describe('time tracker range picker', () => {
     await flushPromises();
   };
 
+  const makeEntry = (entry: MockEntry): MockEntry => ({
+    entry_date: '2026-01-01',
+    reported: false,
+    entry_type: 'manual',
+    start_time: null,
+    end_time: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    note: '',
+    ...entry,
+  });
+
+  const buildExportRows = async (
+    tasks: MockTask[],
+    entries: MockEntry[],
+  ): Promise<Array<Record<string, unknown>>> => {
+    mockTasks = tasks;
+    mockEntries = entries;
+
+    const { container, handle } = await mountPanel();
+    try {
+      const openButton = container.querySelector<HTMLButtonElement>('[data-role="export-xlsx"]');
+      expect(openButton).not.toBeNull();
+      openButton?.click();
+      await flushPromises();
+
+      const submitButton = document.body.querySelector<HTMLButtonElement>(
+        '.time-tracker-export-dialog .confirm-dialog-button.primary',
+      );
+      expect(submitButton).not.toBeNull();
+      submitButton?.click();
+      await flushPromises();
+      await flushPromises();
+
+      const exportCall = operationCalls.find(
+        (call) => call.plugin === 'time-tracker' && call.operation === 'export_xlsx',
+      );
+      expect(exportCall).toBeTruthy();
+      expect(Array.isArray(exportCall?.body['rows'])).toBe(true);
+      return exportCall?.body['rows'] as Array<Record<string, unknown>>;
+    } finally {
+      handle.unmount();
+    }
+  };
+
   it.each([
     { label: 'desktop', isMobileViewport: false },
     { label: 'mobile', isMobileViewport: true },
@@ -272,5 +361,146 @@ describe('time tracker range picker', () => {
     } finally {
       handle.unmount();
     }
+  });
+
+  it('exports task description before unique note bullets', async () => {
+    const rows = await buildExportRows(
+      [
+        {
+          id: 'task-1',
+          name: 'Client follow-up',
+          description: '  Summarize client rollout blockers.  ',
+        },
+      ],
+      [
+        makeEntry({
+          id: 'entry-1',
+          task_id: 'task-1',
+          duration_minutes: 30,
+          note: ' - Drafted status update ',
+        }),
+        makeEntry({
+          id: 'entry-2',
+          task_id: 'task-1',
+          duration_minutes: 45,
+          note: '• Confirmed owners',
+        }),
+      ],
+    );
+
+    expect(rows).toEqual([
+      {
+        item: 'Client follow-up',
+        total_minutes: 75,
+        description:
+          'Summarize client rollout blockers.\n\nNotes:\n• Drafted status update\n• Confirmed owners',
+      },
+    ]);
+  });
+
+  it('exports task description only when entries have no notes', async () => {
+    const rows = await buildExportRows(
+      [{ id: 'task-1', name: 'Planning', description: ' Quarterly planning summary ' }],
+      [
+        makeEntry({
+          id: 'entry-1',
+          task_id: 'task-1',
+          duration_minutes: 60,
+          note: '',
+        }),
+      ],
+    );
+
+    expect(rows).toEqual([
+      {
+        item: 'Planning',
+        total_minutes: 60,
+        description: 'Quarterly planning summary',
+      },
+    ]);
+  });
+
+  it('preserves notes-only export descriptions', async () => {
+    const rows = await buildExportRows(
+      [{ id: 'task-1', name: 'Implementation', description: '' }],
+      [
+        makeEntry({
+          id: 'entry-1',
+          task_id: 'task-1',
+          duration_minutes: 25,
+          note: 'Built report view',
+        }),
+        makeEntry({
+          id: 'entry-2',
+          task_id: 'task-1',
+          duration_minutes: 35,
+          note: '* Added tests',
+        }),
+      ],
+    );
+
+    expect(rows).toEqual([
+      {
+        item: 'Implementation',
+        total_minutes: 60,
+        description: '• Built report view\n• Added tests',
+      },
+    ]);
+  });
+
+  it('deduplicates normalized notes case-insensitively', async () => {
+    const rows = await buildExportRows(
+      [{ id: 'task-1', name: 'QA', description: 'Verification pass' }],
+      [
+        makeEntry({
+          id: 'entry-1',
+          task_id: 'task-1',
+          duration_minutes: 10,
+          note: '- Smoke tested export',
+        }),
+        makeEntry({
+          id: 'entry-2',
+          task_id: 'task-1',
+          duration_minutes: 20,
+          note: 'smoke tested export',
+        }),
+        makeEntry({
+          id: 'entry-3',
+          task_id: 'task-1',
+          duration_minutes: 30,
+          note: '— Checked workbook formatting',
+        }),
+      ],
+    );
+
+    expect(rows).toEqual([
+      {
+        item: 'QA',
+        total_minutes: 60,
+        description: 'Verification pass\n\nNotes:\n• Smoke tested export\n• Checked workbook formatting',
+      },
+    ]);
+  });
+
+  it('exports an empty description when a row has neither task description nor notes', async () => {
+    const rows = await buildExportRows(
+      [{ id: 'task-1', name: 'Admin', description: '   ' }],
+      [
+        makeEntry({
+          id: 'entry-1',
+          task_id: 'task-1',
+          duration_minutes: 15,
+          note: ' - ',
+        }),
+      ],
+    );
+
+    expect(rows).toEqual([
+      {
+        item: 'Admin',
+        total_minutes: 15,
+        description: '',
+      },
+    ]);
   });
 });

--- a/packages/plugins/official/time-tracker/web/index.test.ts
+++ b/packages/plugins/official/time-tracker/web/index.test.ts
@@ -503,4 +503,26 @@ describe('time tracker range picker', () => {
       },
     ]);
   });
+
+  it('exports missing task entries as unknown task rows without task description', async () => {
+    const rows = await buildExportRows(
+      [],
+      [
+        makeEntry({
+          id: 'entry-1',
+          task_id: 'missing-task',
+          duration_minutes: 20,
+          note: '- Investigated orphaned entry',
+        }),
+      ],
+    );
+
+    expect(rows).toEqual([
+      {
+        item: 'Unknown task',
+        total_minutes: 20,
+        description: '• Investigated orphaned entry',
+      },
+    ]);
+  });
 });

--- a/packages/plugins/official/time-tracker/web/index.ts
+++ b/packages/plugins/official/time-tracker/web/index.ts
@@ -303,6 +303,7 @@ type ArtifactMetadata = {
 };
 
 const DURATION_PRESETS = [15, 30, 45, 60, 90, 120];
+const EXPORT_NOTE_PREFIX = '• ';
 
 const fallbackDialogManager = new DialogManager();
 const fallbackContextMenuManager = new ContextMenuManager({
@@ -688,6 +689,22 @@ function setVisible(el: HTMLElement | null, visible: boolean): void {
     return;
   }
   el.style.display = visible ? '' : 'none';
+}
+
+function normalizeExportNote(note: string): string {
+  return note.trim().replace(/^[-*•–—](?:\s+|$)/, '').trim();
+}
+
+function formatExportDescription(taskDescription: string, notes: string[]): string {
+  const description = taskDescription.trim();
+  const noteText = notes.map((note) => `${EXPORT_NOTE_PREFIX}${note}`).join('\n');
+  if (description && noteText) {
+    return `${description}\n\nNotes:\n${noteText}`;
+  }
+  if (description) {
+    return description;
+  }
+  return noteText;
 }
 
 function isSameDay(a: Date, b: Date): boolean {
@@ -1329,33 +1346,37 @@ if (!registry || typeof registry.registerPanel !== 'function') {
         entryCount: number;
         taskCount: number;
       } {
-        function normalizeExportNote(note: string): string {
-          return note.replace(/^[-*•–—]\s+/, '');
-        }
-
         const taskMap = new Map<
           string,
-          { item: string; totalMinutes: number; notes: Map<string, string> }
+          {
+            item: string;
+            taskDescription: string;
+            totalMinutes: number;
+            notes: Map<string, string>;
+          }
         >();
         let totalMinutes = 0;
         for (const entry of entries) {
           totalMinutes += entry.duration_minutes;
           const task = getTaskById(entry.task_id);
           const item = task ? task.name : 'Unknown task';
+          const taskDescription = task?.description.trim() ?? '';
           const existing =
             taskMap.get(entry.task_id) ??
-            ({ item, totalMinutes: 0, notes: new Map<string, string>() } as const);
+            ({
+              item,
+              taskDescription,
+              totalMinutes: 0,
+              notes: new Map<string, string>(),
+            } as const);
           const next = {
             item: existing.item,
+            taskDescription: existing.taskDescription,
             totalMinutes: existing.totalMinutes + entry.duration_minutes,
             notes: existing.notes,
           };
-          const rawNote = entry.note.trim();
-          if (rawNote) {
-            const normalizedNote = normalizeExportNote(rawNote);
-            if (!normalizedNote) {
-              continue;
-            }
+          const normalizedNote = normalizeExportNote(entry.note);
+          if (normalizedNote) {
             const key = normalizedNote.toLowerCase();
             if (!next.notes.has(key)) {
               next.notes.set(key, normalizedNote);
@@ -1366,12 +1387,10 @@ if (!registry || typeof registry.registerPanel !== 'function') {
         const rows = Array.from(taskMap.values())
           .map((record) => {
             const notes = Array.from(record.notes.values());
-            const description =
-              notes.length > 0 ? notes.map((note) => `• ${note}`).join('\n') : '';
             return {
               item: record.item,
               total_minutes: record.totalMinutes,
-              description,
+              description: formatExportDescription(record.taskDescription, notes),
             };
           })
           .sort((a, b) => a.item.localeCompare(b.item));

--- a/packages/plugins/official/time-tracker/web/index.ts
+++ b/packages/plugins/official/time-tracker/web/index.ts
@@ -695,7 +695,7 @@ function normalizeExportNote(note: string): string {
   return note.trim().replace(/^[-*•–—](?:\s+|$)/, '').trim();
 }
 
-function formatExportDescription(taskDescription: string, notes: string[]): string {
+function composeExportRowDescription(taskDescription: string, notes: string[]): string {
   const description = taskDescription.trim();
   const noteText = notes.map((note) => `${EXPORT_NOTE_PREFIX}${note}`).join('\n');
   if (description && noteText) {
@@ -1360,29 +1360,25 @@ if (!registry || typeof registry.registerPanel !== 'function') {
           totalMinutes += entry.duration_minutes;
           const task = getTaskById(entry.task_id);
           const item = task ? task.name : 'Unknown task';
-          const taskDescription = task?.description.trim() ?? '';
-          const existing =
-            taskMap.get(entry.task_id) ??
-            ({
+          const taskDescription = (task?.description ?? '').trim();
+          let record = taskMap.get(entry.task_id);
+          if (!record) {
+            record = {
               item,
               taskDescription,
               totalMinutes: 0,
               notes: new Map<string, string>(),
-            } as const);
-          const next = {
-            item: existing.item,
-            taskDescription: existing.taskDescription,
-            totalMinutes: existing.totalMinutes + entry.duration_minutes,
-            notes: existing.notes,
-          };
+            };
+            taskMap.set(entry.task_id, record);
+          }
+          record.totalMinutes += entry.duration_minutes;
           const normalizedNote = normalizeExportNote(entry.note);
           if (normalizedNote) {
             const key = normalizedNote.toLowerCase();
-            if (!next.notes.has(key)) {
-              next.notes.set(key, normalizedNote);
+            if (!record.notes.has(key)) {
+              record.notes.set(key, normalizedNote);
             }
           }
-          taskMap.set(entry.task_id, next);
         }
         const rows = Array.from(taskMap.values())
           .map((record) => {
@@ -1390,7 +1386,7 @@ if (!registry || typeof registry.registerPanel !== 'function') {
             return {
               item: record.item,
               total_minutes: record.totalMinutes,
-              description: formatExportDescription(record.taskDescription, notes),
+              description: composeExportRowDescription(record.taskDescription, notes),
             };
           })
           .sort((a, b) => a.item.localeCompare(b.item));


### PR DESCRIPTION
## Summary
- include task descriptions before entry notes in time-tracker XLSX export descriptions
- preserve notes-only export formatting and note de-duplication
- document the export behavior and add focused web export coverage

## Tests
- npm test -- packages/plugins/official/time-tracker
- npm run build

## Review
- agent-pack report --id code-review-5ecd17
