### PR TITLE
Use session picker for voice notification setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Changed
 
+- Changed the Voice notification session control to use the shared searchable session picker, replacing the prior native select. ([#100](https://github.com/kcosr/assistant/pull/100))
 - Changed time-tracker XLSX exports to include each task description before unique entry-note bullets in the Description column. ([#99](https://github.com/kcosr/assistant/pull/99))
 - Migrated Pi SDK dependencies from `@mariozechner/*` packages to the `@earendil-works/*` scope at `0.74.0`. ([#98](https://github.com/kcosr/assistant/pull/98))
 - Removed startup caches for instruction skills and context files. Skills and context files are now read from disk on every access, ensuring the skills dropdown and system prompt always reflect the current state of files without requiring a server restart. ([#93](https://github.com/kcosr/assistant/pull/93))

--- a/docs/UI_SPEC.md
+++ b/docs/UI_SPEC.md
@@ -95,6 +95,8 @@ Voice notification session behavior:
 - The Voice Settings modal uses the same searchable session picker for the notification session
   preference.
 - The control shows `None` when no preferred notification session is selected.
+- If the saved session no longer exists, the control can briefly show
+  `Unavailable session (<id>)` before the existing cleanup path clears the preference.
 - Selecting a session updates the `preferredVoiceSessionId` voice preference through the normal
   voice settings path.
 - The picker includes a `None` row to clear the preferred notification session.

--- a/docs/UI_SPEC.md
+++ b/docs/UI_SPEC.md
@@ -44,6 +44,8 @@ Required elements:
 - **Command Palette**: search actions.
 - **Connection Status**: current server connectivity.
 - **Settings**: preferences and layout reset (theme + UI/code font selectors).
+- **Voice Settings**: audio and voice preferences, including a searchable session picker for the
+  notification session preference.
 - **Header Panels**: pinned panel buttons that open a popover panel anchored in the toolbar.
 
 ### Header Panels (Pinned)
@@ -87,6 +89,15 @@ Binding indicator behavior:
 - Panels do not implicitly follow a global "active session"; chat binding is explicit
 - Non-chat panels do not expose session binding controls
 - New unbound chat panels auto-open the session picker to prompt session selection
+
+Voice notification session behavior:
+
+- The Voice Settings modal uses the same searchable session picker for the notification session
+  preference.
+- The control shows `None` when no preferred notification session is selected.
+- Selecting a session updates the `preferredVoiceSessionId` voice preference through the normal
+  voice settings path.
+- The picker includes a `None` row to clear the preferred notification session.
 
 ### Unavailable Panels
 

--- a/packages/web-client/public/index.html
+++ b/packages/web-client/public/index.html
@@ -358,17 +358,11 @@
             <input type="checkbox" id="auto-listen-checkbox" />
             Auto-listen
           </label>
-          <label
-            class="settings-dropdown-item"
-            for="standalone-notification-playback-checkbox"
-          >
+          <label class="settings-dropdown-item" for="standalone-notification-playback-checkbox">
             <input type="checkbox" id="standalone-notification-playback-checkbox" />
             Play standalone notifications aloud
           </label>
-          <label
-            class="settings-dropdown-item"
-            for="notification-title-playback-checkbox"
-          >
+          <label class="settings-dropdown-item" for="notification-title-playback-checkbox">
             <input type="checkbox" id="notification-title-playback-checkbox" />
             Read notification title before speech text
           </label>
@@ -382,11 +376,19 @@
               spellcheck="false"
             />
           </label>
-          <label class="list-item-form-label" for="voice-preferred-session-select">
+          <label class="list-item-form-label" for="voice-preferred-session-button">
             <span class="list-item-form-label-text">Voice notification session</span>
-            <select id="voice-preferred-session-select" class="list-item-form-input">
-              <option value="">None</option>
-            </select>
+            <button
+              type="button"
+              id="voice-preferred-session-button"
+              class="list-item-form-input voice-preferred-session-button"
+              aria-haspopup="listbox"
+              aria-label="Voice notification session: None"
+            >
+              <span id="voice-preferred-session-label" class="voice-preferred-session-label">
+                None
+              </span>
+            </button>
           </label>
           <label class="settings-dropdown-item" for="voice-tts-preferred-session-only-checkbox">
             <input type="checkbox" id="voice-tts-preferred-session-only-checkbox" />

--- a/packages/web-client/public/styles.css
+++ b/packages/web-client/public/styles.css
@@ -1716,6 +1716,23 @@ button.settings-dropdown-item {
   box-shadow: var(--shadow-focus-ring);
 }
 
+.voice-settings-grid .voice-preferred-session-button {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  min-height: 38px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.voice-preferred-session-label {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .voice-settings-slider-field {
   display: flex;
   flex-direction: column;
@@ -2054,7 +2071,8 @@ button.settings-dropdown-item {
   position: fixed;
   right: var(--spacing-lg);
   bottom: calc(
-    var(--spacing-lg) + var(--capacitor-nav-bar-height, 0px) + var(--command-palette-fab-offset, 64px)
+    var(--spacing-lg) + var(--capacitor-nav-bar-height, 0px) +
+      var(--command-palette-fab-offset, 64px)
   );
   width: 52px;
   height: 52px;
@@ -2099,8 +2117,11 @@ button.settings-dropdown-item {
 }
 
 .command-palette-fab.voice-fab {
-  background:
-    radial-gradient(circle at 30% 30%, color-mix(in srgb, var(--color-accent-primary) 88%, white), var(--color-accent-primary));
+  background: radial-gradient(
+    circle at 30% 30%,
+    color-mix(in srgb, var(--color-accent-primary) 88%, white),
+    var(--color-accent-primary)
+  );
   color: var(--color-text-on-accent);
 }
 
@@ -2117,8 +2138,12 @@ button.settings-dropdown-item {
 }
 
 .command-palette-fab.voice-fab.voice-fab-speaking {
-  background:
-    radial-gradient(circle at 30% 30%, rgba(255, 193, 107, 0.95), rgba(255, 152, 0, 0.92) 38%, rgba(255, 85, 85, 0.96) 100%);
+  background: radial-gradient(
+    circle at 30% 30%,
+    rgba(255, 193, 107, 0.95),
+    rgba(255, 152, 0, 0.92) 38%,
+    rgba(255, 85, 85, 0.96) 100%
+  );
   color: var(--color-text-on-accent);
   animation: native-voice-button-pulse 1.2s ease-in-out infinite;
 }
@@ -3080,7 +3105,9 @@ body.panel-reordering {
   background: transparent;
   color: var(--color-text-muted);
   cursor: pointer;
-  transition: background-color var(--transition-fast), color var(--transition-fast);
+  transition:
+    background-color var(--transition-fast),
+    color var(--transition-fast);
 }
 
 .panel-chrome-button:hover {
@@ -6614,8 +6641,12 @@ textarea.interaction-input {
 }
 
 .input-mic-button.native-speaking {
-  background:
-    radial-gradient(circle at 30% 30%, rgba(255, 193, 107, 0.95), rgba(255, 152, 0, 0.92) 38%, rgba(255, 85, 85, 0.96) 100%);
+  background: radial-gradient(
+    circle at 30% 30%,
+    rgba(255, 193, 107, 0.95),
+    rgba(255, 152, 0, 0.92) 38%,
+    rgba(255, 85, 85, 0.96) 100%
+  );
   border-color: color-mix(in srgb, var(--theme-danger) 72%, transparent);
   box-shadow:
     0 0 0 0 rgba(255, 152, 0, 0.34),

--- a/packages/web-client/public/styles.css
+++ b/packages/web-client/public/styles.css
@@ -3194,7 +3194,7 @@ body.panel-reordering {
 /* Session picker dropdown */
 .session-picker-popover {
   position: fixed;
-  z-index: 1102;
+  z-index: 1104;
   display: flex;
   flex-direction: column;
   min-width: 240px;

--- a/packages/web-client/src/controllers/panelSessionPicker.test.ts
+++ b/packages/web-client/src/controllers/panelSessionPicker.test.ts
@@ -144,6 +144,39 @@ describe('SessionPickerController', () => {
     controller.close();
   });
 
+  it('keeps the session row selected when a nullable session choice has a value', () => {
+    const controller = new SessionPickerController({
+      getSessionSummaries: () => [{ sessionId: 's1', name: 'Session 1' }],
+      getAgentSummaries: () => [],
+      openSessionComposer: vi.fn(),
+    });
+
+    const anchor = document.createElement('button');
+    document.body.appendChild(anchor);
+
+    controller.open({
+      anchor,
+      title: 'Select voice notification session',
+      selectedSessionId: 's1',
+      clearSelectionLabel: 'None',
+      onSelectSession: () => undefined,
+      onSelectClearSelection: () => undefined,
+    });
+
+    const items = Array.from(document.querySelectorAll<HTMLElement>('.session-picker-item'));
+    expect(items.at(0)?.textContent).toContain('None');
+    expect(items.at(0)?.classList.contains('selected')).toBe(false);
+    expect(items.at(0)?.classList.contains('focused')).toBe(false);
+
+    const selectedSession = document.querySelector<HTMLElement>(
+      '.session-picker-item[data-session-id="s1"]',
+    );
+    expect(selectedSession?.classList.contains('selected')).toBe(true);
+    expect(selectedSession?.classList.contains('focused')).toBe(true);
+
+    controller.close();
+  });
+
   it('does not render a clear-selection row unless a caller opts in', () => {
     const controller = new SessionPickerController({
       getSessionSummaries: () => [{ sessionId: 's1', name: 'Session 1' }],

--- a/packages/web-client/src/controllers/panelSessionPicker.test.ts
+++ b/packages/web-client/src/controllers/panelSessionPicker.test.ts
@@ -111,6 +111,43 @@ describe('SessionPickerController', () => {
     controller.close();
   });
 
+  it('can pin the picker near the viewport top for mobile dialog flows', () => {
+    const controller = new SessionPickerController({
+      getSessionSummaries: () => [{ sessionId: 's1', name: 'Session 1' }],
+      getAgentSummaries: () => [],
+      openSessionComposer: vi.fn(),
+    });
+
+    const anchor = document.createElement('button');
+    anchor.getBoundingClientRect = () =>
+      ({
+        x: 24,
+        y: 540,
+        top: 540,
+        left: 24,
+        right: 304,
+        bottom: 578,
+        width: 280,
+        height: 38,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    document.body.appendChild(anchor);
+
+    controller.open({
+      anchor,
+      title: 'Select voice notification session',
+      autoFocusSearch: false,
+      placement: 'viewport-top',
+      onSelectSession: () => undefined,
+    });
+
+    const menu = document.querySelector<HTMLElement>('.session-picker-popover');
+    expect(menu?.style.top).toBe('8px');
+    expect(menu?.style.left).toBe('24px');
+
+    controller.close();
+  });
+
   it('renders an explicit clear-selection row for nullable session choices', () => {
     const onSelectClearSelection = vi.fn();
     const controller = new SessionPickerController({

--- a/packages/web-client/src/controllers/panelSessionPicker.test.ts
+++ b/packages/web-client/src/controllers/panelSessionPicker.test.ts
@@ -111,13 +111,26 @@ describe('SessionPickerController', () => {
     controller.close();
   });
 
-  it('can pin the picker near the viewport top for mobile dialog flows', () => {
+  it('can pin the picker near a dialog top for mobile dialog flows', () => {
     const controller = new SessionPickerController({
       getSessionSummaries: () => [{ sessionId: 's1', name: 'Session 1' }],
       getAgentSummaries: () => [],
       openSessionComposer: vi.fn(),
     });
 
+    const dialog = document.createElement('div');
+    dialog.getBoundingClientRect = () =>
+      ({
+        x: 16,
+        y: 36,
+        top: 36,
+        left: 16,
+        right: 344,
+        bottom: 720,
+        width: 328,
+        height: 684,
+        toJSON: () => ({}),
+      }) as DOMRect;
     const anchor = document.createElement('button');
     anchor.getBoundingClientRect = () =>
       ({
@@ -131,18 +144,20 @@ describe('SessionPickerController', () => {
         height: 38,
         toJSON: () => ({}),
       }) as DOMRect;
-    document.body.appendChild(anchor);
+    dialog.appendChild(anchor);
+    document.body.appendChild(dialog);
 
     controller.open({
       anchor,
       title: 'Select voice notification session',
       autoFocusSearch: false,
       placement: 'viewport-top',
+      placementContainer: dialog,
       onSelectSession: () => undefined,
     });
 
     const menu = document.querySelector<HTMLElement>('.session-picker-popover');
-    expect(menu?.style.top).toBe('8px');
+    expect(menu?.style.top).toBe('44px');
     expect(menu?.style.left).toBe('24px');
 
     controller.close();

--- a/packages/web-client/src/controllers/panelSessionPicker.test.ts
+++ b/packages/web-client/src/controllers/panelSessionPicker.test.ts
@@ -111,6 +111,60 @@ describe('SessionPickerController', () => {
     controller.close();
   });
 
+  it('renders an explicit clear-selection row for nullable session choices', () => {
+    const onSelectClearSelection = vi.fn();
+    const controller = new SessionPickerController({
+      getSessionSummaries: () => [{ sessionId: 's1', name: 'Session 1' }],
+      getAgentSummaries: () => [],
+      openSessionComposer: vi.fn(),
+    });
+
+    const anchor = document.createElement('button');
+    document.body.appendChild(anchor);
+
+    controller.open({
+      anchor,
+      title: 'Select voice notification session',
+      selectedSessionId: '',
+      clearSelectionLabel: 'None',
+      onSelectSession: () => undefined,
+      onSelectClearSelection,
+    });
+
+    const items = Array.from(document.querySelectorAll<HTMLElement>('.session-picker-item'));
+    expect(items.at(0)?.textContent).toContain('None');
+    expect(items.at(0)?.classList.contains('selected')).toBe(true);
+    expect(items.at(0)?.classList.contains('focused')).toBe(true);
+
+    items.at(0)?.click();
+
+    expect(onSelectClearSelection).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('.session-picker-popover')).toBeNull();
+
+    controller.close();
+  });
+
+  it('does not render a clear-selection row unless a caller opts in', () => {
+    const controller = new SessionPickerController({
+      getSessionSummaries: () => [{ sessionId: 's1', name: 'Session 1' }],
+      getAgentSummaries: () => [],
+      openSessionComposer: vi.fn(),
+    });
+
+    const anchor = document.createElement('button');
+    document.body.appendChild(anchor);
+
+    controller.open({
+      anchor,
+      title: 'Sessions',
+      onSelectSession: () => undefined,
+    });
+
+    expect(document.querySelector('.session-picker-item')?.textContent).not.toContain('None');
+
+    controller.close();
+  });
+
   it('invokes clear from the session row action button', () => {
     const onClearSession = vi.fn();
     const controller = new SessionPickerController({
@@ -366,7 +420,9 @@ describe('SessionPickerController', () => {
       onSelectOpenSession,
     });
 
-    const item = document.querySelector<HTMLDivElement>('.session-picker-item[data-session-id="s1"]');
+    const item = document.querySelector<HTMLDivElement>(
+      '.session-picker-item[data-session-id="s1"]',
+    );
     expect(item?.classList.contains('disabled')).toBe(false);
     expect(item?.textContent).toContain('(open)');
 

--- a/packages/web-client/src/controllers/panelSessionPicker.ts
+++ b/packages/web-client/src/controllers/panelSessionPicker.ts
@@ -27,6 +27,7 @@ export interface SessionPickerOpenOptions {
   anchor: HTMLElement;
   title: string;
   autoFocusSearch?: boolean;
+  placement?: 'anchor' | 'viewport-top';
   selectedSessionId?: string | null;
   disabledSessionIds?: Set<string>;
   openSessionIds?: Set<string>;
@@ -429,7 +430,7 @@ export class SessionPickerController {
     };
 
     renderList();
-    this.positionMenu(menu, options.anchor);
+    this.positionMenu(menu, options);
 
     if (options.autoFocusSearch !== false) {
       setTimeout(() => {
@@ -601,7 +602,8 @@ export class SessionPickerController {
     return true;
   }
 
-  private positionMenu(menu: HTMLDivElement, anchor: HTMLElement): void {
+  private positionMenu(menu: HTMLDivElement, options: SessionPickerOpenOptions): void {
+    const anchor = options.anchor;
     const anchorRect = anchor.getBoundingClientRect();
     const targetWidth = Math.min(360, Math.max(280, anchorRect.width));
     menu.style.minWidth = `${targetWidth}px`;
@@ -611,6 +613,18 @@ export class SessionPickerController {
 
     let left = anchorRect.left;
     let top = anchorRect.bottom + 6;
+
+    if (options.placement === 'viewport-top') {
+      const viewport = window.visualViewport;
+      const viewportLeft = viewport?.offsetLeft ?? 0;
+      const viewportTop = viewport?.offsetTop ?? 0;
+      const viewportWidth = viewport?.width ?? window.innerWidth;
+      const viewportHeight = viewport?.height ?? window.innerHeight;
+      const maxLeft = viewportLeft + viewportWidth - menuRect.width - padding;
+      left = Math.min(Math.max(anchorRect.left, viewportLeft + padding), maxLeft);
+      top = viewportTop + padding;
+      menu.style.maxHeight = `${Math.max(180, Math.min(360, viewportHeight - padding * 2))}px`;
+    }
 
     if (left + menuRect.width > window.innerWidth - padding) {
       left = window.innerWidth - menuRect.width - padding;

--- a/packages/web-client/src/controllers/panelSessionPicker.ts
+++ b/packages/web-client/src/controllers/panelSessionPicker.ts
@@ -31,10 +31,12 @@ export interface SessionPickerOpenOptions {
   disabledSessionIds?: Set<string>;
   openSessionIds?: Set<string>;
   allowUnbound?: boolean;
+  clearSelectionLabel?: string;
   createSessionOptions?: CreateSessionOptions;
   onSelectSession: (sessionId: string) => void;
   onSelectOpenSession?: (sessionId: string) => void;
   onSelectUnbound?: () => void;
+  onSelectClearSelection?: () => void;
   onDeleteSession?: (sessionId: string) => void;
   onClearSession?: (sessionId: string) => void;
   onEditSession?: (sessionId: string) => void;
@@ -345,6 +347,15 @@ export class SessionPickerController {
         addSection('Unbound');
         addItem('Unbound', () => options.onSelectUnbound?.(), {
           disabled: !options.onSelectUnbound,
+        });
+      }
+
+      const clearSelectionLabel = options.clearSelectionLabel?.trim();
+      if (clearSelectionLabel) {
+        addSection('Selection');
+        addItem(clearSelectionLabel, () => options.onSelectClearSelection?.(), {
+          disabled: !options.onSelectClearSelection,
+          selected: !options.selectedSessionId,
         });
       }
 

--- a/packages/web-client/src/controllers/panelSessionPicker.ts
+++ b/packages/web-client/src/controllers/panelSessionPicker.ts
@@ -28,6 +28,7 @@ export interface SessionPickerOpenOptions {
   title: string;
   autoFocusSearch?: boolean;
   placement?: 'anchor' | 'viewport-top';
+  placementContainer?: HTMLElement | null;
   selectedSessionId?: string | null;
   disabledSessionIds?: Set<string>;
   openSessionIds?: Set<string>;
@@ -620,9 +621,10 @@ export class SessionPickerController {
       const viewportTop = viewport?.offsetTop ?? 0;
       const viewportWidth = viewport?.width ?? window.innerWidth;
       const viewportHeight = viewport?.height ?? window.innerHeight;
+      const containerTop = options.placementContainer?.getBoundingClientRect().top;
       const maxLeft = viewportLeft + viewportWidth - menuRect.width - padding;
       left = Math.min(Math.max(anchorRect.left, viewportLeft + padding), maxLeft);
-      top = viewportTop + padding;
+      top = Math.max(viewportTop, containerTop ?? viewportTop) + padding;
       menu.style.maxHeight = `${Math.max(180, Math.min(360, viewportHeight - padding * 2))}px`;
     }
 

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -3983,9 +3983,12 @@ async function main(): Promise<void> {
   });
   voicePreferredSessionButtonEl.addEventListener('click', () => {
     const settings = getCurrentVoiceSettings();
+    const useMobilePickerPlacement = isMobileViewport();
     openSessionPicker({
       anchor: voicePreferredSessionButtonEl,
       title: 'Select voice notification session',
+      autoFocusSearch: !useMobilePickerPlacement,
+      placement: useMobilePickerPlacement ? 'viewport-top' : 'anchor',
       selectedSessionId: settings.preferredVoiceSessionId,
       clearSelectionLabel: 'None',
       onSelectClearSelection: () => {

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -72,7 +72,6 @@ import {
   type CreateScheduledSessionInput,
   type SessionComposerOpenOptions,
 } from './controllers/sessionComposerController';
-import type { PanelInitOptions } from './controllers/panelRegistry';
 import type { ChatRuntime } from './panels/chat';
 import type { ChatPanelDom } from './panels/chat/chatPanel';
 import { CHAT_PANEL_MANIFEST, createChatPanel } from './panels/chat';
@@ -628,8 +627,7 @@ async function main(): Promise<void> {
     CHAT_PANEL_MANIFEST,
     createChatPanel({
       getRuntimeOptions: getChatRuntimeOptions,
-      onRuntimeReady: ({ runtime, dom, host, init }) =>
-        registerChatPanelRuntime({ runtime, dom, host, init }),
+      onRuntimeReady: ({ runtime, dom, host }) => registerChatPanelRuntime({ runtime, dom, host }),
     }),
   );
   registerBuiltInPanel(WORKSPACE_NAVIGATOR_PANEL_MANIFEST, createWorkspaceNavigatorPanel());
@@ -1358,8 +1356,7 @@ async function main(): Promise<void> {
   }
 
   function syncNativeVoiceSettings(): void {
-    const settings = getPrimaryChatInputRuntime()?.getVoiceSettings() ?? initialVoiceSettings;
-    nativeVoiceSettingsSync.request(settings);
+    nativeVoiceSettingsSync.request(getCurrentVoiceSettings());
   }
 
   function applyVoiceSettingsToChatInputs(settings: VoiceSettings): void {
@@ -1684,7 +1681,6 @@ async function main(): Promise<void> {
     runtime: ChatRuntime;
     dom: ChatPanelDom;
     host: PanelHost;
-    init: PanelInitOptions;
   }): () => void {
     const { runtime, dom, host } = options;
     const panelId = host.panelId();
@@ -2747,8 +2743,7 @@ async function main(): Promise<void> {
 
   panelHostControllerInstance.setContext(CHAT_PANEL_SERVICES_CONTEXT_KEY, {
     getRuntimeOptions: getChatRuntimeOptions,
-    registerChatPanel: ({ runtime, dom, host, init }) =>
-      registerChatPanelRuntime({ runtime, dom, host, init }),
+    registerChatPanel: ({ runtime, dom, host }) => registerChatPanelRuntime({ runtime, dom, host }),
   } satisfies ChatPanelServices);
 
   await fetchPlugins();
@@ -3911,6 +3906,7 @@ async function main(): Promise<void> {
   });
   settingsDropdownController.attach();
   const closeVoiceSettingsModal = (): void => {
+    sessionPickerController?.close();
     clearVoiceSettingsDeviceRefreshTimers();
     voiceSettingsModalEl.hidden = true;
     voiceSettingsModalEl.style.display = 'none';
@@ -3966,9 +3962,6 @@ async function main(): Promise<void> {
   voiceSettingsButtonEl.addEventListener('click', () => {
     openVoiceSettingsModal();
   });
-  const syncVoiceSettingsFromCurrentInputs = (): void => {
-    syncVoiceSettingsFromInputs();
-  };
   [
     audioModeSelectEl,
     autoListenCheckboxEl,
@@ -3986,7 +3979,7 @@ async function main(): Promise<void> {
     voiceStartupPreRollSliderEl,
     voiceTtsGainSliderEl,
   ].forEach((control) => {
-    control.addEventListener('change', syncVoiceSettingsFromCurrentInputs);
+    control.addEventListener('change', () => syncVoiceSettingsFromInputs());
   });
   voicePreferredSessionButtonEl.addEventListener('click', () => {
     const settings = getCurrentVoiceSettings();

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -171,7 +171,6 @@ const PROTOCOL_VERSION = CURRENT_PROTOCOL_VERSION;
 
 const RECONNECT_DELAY_MS = 2000;
 const MAX_RECONNECT_DELAY_MS = 30000;
-const WS_DEBUG_STORAGE_KEY = 'aiAssistantWsDebug';
 const WINDOW_ID = getClientWindowId();
 let stopWindowSlotHeartbeat: (() => void) | null = null;
 const startHeartbeat = (): void => {
@@ -185,18 +184,6 @@ const stopHeartbeat = (): void => {
   stopWindowSlotHeartbeat = null;
 };
 startHeartbeat();
-
-const isDebugFlagEnabled = (key: string): boolean => {
-  if (typeof window === 'undefined') {
-    return false;
-  }
-  try {
-    const stored = window.localStorage?.getItem(key);
-    return stored === '1' || stored === 'true';
-  } catch {
-    return false;
-  }
-};
 
 const logWsMessage = (_message: ServerMessage): void => {};
 
@@ -541,7 +528,8 @@ async function main(): Promise<void> {
     standaloneNotificationPlaybackCheckbox: standaloneNotificationPlaybackCheckboxEl,
     notificationTitlePlaybackCheckbox: notificationTitlePlaybackCheckboxEl,
     voiceAdapterBaseUrlInput: voiceAdapterBaseUrlInputEl,
-    voicePreferredSessionSelect: voicePreferredSessionSelectEl,
+    voicePreferredSessionButton: voicePreferredSessionButtonEl,
+    voicePreferredSessionLabel: voicePreferredSessionLabelEl,
     voiceTtsPreferredSessionOnlyCheckbox: voiceTtsPreferredSessionOnlyCheckboxEl,
     voiceMicInputSelect: voiceMicInputSelectEl,
     voiceRecognitionStartTimeoutInput: voiceRecognitionStartTimeoutInputEl,
@@ -1093,46 +1081,34 @@ async function main(): Promise<void> {
     return true;
   }
 
-  function syncPreferredVoiceSessionOptions(): void {
-    const selectEl = voicePreferredSessionSelectEl;
-    const settings = getPrimaryChatInputRuntime()?.getVoiceSettings() ?? initialVoiceSettings;
+  function getCurrentVoiceSettings(): VoiceSettings {
+    return getPrimaryChatInputRuntime()?.getVoiceSettings() ?? currentVoiceSettings;
+  }
+
+  function getPreferredVoiceSessionLabel(settings: VoiceSettings): string {
     const selectedSessionId = settings.preferredVoiceSessionId;
-    const existingValues = new Set<string>();
-    selectEl.replaceChildren();
-
-    const noneOption = document.createElement('option');
-    noneOption.value = '';
-    noneOption.textContent = 'None';
-    selectEl.appendChild(noneOption);
-    existingValues.add('');
-
-    for (const summary of sessionSummaries) {
-      if (existingValues.has(summary.sessionId)) {
-        continue;
-      }
-      const option = document.createElement('option');
-      option.value = summary.sessionId;
-      option.textContent = getSessionLabel(summary.sessionId);
-      selectEl.appendChild(option);
-      existingValues.add(summary.sessionId);
+    if (!selectedSessionId) {
+      return 'None';
     }
+    const exists = sessionSummaries.some((summary) => summary.sessionId === selectedSessionId);
+    return exists
+      ? getSessionLabel(selectedSessionId)
+      : `Unavailable session (${selectedSessionId})`;
+  }
 
-    if (selectedSessionId && !existingValues.has(selectedSessionId)) {
-      const unavailableOption = document.createElement('option');
-      unavailableOption.value = selectedSessionId;
-      unavailableOption.textContent = `Unavailable session (${selectedSessionId})`;
-      selectEl.appendChild(unavailableOption);
-    }
-
-    selectEl.value = selectedSessionId;
-    if (selectEl.value !== selectedSessionId) {
-      selectEl.value = '';
-    }
+  function syncPreferredVoiceSessionControl(): void {
+    const settings = getCurrentVoiceSettings();
+    const label = getPreferredVoiceSessionLabel(settings);
+    voicePreferredSessionLabelEl.textContent = label;
+    voicePreferredSessionButtonEl.title = label;
+    voicePreferredSessionButtonEl.setAttribute(
+      'aria-label',
+      `Voice notification session: ${label}`,
+    );
   }
 
   function clearMissingPreferredVoiceSession(): void {
-    const currentSettings =
-      getPrimaryChatInputRuntime()?.getVoiceSettings() ?? initialVoiceSettings;
+    const currentSettings = getCurrentVoiceSettings();
     const preferredSessionId = currentSettings.preferredVoiceSessionId;
     if (!preferredSessionId) {
       return;
@@ -1710,7 +1686,7 @@ async function main(): Promise<void> {
     host: PanelHost;
     init: PanelInitOptions;
   }): () => void {
-    const { runtime, dom, host, init } = options;
+    const { runtime, dom, host } = options;
     const panelId = host.panelId();
     let bindingSessionId: string | null = null;
     const inputRuntime = createInputRuntime({
@@ -3252,7 +3228,7 @@ async function main(): Promise<void> {
         }
       }
       clearMissingPreferredVoiceSession();
-      syncPreferredVoiceSessionOptions();
+      syncPreferredVoiceSessionControl();
       syncNativeSessionTitles();
       syncSessionContext();
       for (const sessionId of currentModelBySession.keys()) {
@@ -3264,7 +3240,7 @@ async function main(): Promise<void> {
     },
     setAgentSummaries: (agents) => {
       agentSummaries = agents;
-      syncPreferredVoiceSessionOptions();
+      syncPreferredVoiceSessionControl();
       syncNativeSessionTitles();
       syncSessionContext();
     },
@@ -3951,9 +3927,8 @@ async function main(): Promise<void> {
     scheduleVoiceSettingsNativeInputDeviceRefreshes();
     audioModeSelectEl.focus();
   };
-  const syncVoiceSettingsFromInputs = (): void => {
-    const currentSettings =
-      getPrimaryChatInputRuntime()?.getVoiceSettings() ?? initialVoiceSettings;
+  const syncVoiceSettingsFromInputs = (overrides?: Partial<VoiceSettings>): void => {
+    const currentSettings = getCurrentVoiceSettings();
     const nextSettings = normalizeVoiceSettings({
       ...currentSettings,
       audioMode: audioModeSelectEl.value,
@@ -3966,7 +3941,7 @@ async function main(): Promise<void> {
       recognitionCompletionTimeoutMs: voiceRecognitionCompletionTimeoutInputEl.value,
       recognitionEndSilenceMs: voiceRecognitionEndSilenceInputEl.value,
       recognizeStopCommandEnabled: voiceRecognizeStopCommandCheckboxEl.checked,
-      preferredVoiceSessionId: voicePreferredSessionSelectEl.value,
+      preferredVoiceSessionId: currentSettings.preferredVoiceSessionId,
       ttsPreferredSessionOnly: voiceTtsPreferredSessionOnlyCheckboxEl.checked,
       recognitionCueEnabled: voiceRecognitionCueCheckboxEl.checked,
       recognitionCueGain: recognitionCueGainPercentToValue(
@@ -3978,48 +3953,68 @@ async function main(): Promise<void> {
         currentSettings.startupPreRollMs,
       ),
       ttsGain: ttsGainPercentToValue(voiceTtsGainSliderEl.value, currentSettings.ttsGain),
+      ...overrides,
     });
     if (areVoiceSettingsEqual(currentSettings, nextSettings)) {
+      syncPreferredVoiceSessionControl();
       return;
     }
     applyVoiceSettingsToChatInputs(nextSettings);
+    syncPreferredVoiceSessionControl();
   };
   closeVoiceSettingsModal();
   voiceSettingsButtonEl.addEventListener('click', () => {
     openVoiceSettingsModal();
   });
-  audioModeSelectEl.addEventListener('change', syncVoiceSettingsFromInputs);
-  autoListenCheckboxEl.addEventListener('change', syncVoiceSettingsFromInputs);
-  standaloneNotificationPlaybackCheckboxEl.addEventListener('change', syncVoiceSettingsFromInputs);
-  notificationTitlePlaybackCheckboxEl.addEventListener('change', syncVoiceSettingsFromInputs);
-  voiceAdapterBaseUrlInputEl.addEventListener('change', syncVoiceSettingsFromInputs);
-  voicePreferredSessionSelectEl.addEventListener('change', syncVoiceSettingsFromInputs);
-  voiceTtsPreferredSessionOnlyCheckboxEl.addEventListener('change', syncVoiceSettingsFromInputs);
-  voiceMicInputSelectEl.addEventListener('change', syncVoiceSettingsFromInputs);
-  voiceRecognitionStartTimeoutInputEl.addEventListener('change', syncVoiceSettingsFromInputs);
-  voiceRecognitionCompletionTimeoutInputEl.addEventListener('change', syncVoiceSettingsFromInputs);
-  voiceRecognitionEndSilenceInputEl.addEventListener('change', syncVoiceSettingsFromInputs);
-  voiceRecognizeStopCommandCheckboxEl.addEventListener('change', syncVoiceSettingsFromInputs);
-  voiceRecognitionCueCheckboxEl.addEventListener('change', syncVoiceSettingsFromInputs);
+  const syncVoiceSettingsFromCurrentInputs = (): void => {
+    syncVoiceSettingsFromInputs();
+  };
+  [
+    audioModeSelectEl,
+    autoListenCheckboxEl,
+    standaloneNotificationPlaybackCheckboxEl,
+    notificationTitlePlaybackCheckboxEl,
+    voiceAdapterBaseUrlInputEl,
+    voiceTtsPreferredSessionOnlyCheckboxEl,
+    voiceMicInputSelectEl,
+    voiceRecognitionStartTimeoutInputEl,
+    voiceRecognitionCompletionTimeoutInputEl,
+    voiceRecognitionEndSilenceInputEl,
+    voiceRecognizeStopCommandCheckboxEl,
+    voiceRecognitionCueCheckboxEl,
+    voiceRecognitionCueGainSliderEl,
+    voiceStartupPreRollSliderEl,
+    voiceTtsGainSliderEl,
+  ].forEach((control) => {
+    control.addEventListener('change', syncVoiceSettingsFromCurrentInputs);
+  });
+  voicePreferredSessionButtonEl.addEventListener('click', () => {
+    const settings = getCurrentVoiceSettings();
+    openSessionPicker({
+      anchor: voicePreferredSessionButtonEl,
+      title: 'Select voice notification session',
+      selectedSessionId: settings.preferredVoiceSessionId,
+      clearSelectionLabel: 'None',
+      onSelectClearSelection: () => {
+        syncVoiceSettingsFromInputs({ preferredVoiceSessionId: '' });
+      },
+      onSelectSession: (sessionId) => {
+        syncVoiceSettingsFromInputs({ preferredVoiceSessionId: sessionId });
+      },
+    });
+  });
   voiceRecognitionCueGainSliderEl.addEventListener('input', syncRecognitionCueGainLabelFromSlider);
-  voiceRecognitionCueGainSliderEl.addEventListener('change', syncVoiceSettingsFromInputs);
   voiceStartupPreRollSliderEl.addEventListener('input', syncStartupPreRollLabelFromSlider);
-  voiceStartupPreRollSliderEl.addEventListener('change', syncVoiceSettingsFromInputs);
   voiceTtsGainSliderEl.addEventListener('input', syncTtsGainLabelFromSlider);
-  voiceTtsGainSliderEl.addEventListener('change', syncVoiceSettingsFromInputs);
   const resetVoiceSettingsInputs = (): void => {
-    const settings = getPrimaryChatInputRuntime()?.getVoiceSettings() ?? initialVoiceSettings;
+    const settings = getCurrentVoiceSettings();
     audioModeSelectEl.value = settings.audioMode;
     autoListenCheckboxEl.checked = settings.autoListenEnabled;
     standaloneNotificationPlaybackCheckboxEl.checked =
       settings.standaloneNotificationPlaybackEnabled;
     notificationTitlePlaybackCheckboxEl.checked = settings.notificationTitlePlaybackEnabled;
     voiceAdapterBaseUrlInputEl.value = settings.voiceAdapterBaseUrl;
-    syncPreferredVoiceSessionOptions();
-    voicePreferredSessionSelectEl.value = settings.preferredVoiceSessionId;
-    if (voicePreferredSessionSelectEl.value !== settings.preferredVoiceSessionId) {
-      voicePreferredSessionSelectEl.value = '';
-    }
+    syncPreferredVoiceSessionControl();
     voiceTtsPreferredSessionOnlyCheckboxEl.checked = settings.ttsPreferredSessionOnly;
     voiceMicInputSelectEl.value = settings.selectedMicDeviceId;
     if (voiceMicInputSelectEl.value !== settings.selectedMicDeviceId) {

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -3984,11 +3984,14 @@ async function main(): Promise<void> {
   voicePreferredSessionButtonEl.addEventListener('click', () => {
     const settings = getCurrentVoiceSettings();
     const useMobilePickerPlacement = isMobileViewport();
+    const voiceSettingsDialogEl =
+      voicePreferredSessionButtonEl.closest<HTMLElement>('.voice-settings-dialog');
     openSessionPicker({
       anchor: voicePreferredSessionButtonEl,
       title: 'Select voice notification session',
       autoFocusSearch: !useMobilePickerPlacement,
       placement: useMobilePickerPlacement ? 'viewport-top' : 'anchor',
+      placementContainer: useMobilePickerPlacement ? voiceSettingsDialogEl : null,
       selectedSessionId: settings.preferredVoiceSessionId,
       clearSelectionLabel: 'None',
       onSelectClearSelection: () => {

--- a/packages/web-client/src/utils/webClientElements.test.ts
+++ b/packages/web-client/src/utils/webClientElements.test.ts
@@ -35,7 +35,9 @@ describe('getWebClientElements', () => {
       'notification-title-playback-checkbox',
     );
     expect(elements?.voiceAdapterBaseUrlInput.id).toBe('voice-adapter-base-url-input');
-    expect(elements?.voicePreferredSessionSelect.id).toBe('voice-preferred-session-select');
+    expect(elements?.voicePreferredSessionButton.id).toBe('voice-preferred-session-button');
+    expect(elements?.voicePreferredSessionLabel.id).toBe('voice-preferred-session-label');
+    expect(document.getElementById('voice-preferred-session-select')).toBeNull();
     expect(elements?.voiceTtsPreferredSessionOnlyCheckbox.id).toBe(
       'voice-tts-preferred-session-only-checkbox',
     );
@@ -91,7 +93,9 @@ describe('getWebClientElements', () => {
     );
     expect(recognizeStopCommandControl?.hasAttribute('hidden')).toBe(true);
 
-    const startupPreRollControl = dom.window.document.getElementById('voice-startup-pre-roll-control');
+    const startupPreRollControl = dom.window.document.getElementById(
+      'voice-startup-pre-roll-control',
+    );
     expect(startupPreRollControl?.hasAttribute('hidden')).toBe(true);
 
     const ttsGainControl = dom.window.document.getElementById('voice-tts-gain-control');

--- a/packages/web-client/src/utils/webClientElements.ts
+++ b/packages/web-client/src/utils/webClientElements.ts
@@ -9,7 +9,8 @@ export interface WebClientElements {
   standaloneNotificationPlaybackCheckbox: HTMLInputElement;
   notificationTitlePlaybackCheckbox: HTMLInputElement;
   voiceAdapterBaseUrlInput: HTMLInputElement;
-  voicePreferredSessionSelect: HTMLSelectElement;
+  voicePreferredSessionButton: HTMLButtonElement;
+  voicePreferredSessionLabel: HTMLElement;
   voiceTtsPreferredSessionOnlyCheckbox: HTMLInputElement;
   voiceMicInputSelect: HTMLSelectElement;
   voiceRecognitionStartTimeoutInput: HTMLInputElement;
@@ -93,9 +94,10 @@ export function getWebClientElements(): WebClientElements | null {
     'notification-title-playback-checkbox',
   );
   const voiceAdapterBaseUrlInput = getElement<HTMLInputElement>('voice-adapter-base-url-input');
-  const voicePreferredSessionSelect = getElement<HTMLSelectElement>(
-    'voice-preferred-session-select',
+  const voicePreferredSessionButton = getElement<HTMLButtonElement>(
+    'voice-preferred-session-button',
   );
+  const voicePreferredSessionLabel = getElement<HTMLElement>('voice-preferred-session-label');
   const voiceTtsPreferredSessionOnlyCheckbox = getElement<HTMLInputElement>(
     'voice-tts-preferred-session-only-checkbox',
   );
@@ -163,7 +165,8 @@ export function getWebClientElements(): WebClientElements | null {
     !standaloneNotificationPlaybackCheckbox ||
     !notificationTitlePlaybackCheckbox ||
     !voiceAdapterBaseUrlInput ||
-    !voicePreferredSessionSelect ||
+    !voicePreferredSessionButton ||
+    !voicePreferredSessionLabel ||
     !voiceTtsPreferredSessionOnlyCheckbox ||
     !voiceMicInputSelect ||
     !voiceRecognitionStartTimeoutInput ||
@@ -203,7 +206,8 @@ export function getWebClientElements(): WebClientElements | null {
     standaloneNotificationPlaybackCheckbox,
     notificationTitlePlaybackCheckbox,
     voiceAdapterBaseUrlInput,
-    voicePreferredSessionSelect,
+    voicePreferredSessionButton,
+    voicePreferredSessionLabel,
     voiceTtsPreferredSessionOnlyCheckbox,
     voiceMicInputSelect,
     voiceRecognitionStartTimeoutInput,


### PR DESCRIPTION
## Summary
- Replace the Voice Settings native preferred-session select with the shared searchable session picker.
- Add an explicit `None` clear row to `SessionPickerController` for nullable session settings.
- Keep `VoiceSettings.preferredVoiceSessionId` as the persisted setting and preserve native voice settings sync.

## Validation
- `npx vitest --run packages/web-client/src/controllers/panelSessionPicker.test.ts packages/web-client/src/utils/webClientElements.test.ts`
- `npm run build -w @assistant/web-client`
- `npx eslint packages/web-client/src/controllers/panelSessionPicker.ts packages/web-client/src/controllers/panelSessionPicker.test.ts packages/web-client/src/index.ts packages/web-client/src/utils/webClientElements.ts packages/web-client/src/utils/webClientElements.test.ts`
- `npx prettier --check docs/UI_SPEC.md packages/web-client/public/index.html packages/web-client/public/styles.css packages/web-client/src/controllers/panelSessionPicker.ts packages/web-client/src/controllers/panelSessionPicker.test.ts packages/web-client/src/index.ts packages/web-client/src/utils/webClientElements.ts packages/web-client/src/utils/webClientElements.test.ts`

## Notes
- Root `npm run lint`, `npm run format`, `npm test`, and broad web-client Vitest were rerun and still fail on existing unrelated repo issues/OOMs; feature-scoped checks pass.
- Internal review run `2w3h4a` approved for ship after delta fixes.
