### PR TITLE
Fix session picker label search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 ### Fixed
 
+- Fixed chat session picker search so existing sessions match only the displayed label and session id prefix, not hidden agent metadata. ([#101](https://github.com/kcosr/assistant/pull/101))
 - Fixed note edit compact mode to collapse title/description/tag/pinned/favorite rows and fixed split-pane drag resizing to preserve the visible bottom of chat transcripts while resizing stacked panels. ([#97](https://github.com/kcosr/assistant/pull/97))
 - Fixed header dock + button to pin panels to header instead of adding tabs (regression from e6353e8), and fixed compact panel launcher positioning to anchor below the clicked button. ([#96](https://github.com/kcosr/assistant/pull/96))
 - Fixed Android Capacitor status bar styling so native status bar icons/text now follow the effective web light/dark theme, including live updates for `auto` system theme changes. ([#95](https://github.com/kcosr/assistant/pull/95))

--- a/docs/UI_SPEC.md
+++ b/docs/UI_SPEC.md
@@ -85,6 +85,8 @@ Each panel renders inside a standardized frame:
 Binding indicator behavior:
 
 - Chat panels show a session picker dropdown with search, keyboard navigation, and sections for Unbound (optional), Sessions, and New session
+- Existing session search matches the displayed session label (explicit name, auto title, or fallback
+  agent label) and session id prefix; New session options match agent display names.
 - Session rows expose actions: rename, clear history, and delete (hover-revealed on desktop; sub-menu on touch devices)
 - Panels do not implicitly follow a global "active session"; chat binding is explicit
 - Non-chat panels do not expose session binding controls

--- a/packages/agent-server/src/notificationProducers.ts
+++ b/packages/agent-server/src/notificationProducers.ts
@@ -20,12 +20,8 @@ export async function publishFinalResponseNotification(options: {
   if (!options.text.trim()) {
     return;
   }
+  const sessionIndex = options.sessionIndex ?? options.sessionHub?.getSessionIndex();
   try {
-    const sessionIndex =
-      options.sessionIndex ??
-      (typeof options.sessionHub?.getSessionIndex === 'function'
-        ? options.sessionHub.getSessionIndex()
-        : undefined);
     await createNotificationRecord({
       input: {
         kind: 'session_attention',

--- a/packages/agent-server/src/notificationProducers.ts
+++ b/packages/agent-server/src/notificationProducers.ts
@@ -20,8 +20,12 @@ export async function publishFinalResponseNotification(options: {
   if (!options.text.trim()) {
     return;
   }
-  const sessionIndex = options.sessionIndex ?? options.sessionHub?.getSessionIndex();
   try {
+    const sessionIndex =
+      options.sessionIndex ??
+      (typeof options.sessionHub?.getSessionIndex === 'function'
+        ? options.sessionHub.getSessionIndex()
+        : undefined);
     await createNotificationRecord({
       input: {
         kind: 'session_attention',

--- a/packages/web-client/src/controllers/panelSessionPicker.test.ts
+++ b/packages/web-client/src/controllers/panelSessionPicker.test.ts
@@ -250,6 +250,77 @@ describe('SessionPickerController', () => {
     controller.close();
   });
 
+  it('searches existing sessions by effective label without hidden agent terms', () => {
+    const controller = new SessionPickerController({
+      getSessionSummaries: () => [
+        {
+          sessionId: 'named-01',
+          name: 'Project Notes',
+          agentId: 'assistant',
+        },
+        {
+          sessionId: 'auto-001',
+          agentId: 'assistant',
+          attributes: {
+            core: { autoTitle: 'Sprint Review' },
+          },
+        },
+        {
+          sessionId: 'fallback-01',
+          agentId: 'assistant',
+        },
+        {
+          sessionId: 'idmatch1-session',
+          name: 'Quarterly Plan',
+          agentId: 'assistant',
+        },
+      ],
+      getAgentSummaries: () => [{ agentId: 'assistant', displayName: 'Assistant' }],
+      openSessionComposer: vi.fn(),
+    });
+
+    const anchor = document.createElement('button');
+    document.body.appendChild(anchor);
+
+    controller.open({
+      anchor,
+      title: 'Sessions',
+      onSelectSession: () => undefined,
+    });
+
+    const searchInput = document.querySelector<HTMLInputElement>('.session-picker-search');
+    expect(searchInput).toBeTruthy();
+
+    searchInput!.value = 'assistant';
+    searchInput!.dispatchEvent(new Event('input', { bubbles: true }));
+
+    const matchingSessionLabels = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        '.session-picker-item[data-session-id] .session-picker-item-label',
+      ),
+    ).map((item) => item.textContent);
+    expect(matchingSessionLabels).toEqual(['Assistant (fallback)']);
+
+    const newSessionLabels = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        '.session-picker-item:not([data-session-id]) .session-picker-item-label',
+      ),
+    ).map((item) => item.textContent);
+    expect(newSessionLabels).toContain('Assistant');
+
+    searchInput!.value = 'idmatch1';
+    searchInput!.dispatchEvent(new Event('input', { bubbles: true }));
+
+    const idPrefixSessionLabels = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        '.session-picker-item[data-session-id] .session-picker-item-label',
+      ),
+    ).map((item) => item.textContent);
+    expect(idPrefixSessionLabels).toEqual(['Quarterly Plan (idmatch1)']);
+
+    controller.close();
+  });
+
   it('invokes clear from the session row action button', () => {
     const onClearSession = vi.fn();
     const controller = new SessionPickerController({

--- a/packages/web-client/src/controllers/panelSessionPicker.ts
+++ b/packages/web-client/src/controllers/panelSessionPicker.ts
@@ -1,6 +1,6 @@
 import type { CreateSessionOptions } from './sessionManager';
 import type { SessionComposerOpenOptions } from './sessionComposerController';
-import { formatSessionLabel, resolveAutoTitle } from '../utils/sessionLabel';
+import { formatSessionLabel, resolveSessionBaseLabel } from '../utils/sessionLabel';
 import { ICONS } from '../utils/icons';
 
 export interface SessionSummary {
@@ -103,32 +103,13 @@ export class SessionPickerController {
 
     const sessions = this.getOrderedSessions();
     const agentSummaries = this.options.getAgentSummaries();
-    const agentNameById = new Map(
-      agentSummaries
-        .map((agent) => [agent.agentId, agent.displayName] as const)
-        .filter((entry) => entry[0] && entry[1]),
-    );
     const disabled = options.disabledSessionIds ?? new Set<string>();
     const openSessionIds = options.openSessionIds ?? new Set<string>();
 
-    const getAgentLabel = (agentId?: string): string => {
-      const trimmed = typeof agentId === 'string' ? agentId.trim() : '';
-      if (!trimmed) {
-        return '';
-      }
-      return agentNameById.get(trimmed) ?? trimmed;
-    };
-
     const getSessionSearchLabel = (summary: SessionSummary): string => {
-      const name = typeof summary.name === 'string' ? summary.name.trim() : '';
-      const autoTitle = resolveAutoTitle(summary.attributes);
-      const agentId = typeof summary.agentId === 'string' ? summary.agentId.trim() : '';
-      const agentLabel = getAgentLabel(agentId);
+      const baseLabel = resolveSessionBaseLabel(summary, agentSummaries);
       const idPrefix = summary.sessionId.slice(0, 8);
-      return [name, autoTitle, agentLabel, agentId, idPrefix]
-        .filter(Boolean)
-        .join(' ')
-        .toLowerCase();
+      return [baseLabel, idPrefix].filter(Boolean).join(' ').toLowerCase();
     };
 
     const getAgentSearchLabel = (summary: AgentSummary): string => {


### PR DESCRIPTION
## Summary
- Change existing-session search to use the effective displayed session label plus session id prefix
- Keep New session agent options searchable by agent display name
- Add focused picker coverage and update UI spec docs

## Validation
- npm test -- packages/web-client/src/controllers/panelSessionPicker.test.ts
- npm run build -w @assistant/web-client
- npm run build
- npx eslint packages/web-client/src/controllers/panelSessionPicker.ts packages/web-client/src/controllers/panelSessionPicker.test.ts
- npx prettier --check docs/UI_SPEC.md packages/web-client/src/controllers/panelSessionPicker.ts packages/web-client/src/controllers/panelSessionPicker.test.ts

Known baseline accepted for this run: root npm test, npm run lint, and npm run format currently fail on unrelated repository-wide baseline issues documented in task-runner run 6xcban.
