### PR TITLE
Support Pi custom model runtime config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Added
 
-- Added Pi SDK custom-model config support for `api`, `authHeader`, `compat`, synthesized model metadata, and compaction so Assistant agents can target OpenAI-compatible endpoints that need Pi compatibility flags.
+- Added Pi SDK custom-model config support for `api`, `authHeader`, `compat`, synthesized model metadata, and compaction so Assistant agents can target OpenAI-compatible endpoints that need Pi compatibility flags. ([#102](https://github.com/kcosr/assistant/pull/102))
 - Added Pi SDK session context compaction with Pi-compatible JSONL `compaction` entries, manual chat menu/API compaction, effective replay context, and threshold auto-compaction. ([#98](https://github.com/kcosr/assistant/pull/98))
 - Added core notifications panel plugin with server-side storage, tool/HTTP/CLI ingress, live WebSocket panel updates, All/Unread filtering, Card/Compact density modes, read/unread toggle, session-linked navigation with resolved session titles, overflow menu for bulk actions, and panel tab unread-count badge. ([#96](https://github.com/kcosr/assistant/pull/96))
 - Added bang shell command feature (`!command`) for executing shell commands directly in chat with real-time streaming output, dedicated terminal bubble rendering, and `_assistant_` prefix LLM suppression. Gated behind `bangCommandEnabled` agent config flag (default: false). ([#94](https://github.com/kcosr/assistant/pull/94))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Added Pi SDK custom-model config support for `api`, `authHeader`, `compat`, and synthesized model metadata so Assistant agents can target OpenAI-compatible endpoints that need Pi compatibility flags.
 - Added Pi SDK session context compaction with Pi-compatible JSONL `compaction` entries, manual chat menu/API compaction, effective replay context, and threshold auto-compaction. ([#98](https://github.com/kcosr/assistant/pull/98))
 - Added core notifications panel plugin with server-side storage, tool/HTTP/CLI ingress, live WebSocket panel updates, All/Unread filtering, Card/Compact density modes, read/unread toggle, session-linked navigation with resolved session titles, overflow menu for bulk actions, and panel tab unread-count badge. ([#96](https://github.com/kcosr/assistant/pull/96))
 - Added bang shell command feature (`!command`) for executing shell commands directly in chat with real-time streaming output, dedicated terminal bubble rendering, and `_assistant_` prefix LLM suppression. Gated behind `bangCommandEnabled` agent config flag (default: false). ([#94](https://github.com/kcosr/assistant/pull/94))
@@ -68,7 +69,6 @@
 
 ### Removed
 
-
 ## [0.18.1] - 2026-04-05
 
 ### Breaking Changes
@@ -89,7 +89,6 @@
 - Fixed panel inventory and `panels_selected` to report the actual active chat tab as the selected panel instead of surfacing a stale `empty` placeholder when chat is focused.
 
 ### Removed
-
 
 ## [0.18.0] - 2026-04-05
 
@@ -112,6 +111,7 @@
 - Added installable PWA icons to the mobile web manifest so the mobile app can be added to a home screen with proper `any maskable` icon sizes from 48px through 512px.
 
 ### Changed
+
 - Allowed Pi-backed agents to target custom `provider/model` ids through `chat.config.baseUrl` by
   synthesizing an `openai-responses` model when the provider has no built-in Pi model catalog.
 - Changed Android share-intent chat destinations to prefer the configured native voice session
@@ -161,7 +161,6 @@
 - Removed dead Pi EventStore overlay mirroring; Pi sessions now ignore EventStore persistence on the canonical path instead of duplicating overlay writes into the Pi transcript log.
 - Removed the dead Pi `ChatEvent` reconstruction helper and stale Pi history-provider test matrix; Pi replay validation now targets canonical transcript projection only.
 - Removed Pi replay support for legacy assistant overlay custom entries; canonical replay now restores only from canonical Pi `message` records plus request-boundary markers.
-
 
 ## [0.17.5] - 2026-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Added
 
-- Added Pi SDK custom-model config support for `api`, `authHeader`, `compat`, and synthesized model metadata so Assistant agents can target OpenAI-compatible endpoints that need Pi compatibility flags.
+- Added Pi SDK custom-model config support for `api`, `authHeader`, `compat`, synthesized model metadata, and compaction so Assistant agents can target OpenAI-compatible endpoints that need Pi compatibility flags.
 - Added Pi SDK session context compaction with Pi-compatible JSONL `compaction` entries, manual chat menu/API compaction, effective replay context, and threshold auto-compaction. ([#98](https://github.com/kcosr/assistant/pull/98))
 - Added core notifications panel plugin with server-side storage, tool/HTTP/CLI ingress, live WebSocket panel updates, All/Unread filtering, Card/Compact density modes, read/unread toggle, session-linked navigation with resolved session titles, overflow menu for bulk actions, and panel tab unread-count badge. ([#96](https://github.com/kcosr/assistant/pull/96))
 - Added bang shell command feature (`!command`) for executing shell commands directly in chat with real-time streaming output, dedicated terminal bubble rendering, and `_assistant_` prefix LLM suppression. Gated behind `bangCommandEnabled` agent config flag (default: false). ([#94](https://github.com/kcosr/assistant/pull/94))
@@ -69,6 +69,7 @@
 
 ### Removed
 
+
 ## [0.18.1] - 2026-04-05
 
 ### Breaking Changes
@@ -89,6 +90,7 @@
 - Fixed panel inventory and `panels_selected` to report the actual active chat tab as the selected panel instead of surfacing a stale `empty` placeholder when chat is focused.
 
 ### Removed
+
 
 ## [0.18.0] - 2026-04-05
 
@@ -111,7 +113,6 @@
 - Added installable PWA icons to the mobile web manifest so the mobile app can be added to a home screen with proper `any maskable` icon sizes from 48px through 512px.
 
 ### Changed
-
 - Allowed Pi-backed agents to target custom `provider/model` ids through `chat.config.baseUrl` by
   synthesizing an `openai-responses` model when the provider has no built-in Pi model catalog.
 - Changed Android share-intent chat destinations to prefer the configured native voice session
@@ -161,6 +162,7 @@
 - Removed dead Pi EventStore overlay mirroring; Pi sessions now ignore EventStore persistence on the canonical path instead of duplicating overlay writes into the Pi transcript log.
 - Removed the dead Pi `ChatEvent` reconstruction helper and stale Pi history-provider test matrix; Pi replay validation now targets canonical transcript projection only.
 - Removed Pi replay support for legacy assistant overlay custom entries; canonical replay now restores only from canonical Pi `message` records plus request-boundary markers.
+
 
 ## [0.17.5] - 2026-04-01
 

--- a/packages/agent-server/README.md
+++ b/packages/agent-server/README.md
@@ -1010,18 +1010,18 @@ Agents are configured in `config.json` under `agents`. Each agent supports:
   - `config`:
     - for `provider: "pi"`:
       - `provider` (optional): default provider used when a model omits a prefix (required if any model omits a prefix)
-      - `api` (optional): API implementation for synthesized custom models, such as `openai-completions` for OpenAI-compatible Chat Completions endpoints. Defaults to `openai-responses`.
+      - `api` (optional): API implementation for synthesized custom models, such as `openai-completions` for OpenAI-compatible Chat Completions endpoints. Defaults to `openai-responses`; must be one of the Pi SDK built-in API implementations.
       - `apiKey` (optional): API key override for the configured provider
       - `authHeader` (optional): when `true`, also sends `Authorization: Bearer <apiKey>` in request headers, matching Pi `models.json` behavior
       - `baseUrl` (optional): base URL override for the configured provider
         - when `baseUrl` is set and the resolved provider has no built-in Pi model list, the server synthesizes a model for the configured `provider/model` id so custom endpoints can be targeted without adding new config fields
       - `headers` (optional): custom HTTP headers to send with each request
-      - `compat` (optional): Pi model compatibility overrides such as `supportsDeveloperRole`, `supportsReasoningEffort`, `supportsUsageInStreaming`, `maxTokensField`, and `thinkingFormat`
+      - `compat` (optional): validated Pi model compatibility overrides such as `supportsDeveloperRole`, `supportsReasoningEffort`, `supportsUsageInStreaming`, `maxTokensField`, and `thinkingFormat`
       - connection overrides apply only when the resolved provider matches `config.provider`
       - `timeoutMs` (optional): request timeout in milliseconds
       - `maxTokens` (optional): positive integer completion limit
-      - `contextWindow` (optional): context-window override for synthesized models (used when `baseUrl` is set and provider has no built-in Pi model catalog entry)
-      - `reasoning`, `input`, and `cost` (optional): model metadata overrides for synthesized custom models
+      - `contextWindow` (optional): context-window override for resolved Pi models, including synthesized custom models
+      - `reasoning`, `input`, and `cost` (optional): model metadata overrides for resolved Pi models, including synthesized custom models
       - `temperature` (optional): temperature to use for generation
       - `maxToolIterations` (optional): max consecutive tool iterations before aborting with an error (default 100)
     - for `provider: "claude-cli"`:

--- a/packages/agent-server/README.md
+++ b/packages/agent-server/README.md
@@ -557,15 +557,15 @@ Plugins can opt into periodic git snapshots of their data directories:
 
 The coding plugin provides tools for working with the configured workspace root. Tools are designed to be safe by default (no path traversal outside the workspace) and to truncate very large outputs.
 
-| Tool    | Description                                                                                     |
-| ------- | ----------------------------------------------------------------------------------------------- |
-| `bash`  | Run a bash command in the workspace root and return combined stdout/stderr (tail‑truncated). |
-| `read`  | Read a text or image file from the workspace root with optional line offsets and limits.     |
-| `write` | Write/overwrite a text file in the workspace root, creating parent directories as needed.    |
-| `edit`  | Replace an exact, unique text span in a file and return a human‑readable diff.                  |
+| Tool    | Description                                                                                             |
+| ------- | ------------------------------------------------------------------------------------------------------- |
+| `bash`  | Run a bash command in the workspace root and return combined stdout/stderr (tail‑truncated).            |
+| `read`  | Read a text or image file from the workspace root with optional line offsets and limits.                |
+| `write` | Write/overwrite a text file in the workspace root, creating parent directories as needed.               |
+| `edit`  | Replace an exact, unique text span in a file and return a human‑readable diff.                          |
 | `ls`    | List directory contents (including dotfiles), sorted alphabetically, with a "/" suffix for directories. |
-| `find`  | Find files by glob pattern. Uses `fd` when available, falling back to Node.js glob.             |
-| `grep`  | Search file contents for a pattern using ripgrep when available, with a Node.js fallback.       |
+| `find`  | Find files by glob pattern. Uses `fd` when available, falling back to Node.js glob.                     |
+| `grep`  | Search file contents for a pattern using ripgrep when available, with a Node.js fallback.               |
 
 #### `grep`
 
@@ -750,8 +750,8 @@ The coding plugin provides tools for working with the configured workspace root 
 | `write` | Write content to a file in the workspace, creating parent directories if needed and overwriting existing files. |
 | `edit`  | Edit a file by replacing an exact text match; the old text must be unique within the file.                      |
 | `ls`    | List directory contents (including dotfiles), sorted alphabetically, with a “/” suffix for directories.         |
-| `find`  | Find files by glob pattern relative to the current workspace, respecting ignore files and truncation limits.     |
-| `grep`  | Search file contents for matching lines with file paths and line numbers, with truncation for large results.     |
+| `find`  | Find files by glob pattern relative to the current workspace, respecting ignore files and truncation limits.    |
+| `grep`  | Search file contents for matching lines with file paths and line numbers, with truncation for large results.    |
 
 `plugins.coding.local.workspaceRoot` may be set to `${session.workingDir}`. When present,
 relative coding-tool paths and `bash` commands resolve from the session’s
@@ -813,10 +813,10 @@ The diff plugin supports instances; object entries can override the base config:
       "workspaceRoot": "/path/to/workspace",
       "instances": [
         "work",
-        { "id": "oss", "label": "Open Source", "workspaceRoot": "/path/to/oss" }
-      ]
-    }
-  }
+        { "id": "oss", "label": "Open Source", "workspaceRoot": "/path/to/oss" },
+      ],
+    },
+  },
 }
 ```
 
@@ -1010,14 +1010,18 @@ Agents are configured in `config.json` under `agents`. Each agent supports:
   - `config`:
     - for `provider: "pi"`:
       - `provider` (optional): default provider used when a model omits a prefix (required if any model omits a prefix)
+      - `api` (optional): API implementation for synthesized custom models, such as `openai-completions` for OpenAI-compatible Chat Completions endpoints. Defaults to `openai-responses`.
       - `apiKey` (optional): API key override for the configured provider
+      - `authHeader` (optional): when `true`, also sends `Authorization: Bearer <apiKey>` in request headers, matching Pi `models.json` behavior
       - `baseUrl` (optional): base URL override for the configured provider
-        - when `baseUrl` is set and the resolved provider has no built-in Pi model list, the server synthesizes an `openai-responses` model for the configured `provider/model` id so custom endpoints can be targeted without adding new config fields
+        - when `baseUrl` is set and the resolved provider has no built-in Pi model list, the server synthesizes a model for the configured `provider/model` id so custom endpoints can be targeted without adding new config fields
       - `headers` (optional): custom HTTP headers to send with each request
+      - `compat` (optional): Pi model compatibility overrides such as `supportsDeveloperRole`, `supportsReasoningEffort`, `supportsUsageInStreaming`, `maxTokensField`, and `thinkingFormat`
       - connection overrides apply only when the resolved provider matches `config.provider`
       - `timeoutMs` (optional): request timeout in milliseconds
       - `maxTokens` (optional): positive integer completion limit
       - `contextWindow` (optional): context-window override for synthesized models (used when `baseUrl` is set and provider has no built-in Pi model catalog entry)
+      - `reasoning`, `input`, and `cost` (optional): model metadata overrides for synthesized custom models
       - `temperature` (optional): temperature to use for generation
       - `maxToolIterations` (optional): max consecutive tool iterations before aborting with an error (default 100)
     - for `provider: "claude-cli"`:

--- a/packages/agent-server/src/agents.ts
+++ b/packages/agent-server/src/agents.ts
@@ -1,3 +1,5 @@
+import type { Api, Model } from '@earendil-works/pi-ai';
+
 export interface CliWrapperConfig {
   /**
    * Command wrapper path for running CLI tools in a container.
@@ -185,12 +187,31 @@ export interface PiSdkChatConfig {
    * Example: "anthropic" for "claude-sonnet-4-5".
    */
   provider?: string;
+  /**
+   * API implementation for synthesized custom Pi models.
+   * Example: "openai-completions" for OpenAI-compatible Chat Completions endpoints.
+   */
+  api?: string;
   apiKey?: string;
+  /**
+   * When true, add `Authorization: Bearer <apiKey>` to request headers.
+   * This mirrors Pi's models.json `authHeader` behavior.
+   */
+  authHeader?: boolean;
   baseUrl?: string;
   headers?: Record<string, string>;
   timeoutMs?: number;
   maxTokens?: number;
   contextWindow?: number;
+  reasoning?: boolean;
+  input?: ('text' | 'image')[];
+  cost?: {
+    input?: number | undefined;
+    output?: number | undefined;
+    cacheRead?: number | undefined;
+    cacheWrite?: number | undefined;
+  };
+  compat?: Model<Api>['compat'];
   temperature?: number;
   maxToolIterations?: number;
   compaction?: {

--- a/packages/agent-server/src/chatProcessor.test.ts
+++ b/packages/agent-server/src/chatProcessor.test.ts
@@ -83,10 +83,42 @@ vi.mock('@earendil-works/pi-agent-core', async () => {
 
 vi.mock('./llm/piSdkProvider', async () => {
   const actual = await vi.importActual<typeof import('./llm/piSdkProvider')>('./llm/piSdkProvider');
+  const resolvePiSdkModel = vi.fn();
+  const resolvePiSdkRuntimeModel = vi.fn(
+    async (options: {
+      modelSpec: string;
+      config?: {
+        provider?: string;
+        apiKey?: string;
+        headers?: Record<string, string>;
+        authHeader?: boolean;
+      };
+    }) => {
+      const resolved = await resolvePiSdkModel({
+        modelSpec: options.modelSpec,
+        ...(options.config?.provider ? { defaultProvider: options.config.provider } : {}),
+      });
+      const headers =
+        options.config?.authHeader && options.config.apiKey
+          ? { ...(options.config.headers ?? {}), Authorization: `Bearer ${options.config.apiKey}` }
+          : options.config?.headers;
+      return {
+        ...resolved,
+        runtimeModel: {
+          ...resolved.model,
+          ...(headers ? { headers } : {}),
+        },
+        providerMatchesConfig: true,
+        ...(options.config?.apiKey ? { apiKey: options.config.apiKey } : {}),
+        ...(headers ? { headers } : {}),
+      };
+    },
+  );
   return {
     ...actual,
     runPiSdkChatCompletionIteration: vi.fn(),
-    resolvePiSdkModel: vi.fn(),
+    resolvePiSdkModel,
+    resolvePiSdkRuntimeModel,
     extractAssistantTextBlocksFromPiMessage: vi.fn(
       (message: { content?: Array<Record<string, unknown>> } | undefined) => {
         const content = Array.isArray(message?.content) ? message.content : [];

--- a/packages/agent-server/src/chatRunCore.ts
+++ b/packages/agent-server/src/chatRunCore.ts
@@ -26,6 +26,7 @@ import {
   type ThinkingLevel as PiAgentThinkingLevel,
 } from '@earendil-works/pi-agent-core';
 import {
+  type Api,
   type AssistantMessage,
   type AssistantMessageEvent,
   type Message as PiSdkMessage,
@@ -784,7 +785,7 @@ function getMessageTimestampMs(
 
 function buildSyntheticAssistantMessage(options: {
   message: Extract<ChatCompletionMessage, { role: 'assistant' }>;
-  model: Model<any>;
+  model: Model<Api>;
 }): AssistantMessage {
   const { message, model } = options;
   const content: Array<TextContent | ToolCall> = [];
@@ -837,7 +838,7 @@ function buildToolNameIndex(messages: ChatCompletionMessage[]): Map<string, stri
 function toPiAgentMessage(options: {
   message: Exclude<ChatCompletionMessage, { role: 'system' }>;
   toolNameIndex: Map<string, string>;
-  model: Model<any>;
+  model: Model<Api>;
 }): AgentMessage {
   const { message, toolNameIndex, model } = options;
   if (message.role === 'user') {
@@ -866,7 +867,7 @@ function toPiAgentMessage(options: {
 function buildPiAgentContext(options: {
   messages: ChatCompletionMessage[];
   text: string;
-  model: Model<any>;
+  model: Model<Api>;
 }): {
   systemPrompt: string;
   contextMessages: AgentMessage[];
@@ -1347,22 +1348,26 @@ export async function runChatCompletionCore(
     let resolvedModel: Awaited<ReturnType<typeof resolvePiSdkModel>>;
     try {
       const defaultProvider = piConfig?.provider;
+      const piModelOverrides = {
+        ...(piConfig?.baseUrl ? { baseUrl: piConfig.baseUrl } : {}),
+        ...(piConfig?.api ? { api: piConfig.api } : {}),
+        ...(piConfig?.contextWindow !== undefined ? { contextWindow: piConfig.contextWindow } : {}),
+        ...(piConfig?.maxTokens !== undefined ? { maxTokens: piConfig.maxTokens } : {}),
+        ...(piConfig?.reasoning !== undefined ? { reasoning: piConfig.reasoning } : {}),
+        ...(piConfig?.input !== undefined ? { input: piConfig.input } : {}),
+        ...(piConfig?.cost !== undefined ? { cost: piConfig.cost } : {}),
+        ...(piConfig?.compat !== undefined ? { compat: piConfig.compat } : {}),
+      };
       resolvedModel =
         defaultProvider === undefined
           ? await resolvePiSdkModel({
               modelSpec,
-              ...(piConfig?.baseUrl ? { baseUrl: piConfig.baseUrl } : {}),
-              ...(piConfig?.contextWindow !== undefined
-                ? { contextWindow: piConfig.contextWindow }
-                : {}),
+              ...piModelOverrides,
             })
           : await resolvePiSdkModel({
               modelSpec,
               defaultProvider,
-              ...(piConfig?.baseUrl ? { baseUrl: piConfig.baseUrl } : {}),
-              ...(piConfig?.contextWindow !== undefined
-                ? { contextWindow: piConfig.contextWindow }
-                : {}),
+              ...piModelOverrides,
             });
     } catch (err) {
       throw new ChatRunError(
@@ -1384,7 +1389,11 @@ export async function runChatCompletionCore(
       ? (piConfig?.apiKey ?? piAgentAuthApiKey)
       : piAgentAuthApiKey;
     const baseUrl = providerMatchesConfig ? piConfig?.baseUrl : undefined;
-    const headers = providerMatchesConfig ? piConfig?.headers : undefined;
+    const configuredHeaders = providerMatchesConfig ? piConfig?.headers : undefined;
+    const headers =
+      providerMatchesConfig && piConfig?.authHeader && apiKey
+        ? { ...configuredHeaders, Authorization: `Bearer ${apiKey}` }
+        : configuredHeaders;
     const canonicalReplayMessages = await loadCanonicalPiReplayMessages({
       summary: state.summary,
     });
@@ -1412,10 +1421,14 @@ export async function runChatCompletionCore(
       ];
     }
 
-    const agentModel: Model<any> = {
+    const agentModel: Model<Api> = {
       ...resolvedModel.model,
+      ...(providerMatchesConfig && piConfig?.api ? { api: piConfig.api } : {}),
       ...(baseUrl ? { baseUrl } : {}),
       ...(headers ? { headers } : {}),
+      ...(providerMatchesConfig && piConfig?.compat !== undefined
+        ? { compat: piConfig.compat }
+        : {}),
     };
     piContextWindow = agentModel.contextWindow;
     type PiRuntimeConfig = {
@@ -1426,7 +1439,7 @@ export async function runChatCompletionCore(
     };
     type PiRuntimeState = {
       requestConfig: PiRuntimeConfig;
-      onPayload?: ((payload: unknown, model: Model<any>) => unknown | Promise<unknown>) | undefined;
+      onPayload?: ((payload: unknown, model: Model<Api>) => unknown | Promise<unknown>) | undefined;
       agent: Agent;
     };
     const piAgentRuntime =

--- a/packages/agent-server/src/chatRunCore.ts
+++ b/packages/agent-server/src/chatRunCore.ts
@@ -9,16 +9,11 @@ import type {
   ServerThinkingDeltaMessage,
   ServerThinkingDoneMessage,
   ServerThinkingStartMessage,
-  ServerToolCallStartMessage,
   ServerToolResultMessage,
 } from '@assistant/shared';
 
 import type { AgentDefinition, PiSdkChatConfig } from './agents';
-import type {
-  ChatCompletionMessage,
-  ChatCompletionToolCallMessageToolCall,
-  ChatCompletionToolCallState,
-} from './chatCompletionTypes';
+import type { ChatCompletionMessage, ChatCompletionToolCallState } from './chatCompletionTypes';
 import {
   Agent,
   type AgentEvent,
@@ -61,11 +56,7 @@ import { resolveCliRuntimeConfig } from './ws/cliRuntimeConfig';
 import { runPiCliChat, type PiCliChatConfig, type PiSessionInfo } from './ws/piCliChat';
 import { buildProviderAttributesPatch, getProviderAttributes } from './history/providerAttributes';
 import { loadCanonicalPiReplayMessages } from './history/piSessionReplay';
-import {
-  parseAssistantTextSignature,
-  resolvePiSdkModel,
-  resolvePiSdkAuthApiKey,
-} from './llm/piSdkProvider';
+import { parseAssistantTextSignature, resolvePiSdkRuntimeModel } from './llm/piSdkProvider';
 import {
   calculateContextTokens,
   extractSessionContextUsageFromAssistantMessage,
@@ -200,7 +191,6 @@ export function isChatRunError(err: unknown): err is ChatRunError {
   return err instanceof ChatRunError;
 }
 
-const DEFAULT_PI_REQUEST_TIMEOUT_MS = 300_000;
 const PI_CONTEXT_OVERFLOW_RECOVERY_MESSAGE =
   'Context overflow recovery failed after one compact-and-retry attempt. Try reducing context or switching to a larger-context model.';
 
@@ -439,7 +429,7 @@ function getRequestId(
   return requestId ?? state.activeChatRun?.requestId ?? responseId;
 }
 
-function createRequestPayload(requestId?: string): {} | { requestId: string } {
+function createRequestPayload(requestId?: string): { requestId?: string } {
   return requestId ? { requestId } : {};
 }
 
@@ -964,9 +954,7 @@ export async function runChatCompletionCore(
     agent,
     provider,
     envConfig,
-    chatCompletionTools,
     agentTools = [],
-    handleChatToolCalls,
     sessionHub,
     output,
     abortController,
@@ -1345,30 +1333,13 @@ export async function runChatCompletionCore(
       );
     }
 
-    let resolvedModel: Awaited<ReturnType<typeof resolvePiSdkModel>>;
+    let resolvedRuntime: Awaited<ReturnType<typeof resolvePiSdkRuntimeModel>>;
     try {
-      const defaultProvider = piConfig?.provider;
-      const piModelOverrides = {
-        ...(piConfig?.baseUrl ? { baseUrl: piConfig.baseUrl } : {}),
-        ...(piConfig?.api ? { api: piConfig.api } : {}),
-        ...(piConfig?.contextWindow !== undefined ? { contextWindow: piConfig.contextWindow } : {}),
-        ...(piConfig?.maxTokens !== undefined ? { maxTokens: piConfig.maxTokens } : {}),
-        ...(piConfig?.reasoning !== undefined ? { reasoning: piConfig.reasoning } : {}),
-        ...(piConfig?.input !== undefined ? { input: piConfig.input } : {}),
-        ...(piConfig?.cost !== undefined ? { cost: piConfig.cost } : {}),
-        ...(piConfig?.compat !== undefined ? { compat: piConfig.compat } : {}),
-      };
-      resolvedModel =
-        defaultProvider === undefined
-          ? await resolvePiSdkModel({
-              modelSpec,
-              ...piModelOverrides,
-            })
-          : await resolvePiSdkModel({
-              modelSpec,
-              defaultProvider,
-              ...piModelOverrides,
-            });
+      resolvedRuntime = await resolvePiSdkRuntimeModel({
+        modelSpec,
+        ...(piConfig ? { config: piConfig } : {}),
+        log,
+      });
     } catch (err) {
       throw new ChatRunError(
         'agent_config_error',
@@ -1378,22 +1349,6 @@ export async function runChatCompletionCore(
 
     const thinking = resolveSessionThinkingForRun({ agent, summary: state.summary });
     const reasoning = thinking && isPiReasoningLevel(thinking) ? thinking : undefined;
-    const configProvider = piConfig?.provider?.trim();
-    const providerMatchesConfig =
-      !configProvider || configProvider.toLowerCase() === resolvedModel.providerId.toLowerCase();
-    const piAgentAuthApiKey = await resolvePiSdkAuthApiKey({
-      providerId: resolvedModel.providerId,
-      log,
-    });
-    const apiKey = providerMatchesConfig
-      ? (piConfig?.apiKey ?? piAgentAuthApiKey)
-      : piAgentAuthApiKey;
-    const baseUrl = providerMatchesConfig ? piConfig?.baseUrl : undefined;
-    const configuredHeaders = providerMatchesConfig ? piConfig?.headers : undefined;
-    const headers =
-      providerMatchesConfig && piConfig?.authHeader && apiKey
-        ? { ...configuredHeaders, Authorization: `Bearer ${apiKey}` }
-        : configuredHeaders;
     const canonicalReplayMessages = await loadCanonicalPiReplayMessages({
       summary: state.summary,
     });
@@ -1421,15 +1376,7 @@ export async function runChatCompletionCore(
       ];
     }
 
-    const agentModel: Model<Api> = {
-      ...resolvedModel.model,
-      ...(providerMatchesConfig && piConfig?.api ? { api: piConfig.api } : {}),
-      ...(baseUrl ? { baseUrl } : {}),
-      ...(headers ? { headers } : {}),
-      ...(providerMatchesConfig && piConfig?.compat !== undefined
-        ? { compat: piConfig.compat }
-        : {}),
-    };
+    const agentModel = resolvedRuntime.runtimeModel;
     piContextWindow = agentModel.contextWindow;
     type PiRuntimeConfig = {
       apiKey?: string;
@@ -1479,10 +1426,14 @@ export async function runChatCompletionCore(
         return runtime;
       })() as PiRuntimeState);
     piAgentRuntime.requestConfig = {
-      ...(apiKey ? { apiKey } : {}),
-      ...(piConfig?.temperature !== undefined ? { temperature: piConfig.temperature } : {}),
-      ...(piConfig?.maxTokens !== undefined ? { maxTokens: piConfig.maxTokens } : {}),
-      ...(headers ? { headers } : {}),
+      ...(resolvedRuntime.apiKey ? { apiKey: resolvedRuntime.apiKey } : {}),
+      ...(resolvedRuntime.providerMatchesConfig && piConfig?.temperature !== undefined
+        ? { temperature: piConfig.temperature }
+        : {}),
+      ...(resolvedRuntime.providerMatchesConfig && piConfig?.maxTokens !== undefined
+        ? { maxTokens: piConfig.maxTokens }
+        : {}),
+      ...(resolvedRuntime.headers ? { headers: resolvedRuntime.headers } : {}),
     };
     piAgentRuntime.onPayload = envConfig.debugChatCompletions
       ? async (payload, model) => {
@@ -1491,7 +1442,7 @@ export async function runChatCompletionCore(
             direction: 'request',
             sessionId,
             responseId,
-            provider: resolvedModel.providerId,
+            provider: resolvedRuntime.providerId,
             model: model.id,
             ...(debugChatCompletionsContext !== undefined
               ? { debugContext: debugChatCompletionsContext }
@@ -1847,7 +1798,7 @@ export async function runChatCompletionCore(
       maybeResolvedPiMessage?.role === 'assistant' ? maybeResolvedPiMessage : undefined;
     if (resolvedPiMessage) {
       const contextUsage = extractSessionContextUsageFromAssistantMessage({
-        contextWindow: resolvedModel.model.contextWindow,
+        contextWindow: resolvedRuntime.model.contextWindow,
         message: resolvedPiMessage,
       });
       if (contextUsage && !isSessionContextUsageEqual(state.summary.contextUsage, contextUsage)) {
@@ -1862,8 +1813,8 @@ export async function runChatCompletionCore(
           direction: 'response',
           sessionId,
           responseId,
-          provider: resolvedModel.providerId,
-          model: resolvedModel.model.id,
+          provider: resolvedRuntime.providerId,
+          model: resolvedRuntime.model.id,
           ...(debugChatCompletionsContext !== undefined
             ? { debugContext: debugChatCompletionsContext }
             : {}),
@@ -1909,7 +1860,7 @@ export async function runChatCompletionCore(
     } else if (resolvedPiMessage?.stopReason === 'error') {
       if (
         overflowRecoveryAttempted ||
-        !isPiContextOverflow(resolvedPiMessage, resolvedModel.model.contextWindow)
+        !isPiContextOverflow(resolvedPiMessage, resolvedRuntime.model.contextWindow)
       ) {
         throw new ChatRunError(
           'upstream_error',
@@ -1972,7 +1923,7 @@ export async function runChatCompletionCore(
             : 'aborted';
         finalPiSdkMessage = retryPiMessage;
       } else if (retryPiMessage.stopReason === 'error') {
-        if (isPiContextOverflow(retryPiMessage, resolvedModel.model.contextWindow)) {
+        if (isPiContextOverflow(retryPiMessage, resolvedRuntime.model.contextWindow)) {
           throw new ChatRunError('upstream_error', PI_CONTEXT_OVERFLOW_RECOVERY_MESSAGE);
         }
         throw new ChatRunError(

--- a/packages/agent-server/src/config.test.ts
+++ b/packages/agent-server/src/config.test.ts
@@ -772,13 +772,27 @@ describe('loadConfig', () => {
             thinking: ['low'],
             config: {
               provider: 'anthropic',
+              api: 'openai-completions',
               baseUrl: 'https://api.anthropic.com',
               apiKey: '${PI_API_KEY}',
+              authHeader: true,
               headers: {
                 'X-Request-Source': '${PI_HEADER_SOURCE}',
               },
               maxTokens: 4096,
               contextWindow: 65536,
+              reasoning: true,
+              input: ['text', 'image'],
+              cost: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+              },
+              compat: {
+                supportsDeveloperRole: false,
+                supportsReasoningEffort: false,
+              },
               temperature: 0.7,
               maxToolIterations: 25,
               compaction: {
@@ -809,13 +823,27 @@ describe('loadConfig', () => {
       thinking: ['low'],
       config: {
         provider: 'anthropic',
+        api: 'openai-completions',
         baseUrl: 'https://api.anthropic.com',
         apiKey: 'test-pi-key',
+        authHeader: true,
         headers: {
           'X-Request-Source': 'assistant',
         },
         maxTokens: 4096,
         contextWindow: 65536,
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+        },
+        compat: {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: false,
+        },
         temperature: 0.7,
         maxToolIterations: 25,
         compaction: {

--- a/packages/agent-server/src/config.test.ts
+++ b/packages/agent-server/src/config.test.ts
@@ -855,6 +855,38 @@ describe('loadConfig', () => {
     });
   });
 
+  it('rejects invalid pi sdk custom model metadata config', async () => {
+    const filePath = createTempFile('config-pi-invalid-custom-model-metadata');
+    const configJson = {
+      agents: [
+        {
+          agentId: 'pi',
+          displayName: 'Pi',
+          description: 'Pi SDK agent.',
+          chat: {
+            provider: 'pi',
+            models: ['local/model'],
+            config: {
+              provider: 'local',
+              api: 'openai-completon',
+              baseUrl: 'http://127.0.0.1:4010/v1',
+              cost: {
+                input: -1,
+              },
+              compat: {
+                supportsDeveloprRole: false,
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    await fs.writeFile(filePath, JSON.stringify(configJson), 'utf8');
+
+    expect(() => loadConfig(filePath)).toThrow();
+  });
+
   it('throws a descriptive error for invalid JSON', async () => {
     const filePath = createTempFile('config-invalid-json');
     await fs.writeFile(filePath, '{ "agents": [ }', 'utf8');

--- a/packages/agent-server/src/config.ts
+++ b/packages/agent-server/src/config.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { z } from 'zod';
-import type { AgentDefinition } from './agents';
+import type { AgentDefinition, PiSdkChatConfig } from './agents';
 import { DEFAULT_ATTACHMENT_PREVIEW_SNIPPET_CHARS } from './attachments/constants';
 import { normalizeContextFileSourcesForConfigDir } from './contextFiles';
 import { normalizeInstructionSkillSourcesForConfigDir } from './instructionSkills';
@@ -210,9 +210,47 @@ const PiCliChatConfigSchema = z.object({
   wrapper: CliWrapperConfigSchema.optional(),
 });
 
+const PiSdkApiSchema = z.enum([
+  'openai-completions',
+  'mistral-conversations',
+  'openai-responses',
+  'azure-openai-responses',
+  'openai-codex-responses',
+  'anthropic-messages',
+  'bedrock-converse-stream',
+  'google-generative-ai',
+  'google-vertex',
+]);
+
+const PiSdkCompatSchema = z
+  .object({
+    supportsStore: z.boolean().optional(),
+    supportsDeveloperRole: z.boolean().optional(),
+    supportsReasoningEffort: z.boolean().optional(),
+    supportsUsageInStreaming: z.boolean().optional(),
+    maxTokensField: z.enum(['max_completion_tokens', 'max_tokens']).optional(),
+    requiresToolResultName: z.boolean().optional(),
+    requiresAssistantAfterToolResult: z.boolean().optional(),
+    requiresThinkingAsText: z.boolean().optional(),
+    requiresReasoningContentOnAssistantMessages: z.boolean().optional(),
+    thinkingFormat: z
+      .enum(['openai', 'openrouter', 'deepseek', 'zai', 'qwen', 'qwen-chat-template'])
+      .optional(),
+    openRouterRouting: z.record(z.string(), z.unknown()).optional(),
+    vercelGatewayRouting: z.record(z.string(), z.unknown()).optional(),
+    zaiToolStream: z.boolean().optional(),
+    supportsStrictMode: z.boolean().optional(),
+    cacheControlFormat: z.literal('anthropic').optional(),
+    sendSessionAffinityHeaders: z.boolean().optional(),
+    supportsLongCacheRetention: z.boolean().optional(),
+    sendSessionIdHeader: z.boolean().optional(),
+    supportsEagerToolInputStreaming: z.boolean().optional(),
+  })
+  .strict();
+
 const PiSdkChatConfigSchema = z.object({
   provider: NonEmptyTrimmedStringSchema.optional(),
-  api: NonEmptyTrimmedStringSchema.optional(),
+  api: PiSdkApiSchema.optional(),
   apiKey: NonEmptyTrimmedStringSchema.optional(),
   authHeader: z.boolean().optional(),
   baseUrl: NonEmptyTrimmedStringSchema.optional(),
@@ -227,13 +265,13 @@ const PiSdkChatConfigSchema = z.object({
     .optional(),
   cost: z
     .object({
-      input: z.number().optional(),
-      output: z.number().optional(),
-      cacheRead: z.number().optional(),
-      cacheWrite: z.number().optional(),
+      input: z.number().min(0).optional(),
+      output: z.number().min(0).optional(),
+      cacheRead: z.number().min(0).optional(),
+      cacheWrite: z.number().min(0).optional(),
     })
     .optional(),
-  compat: z.record(z.string(), z.unknown()).optional(),
+  compat: PiSdkCompatSchema.optional(),
   temperature: z.number().min(0).max(2).optional(),
   maxToolIterations: z.number().int().min(1).optional(),
   compaction: z
@@ -485,7 +523,9 @@ export const AgentConfigSchema = RawAgentConfigSchema.transform((value) => {
                 ...(config.reasoning !== undefined ? { reasoning: config.reasoning } : {}),
                 ...(config.input !== undefined ? { input: config.input } : {}),
                 ...(config.cost !== undefined ? { cost: config.cost } : {}),
-                ...(config.compat !== undefined ? { compat: config.compat } : {}),
+                ...(config.compat !== undefined
+                  ? { compat: config.compat as PiSdkChatConfig['compat'] }
+                  : {}),
                 ...(config.temperature !== undefined ? { temperature: config.temperature } : {}),
                 ...(config.maxToolIterations !== undefined
                   ? { maxToolIterations: config.maxToolIterations }

--- a/packages/agent-server/src/config.ts
+++ b/packages/agent-server/src/config.ts
@@ -212,12 +212,28 @@ const PiCliChatConfigSchema = z.object({
 
 const PiSdkChatConfigSchema = z.object({
   provider: NonEmptyTrimmedStringSchema.optional(),
+  api: NonEmptyTrimmedStringSchema.optional(),
   apiKey: NonEmptyTrimmedStringSchema.optional(),
+  authHeader: z.boolean().optional(),
   baseUrl: NonEmptyTrimmedStringSchema.optional(),
   headers: z.record(z.string(), z.string()).optional(),
   timeoutMs: z.number().int().min(1).optional(),
   maxTokens: z.number().int().min(1).optional(),
   contextWindow: z.number().int().min(1).optional(),
+  reasoning: z.boolean().optional(),
+  input: z
+    .array(z.enum(['text', 'image']))
+    .min(1)
+    .optional(),
+  cost: z
+    .object({
+      input: z.number().optional(),
+      output: z.number().optional(),
+      cacheRead: z.number().optional(),
+      cacheWrite: z.number().optional(),
+    })
+    .optional(),
+  compat: z.record(z.string(), z.unknown()).optional(),
   temperature: z.number().min(0).max(2).optional(),
   maxToolIterations: z.number().int().min(1).optional(),
   compaction: z
@@ -456,7 +472,9 @@ export const AgentConfigSchema = RawAgentConfigSchema.transform((value) => {
           ? {
               config: {
                 ...(config.provider ? { provider: config.provider } : {}),
+                ...(config.api ? { api: config.api } : {}),
                 ...(config.apiKey ? { apiKey: config.apiKey } : {}),
+                ...(config.authHeader !== undefined ? { authHeader: config.authHeader } : {}),
                 ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}),
                 ...(config.headers ? { headers: config.headers } : {}),
                 ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
@@ -464,6 +482,10 @@ export const AgentConfigSchema = RawAgentConfigSchema.transform((value) => {
                 ...(config.contextWindow !== undefined
                   ? { contextWindow: config.contextWindow }
                   : {}),
+                ...(config.reasoning !== undefined ? { reasoning: config.reasoning } : {}),
+                ...(config.input !== undefined ? { input: config.input } : {}),
+                ...(config.cost !== undefined ? { cost: config.cost } : {}),
+                ...(config.compat !== undefined ? { compat: config.compat } : {}),
                 ...(config.temperature !== undefined ? { temperature: config.temperature } : {}),
                 ...(config.maxToolIterations !== undefined
                   ? { maxToolIterations: config.maxToolIterations }

--- a/packages/agent-server/src/llm/piSdkProvider.test.ts
+++ b/packages/agent-server/src/llm/piSdkProvider.test.ts
@@ -24,6 +24,7 @@ import {
   mapChatCompletionToolsToPiTools,
   resolvePiSdkAuthApiKey,
   resolvePiSdkModel,
+  resolvePiSdkRuntimeModel,
   runPiSdkChatCompletionIteration,
 } from './piSdkProvider';
 
@@ -147,6 +148,135 @@ describe('resolvePiSdkModel', () => {
         baseUrl: 'http://127.0.0.1:4010/v1',
       }),
     ).rejects.toThrow('Pi model "openai/not-a-real-model" was not found');
+  });
+
+  it('does not apply config-owned custom endpoint overrides to a different explicit provider', async () => {
+    vi.mocked(getProviders).mockReturnValue(['openai'] as never);
+    vi.mocked(getModels).mockReturnValue([]);
+
+    await expect(
+      resolvePiSdkRuntimeModel({
+        modelSpec: 'other/scenarios',
+        config: {
+          provider: 'local',
+          baseUrl: 'http://127.0.0.1:4010/v1',
+          api: 'openai-completions',
+          apiKey: 'local-key',
+          authHeader: true,
+        },
+      }),
+    ).rejects.toThrow('No Pi models found for provider "other"');
+  });
+
+  it('builds runtime model headers and compat for matching custom endpoints', async () => {
+    vi.mocked(getProviders).mockReturnValue(['openai'] as never);
+    vi.mocked(getModels).mockReturnValue([]);
+
+    const resolved = await resolvePiSdkRuntimeModel({
+      modelSpec: 'local/scenarios',
+      config: {
+        provider: 'local',
+        baseUrl: 'http://127.0.0.1:4010/v1',
+        api: 'openai-completions',
+        apiKey: 'local-key',
+        authHeader: true,
+        headers: {
+          'X-Request-Source': 'assistant',
+        },
+        contextWindow: 65536,
+        maxTokens: 4096,
+        compat: {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: false,
+        },
+      },
+    });
+
+    expect(resolved.providerMatchesConfig).toBe(true);
+    expect(resolved.apiKey).toBe('local-key');
+    expect(resolved.runtimeModel).toMatchObject({
+      id: 'scenarios',
+      api: 'openai-completions',
+      provider: 'local',
+      baseUrl: 'http://127.0.0.1:4010/v1',
+      contextWindow: 65536,
+      maxTokens: 4096,
+      headers: {
+        'X-Request-Source': 'assistant',
+        Authorization: 'Bearer local-key',
+      },
+      compat: {
+        supportsDeveloperRole: false,
+        supportsReasoningEffort: false,
+      },
+    });
+  });
+
+  it('applies matching custom metadata overrides to built-in models', async () => {
+    vi.mocked(getProviders).mockReturnValue(['openai'] as never);
+    vi.mocked(getModels).mockImplementation((provider: string) => {
+      if (provider === 'openai') {
+        return [
+          {
+            id: 'gpt-4o-mini',
+            provider: 'openai',
+            api: 'openai-responses',
+            contextWindow: 128000,
+            maxTokens: 16000,
+            reasoning: true,
+            input: ['text'],
+            cost: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+            },
+          } as never,
+        ];
+      }
+      return [];
+    });
+
+    const resolved = await resolvePiSdkRuntimeModel({
+      modelSpec: 'openai/gpt-4o-mini',
+      config: {
+        provider: 'openai',
+        api: 'openai-completions',
+        baseUrl: 'http://127.0.0.1:4010/v1',
+        contextWindow: 65536,
+        maxTokens: 4096,
+        reasoning: false,
+        input: ['text', 'image'],
+        cost: {
+          input: 1,
+          output: 2,
+          cacheRead: 3,
+          cacheWrite: 4,
+        },
+        compat: {
+          supportsDeveloperRole: false,
+        },
+      },
+    });
+
+    expect(resolved.runtimeModel).toMatchObject({
+      id: 'gpt-4o-mini',
+      api: 'openai-completions',
+      baseUrl: 'http://127.0.0.1:4010/v1',
+      contextWindow: 65536,
+      maxTokens: 4096,
+      reasoning: false,
+      input: ['text', 'image'],
+      cost: {
+        input: 1,
+        output: 2,
+        cacheRead: 3,
+        cacheWrite: 4,
+      },
+      compat: {
+        supportsDeveloperRole: false,
+      },
+    });
   });
 });
 

--- a/packages/agent-server/src/llm/piSdkProvider.test.ts
+++ b/packages/agent-server/src/llm/piSdkProvider.test.ts
@@ -79,7 +79,21 @@ describe('resolvePiSdkModel', () => {
     const resolved = await resolvePiSdkModel({
       modelSpec: 'mock-scenarios/scenarios',
       baseUrl: 'http://127.0.0.1:4010/v1',
+      api: 'openai-completions',
       contextWindow: 65536,
+      maxTokens: 4096,
+      reasoning: false,
+      input: ['text', 'image'],
+      cost: {
+        input: 1,
+        output: 2,
+        cacheRead: 3,
+        cacheWrite: 4,
+      },
+      compat: {
+        supportsDeveloperRole: false,
+        supportsReasoningEffort: false,
+      },
     });
 
     expect(resolved.providerId).toBe('mock-scenarios');
@@ -87,18 +101,22 @@ describe('resolvePiSdkModel', () => {
     expect(resolved.model).toMatchObject({
       id: 'scenarios',
       name: 'scenarios',
-      api: 'openai-responses',
+      api: 'openai-completions',
       provider: 'mock-scenarios',
       baseUrl: 'http://127.0.0.1:4010/v1',
-      reasoning: true,
-      input: ['text'],
+      reasoning: false,
+      input: ['text', 'image'],
       contextWindow: 65536,
-      maxTokens: 16000,
+      maxTokens: 4096,
       cost: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
+        input: 1,
+        output: 2,
+        cacheRead: 3,
+        cacheWrite: 4,
+      },
+      compat: {
+        supportsDeveloperRole: false,
+        supportsReasoningEffort: false,
       },
     });
   });
@@ -217,10 +235,9 @@ describe('resolvePiSdkAuthApiKey', () => {
         }),
       );
 
-      const persisted = JSON.parse(await fs.readFile(path.join(tempDir, 'auth.json'), 'utf8')) as Record<
-        string,
-        { access?: string; refresh?: string; accountId?: string }
-      >;
+      const persisted = JSON.parse(
+        await fs.readFile(path.join(tempDir, 'auth.json'), 'utf8'),
+      ) as Record<string, { access?: string; refresh?: string; accountId?: string }>;
       expect(persisted['OpenAI-Codex']).toMatchObject({
         access: 'new-access',
         refresh: 'new-refresh',
@@ -273,7 +290,13 @@ describe('buildPiContext', () => {
 
     const assistantMessage = context.messages[1] as {
       role: string;
-      content: Array<{ type: string; text?: string; id?: string; name?: string; arguments?: unknown }>;
+      content: Array<{
+        type: string;
+        text?: string;
+        id?: string;
+        name?: string;
+        arguments?: unknown;
+      }>;
     };
     expect(assistantMessage.role).toBe('assistant');
     expect(assistantMessage.content[0]).toEqual({ type: 'text', text: 'Hi there' });
@@ -492,9 +515,7 @@ describe('runPiSdkChatCompletionIteration', () => {
       { type: 'toolcall_end', toolCall: { id: 'tc-1', name: 'doThing', arguments: { ok: 1 } } },
     ];
 
-    vi.mocked(streamSimple).mockReturnValue(
-      createStream(events, { stopReason: 'stop' }) as never,
-    );
+    vi.mocked(streamSimple).mockReturnValue(createStream(events, { stopReason: 'stop' }) as never);
 
     const textDeltas: string[] = [];
     const toolStarts: Array<{ id: string; name: string }> = [];
@@ -538,17 +559,13 @@ describe('runPiSdkChatCompletionIteration', () => {
       },
     ]);
     expect(result.text).toBe('Hello world');
-    expect(result.toolCalls).toEqual([
-      { id: 'tc-1', name: 'doThing', argumentsJson: '{"ok":1}' },
-    ]);
+    expect(result.toolCalls).toEqual([{ id: 'tc-1', name: 'doThing', argumentsJson: '{"ok":1}' }]);
   });
 
   it('only tags streamed text deltas with final_answer for openai-responses models', async () => {
     const events = [{ type: 'text_delta', delta: 'Hello' }];
 
-    vi.mocked(streamSimple).mockReturnValue(
-      createStream(events, { stopReason: 'stop' }) as never,
-    );
+    vi.mocked(streamSimple).mockReturnValue(createStream(events, { stopReason: 'stop' }) as never);
 
     const openAiPhases: Array<string | undefined> = [];
     await runPiSdkChatCompletionIteration({
@@ -562,9 +579,7 @@ describe('runPiSdkChatCompletionIteration', () => {
     });
     expect(openAiPhases).toEqual(['final_answer']);
 
-    vi.mocked(streamSimple).mockReturnValue(
-      createStream(events, { stopReason: 'stop' }) as never,
-    );
+    vi.mocked(streamSimple).mockReturnValue(createStream(events, { stopReason: 'stop' }) as never);
 
     const anthropicPhases: Array<string | undefined> = [];
     await runPiSdkChatCompletionIteration({
@@ -581,10 +596,7 @@ describe('runPiSdkChatCompletionIteration', () => {
 
   it('marks aborted when the stream stops with aborted', async () => {
     vi.mocked(streamSimple).mockReturnValue(
-      createStream(
-        [{ type: 'error', reason: 'aborted' }],
-        { stopReason: 'aborted' },
-      ) as never,
+      createStream([{ type: 'error', reason: 'aborted' }], { stopReason: 'aborted' }) as never,
     );
 
     const result = await runPiSdkChatCompletionIteration({
@@ -633,9 +645,7 @@ describe('runPiSdkChatCompletionIteration', () => {
       timestamp: Date.now(),
     } as const;
 
-    vi.mocked(streamSimple).mockReturnValue(
-      createStream([], assistantMessage) as never,
-    );
+    vi.mocked(streamSimple).mockReturnValue(createStream([], assistantMessage) as never);
 
     const onPayload = vi.fn();
     const onResponse = vi.fn();

--- a/packages/agent-server/src/llm/piSdkProvider.ts
+++ b/packages/agent-server/src/llm/piSdkProvider.ts
@@ -101,28 +101,46 @@ function buildSyntheticPiSdkModel(options: {
   providerId: string;
   modelId: string;
   baseUrl: string;
+  api?: string;
   contextWindow?: number;
+  maxTokens?: number;
+  reasoning?: boolean;
+  input?: ('text' | 'image')[];
+  cost?: {
+    input?: number | undefined;
+    output?: number | undefined;
+    cacheRead?: number | undefined;
+    cacheWrite?: number | undefined;
+  };
+  compat?: Model<Api>['compat'];
 }): Model<Api> {
   const { providerId, modelId, baseUrl, contextWindow } = options;
+  const cost = options.cost ?? {};
   return {
     id: modelId,
     name: modelId,
-    api: 'openai-responses',
+    api: (options.api ?? 'openai-responses') as Api,
     provider: providerId,
     baseUrl,
-    reasoning: true,
-    input: ['text'],
+    reasoning: options.reasoning ?? true,
+    input: options.input ?? ['text'],
     cost: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
+      input: cost.input ?? 0,
+      output: cost.output ?? 0,
+      cacheRead: cost.cacheRead ?? 0,
+      cacheWrite: cost.cacheWrite ?? 0,
     },
     contextWindow:
       typeof contextWindow === 'number' && Number.isFinite(contextWindow) && contextWindow > 0
         ? Math.floor(contextWindow)
         : 128000,
-    maxTokens: 16000,
+    maxTokens:
+      typeof options.maxTokens === 'number' &&
+      Number.isFinite(options.maxTokens) &&
+      options.maxTokens > 0
+        ? Math.floor(options.maxTokens)
+        : 16000,
+    ...(options.compat !== undefined ? { compat: options.compat } : {}),
   };
 }
 
@@ -130,7 +148,18 @@ export async function resolvePiSdkModel(options: {
   modelSpec: string;
   defaultProvider?: string;
   baseUrl?: string;
+  api?: string;
   contextWindow?: number;
+  maxTokens?: number;
+  reasoning?: boolean;
+  input?: ('text' | 'image')[];
+  cost?: {
+    input?: number | undefined;
+    output?: number | undefined;
+    cacheRead?: number | undefined;
+    cacheWrite?: number | undefined;
+  };
+  compat?: Model<Api>['compat'];
 }): Promise<PiSdkModelResolution> {
   const { modelSpec, defaultProvider, baseUrl, contextWindow } = options;
   const trimmedSpec = modelSpec.trim();
@@ -150,9 +179,7 @@ export async function resolvePiSdkModel(options: {
   }
 
   if (!providerRaw) {
-    throw new Error(
-      'Pi chat requires provider/model format when chat.config.provider is not set',
-    );
+    throw new Error('Pi chat requires provider/model format when chat.config.provider is not set');
   }
 
   const providerId = await resolveProviderId(providerRaw);
@@ -171,7 +198,13 @@ export async function resolvePiSdkModel(options: {
         providerId,
         modelId,
         baseUrl: baseUrl.trim(),
+        ...(options.api !== undefined ? { api: options.api } : {}),
         ...(contextWindow !== undefined ? { contextWindow } : {}),
+        ...(options.maxTokens !== undefined ? { maxTokens: options.maxTokens } : {}),
+        ...(options.reasoning !== undefined ? { reasoning: options.reasoning } : {}),
+        ...(options.input !== undefined ? { input: options.input } : {}),
+        ...(options.cost !== undefined ? { cost: options.cost } : {}),
+        ...(options.compat !== undefined ? { compat: options.compat } : {}),
       });
       return {
         model: syntheticModel,
@@ -190,7 +223,13 @@ export async function resolvePiSdkModel(options: {
         providerId,
         modelId,
         baseUrl: baseUrl.trim(),
+        ...(options.api !== undefined ? { api: options.api } : {}),
         ...(contextWindow !== undefined ? { contextWindow } : {}),
+        ...(options.maxTokens !== undefined ? { maxTokens: options.maxTokens } : {}),
+        ...(options.reasoning !== undefined ? { reasoning: options.reasoning } : {}),
+        ...(options.input !== undefined ? { input: options.input } : {}),
+        ...(options.cost !== undefined ? { cost: options.cost } : {}),
+        ...(options.compat !== undefined ? { compat: options.compat } : {}),
       });
       return {
         model: syntheticModel,
@@ -293,9 +332,7 @@ export function parseAssistantTextSignature(
       return null;
     }
     const phase =
-      parsed.phase === 'commentary' || parsed.phase === 'final_answer'
-        ? parsed.phase
-        : undefined;
+      parsed.phase === 'commentary' || parsed.phase === 'final_answer' ? parsed.phase : undefined;
     return { id: parsed.id, ...(phase ? { phase } : {}) };
   } catch {
     return null;
@@ -488,10 +525,10 @@ export function buildPiContext(options: {
   return context;
 }
 
-function createTimeoutSignal(options: {
+function createTimeoutSignal(options: { signal: AbortSignal; timeoutMs?: number }): {
   signal: AbortSignal;
-  timeoutMs?: number;
-}): { signal: AbortSignal; clear: () => void } {
+  clear: () => void;
+} {
   const { signal, timeoutMs } = options;
   if (!timeoutMs || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
     return { signal, clear: () => undefined };

--- a/packages/agent-server/src/llm/piSdkProvider.ts
+++ b/packages/agent-server/src/llm/piSdkProvider.ts
@@ -15,6 +15,7 @@ import type {
 } from '@earendil-works/pi-ai';
 import type { AssistantTextPhase } from '@assistant/shared';
 
+import type { PiSdkChatConfig } from '../agents';
 import type { ChatCompletionMessage, ChatCompletionToolCallState } from '../chatCompletionTypes';
 import { resolvePiAgentAuthApiKey } from './piAgentAuth';
 
@@ -34,6 +35,13 @@ export interface PiSdkModelResolution {
   model: Model<Api>;
   providerId: string;
   modelId: string;
+}
+
+export interface PiSdkRuntimeModelResolution extends PiSdkModelResolution {
+  runtimeModel: Model<Api>;
+  providerMatchesConfig: boolean;
+  apiKey?: string;
+  headers?: Record<string, string>;
 }
 
 export interface PiAssistantTextBlock {
@@ -85,6 +93,18 @@ function createEmptyUsage(): Usage {
   };
 }
 
+function buildPiModelCost(
+  cost: PiSdkChatConfig['cost'] | undefined,
+  fallback?: Model<Api>['cost'],
+): Model<Api>['cost'] {
+  return {
+    input: cost?.input ?? fallback?.input ?? 0,
+    output: cost?.output ?? fallback?.output ?? 0,
+    cacheRead: cost?.cacheRead ?? fallback?.cacheRead ?? 0,
+    cacheWrite: cost?.cacheWrite ?? fallback?.cacheWrite ?? 0,
+  };
+}
+
 async function resolveProviderId(providerRaw: string): Promise<string | undefined> {
   const trimmed = providerRaw.trim();
   if (!trimmed) {
@@ -115,7 +135,6 @@ function buildSyntheticPiSdkModel(options: {
   compat?: Model<Api>['compat'];
 }): Model<Api> {
   const { providerId, modelId, baseUrl, contextWindow } = options;
-  const cost = options.cost ?? {};
   return {
     id: modelId,
     name: modelId,
@@ -124,12 +143,7 @@ function buildSyntheticPiSdkModel(options: {
     baseUrl,
     reasoning: options.reasoning ?? true,
     input: options.input ?? ['text'],
-    cost: {
-      input: cost.input ?? 0,
-      output: cost.output ?? 0,
-      cacheRead: cost.cacheRead ?? 0,
-      cacheWrite: cost.cacheWrite ?? 0,
-    },
+    cost: buildPiModelCost(options.cost),
     contextWindow:
       typeof contextWindow === 'number' && Number.isFinite(contextWindow) && contextWindow > 0
         ? Math.floor(contextWindow)
@@ -141,6 +155,146 @@ function buildSyntheticPiSdkModel(options: {
         ? Math.floor(options.maxTokens)
         : 16000,
     ...(options.compat !== undefined ? { compat: options.compat } : {}),
+  };
+}
+
+function buildSyntheticPiSdkModelResolution(options: {
+  providerId: string;
+  modelIdRaw: string;
+  baseUrl: string;
+  contextWindow?: number;
+  api?: string;
+  maxTokens?: number;
+  reasoning?: boolean;
+  input?: ('text' | 'image')[];
+  cost?: {
+    input?: number | undefined;
+    output?: number | undefined;
+    cacheRead?: number | undefined;
+    cacheWrite?: number | undefined;
+  };
+  compat?: Model<Api>['compat'];
+}): PiSdkModelResolution {
+  const { providerId, modelIdRaw, baseUrl, contextWindow } = options;
+  const syntheticModel = buildSyntheticPiSdkModel({
+    providerId,
+    modelId: modelIdRaw.trim(),
+    baseUrl: baseUrl.trim(),
+    ...(options.api !== undefined ? { api: options.api } : {}),
+    ...(contextWindow !== undefined ? { contextWindow } : {}),
+    ...(options.maxTokens !== undefined ? { maxTokens: options.maxTokens } : {}),
+    ...(options.reasoning !== undefined ? { reasoning: options.reasoning } : {}),
+    ...(options.input !== undefined ? { input: options.input } : {}),
+    ...(options.cost !== undefined ? { cost: options.cost } : {}),
+    ...(options.compat !== undefined ? { compat: options.compat } : {}),
+  });
+  return {
+    model: syntheticModel,
+    providerId,
+    modelId: syntheticModel.id,
+  };
+}
+
+function getModelSpecProvider(modelSpec: string): string | undefined {
+  const trimmed = modelSpec.trim();
+  const slashIndex = trimmed.indexOf('/');
+  if (slashIndex === -1) {
+    return undefined;
+  }
+  const provider = trimmed.slice(0, slashIndex).trim();
+  return provider || undefined;
+}
+
+function providerMatchesRawConfig(provider: string | undefined, configProvider: string): boolean {
+  return Boolean(provider && provider.toLowerCase() === configProvider.toLowerCase());
+}
+
+function buildPiModelOverrides(config: PiSdkChatConfig | undefined) {
+  return {
+    ...(config?.baseUrl ? { baseUrl: config.baseUrl } : {}),
+    ...(config?.api ? { api: config.api } : {}),
+    ...(config?.contextWindow !== undefined ? { contextWindow: config.contextWindow } : {}),
+    ...(config?.maxTokens !== undefined ? { maxTokens: config.maxTokens } : {}),
+    ...(config?.reasoning !== undefined ? { reasoning: config.reasoning } : {}),
+    ...(config?.input !== undefined ? { input: config.input } : {}),
+    ...(config?.cost !== undefined ? { cost: config.cost } : {}),
+    ...(config?.compat !== undefined ? { compat: config.compat } : {}),
+  };
+}
+
+function buildPiRuntimeModelOverrides(
+  config: PiSdkChatConfig | undefined,
+  fallbackModel: Model<Api>,
+): Partial<Model<Api>> {
+  return {
+    ...(config?.api ? { api: config.api as Api } : {}),
+    ...(config?.baseUrl ? { baseUrl: config.baseUrl } : {}),
+    ...(config?.contextWindow !== undefined ? { contextWindow: config.contextWindow } : {}),
+    ...(config?.maxTokens !== undefined ? { maxTokens: config.maxTokens } : {}),
+    ...(config?.reasoning !== undefined ? { reasoning: config.reasoning } : {}),
+    ...(config?.input !== undefined ? { input: config.input } : {}),
+    ...(config?.cost !== undefined
+      ? { cost: buildPiModelCost(config.cost, fallbackModel.cost) }
+      : {}),
+    ...(config?.compat !== undefined ? { compat: config.compat } : {}),
+  };
+}
+
+export async function resolvePiSdkRuntimeModel(options: {
+  modelSpec: string;
+  config?: PiSdkChatConfig | undefined;
+  log?: (...args: unknown[]) => void;
+}): Promise<PiSdkRuntimeModelResolution> {
+  const { modelSpec, config, log } = options;
+  const configProviderRaw = config?.provider?.trim();
+  const configProvider = configProviderRaw || undefined;
+  const modelSpecProvider = getModelSpecProvider(modelSpec);
+  const modelSpecUsesConfigProvider =
+    !configProvider ||
+    !modelSpecProvider ||
+    providerMatchesRawConfig(modelSpecProvider, configProvider);
+  const modelOverrides = modelSpecUsesConfigProvider ? buildPiModelOverrides(config) : {};
+  const resolvedModel =
+    configProvider === undefined
+      ? await resolvePiSdkModel({
+          modelSpec,
+          ...modelOverrides,
+        })
+      : await resolvePiSdkModel({
+          modelSpec,
+          defaultProvider: configProvider,
+          ...modelOverrides,
+        });
+  const providerMatchesConfig =
+    !configProvider || configProvider.toLowerCase() === resolvedModel.providerId.toLowerCase();
+  const authApiKey = await resolvePiSdkAuthApiKey({
+    providerId: resolvedModel.providerId,
+    ...(log ? { log } : {}),
+  });
+  const apiKey = providerMatchesConfig ? (config?.apiKey ?? authApiKey) : authApiKey;
+  const configuredHeaders = providerMatchesConfig ? config?.headers : undefined;
+  if (providerMatchesConfig && config?.authHeader && !apiKey) {
+    log?.('Pi chat authHeader is enabled but no API key is configured or available', {
+      providerId: resolvedModel.providerId,
+      modelSpec,
+    });
+  }
+  const headers =
+    providerMatchesConfig && config?.authHeader && apiKey
+      ? { ...configuredHeaders, Authorization: `Bearer ${apiKey}` }
+      : configuredHeaders;
+  const runtimeModel: Model<Api> = {
+    ...resolvedModel.model,
+    ...(providerMatchesConfig ? buildPiRuntimeModelOverrides(config, resolvedModel.model) : {}),
+    ...(headers ? { headers } : {}),
+  };
+
+  return {
+    ...resolvedModel,
+    runtimeModel,
+    providerMatchesConfig,
+    ...(apiKey ? { apiKey } : {}),
+    ...(headers ? { headers } : {}),
   };
 }
 
@@ -193,11 +347,10 @@ export async function resolvePiSdkModel(options: {
   );
   if (!knownProvider) {
     if (typeof baseUrl === 'string' && baseUrl.trim().length > 0) {
-      const modelId = modelIdRaw.trim();
-      const syntheticModel = buildSyntheticPiSdkModel({
+      return buildSyntheticPiSdkModelResolution({
         providerId,
-        modelId,
-        baseUrl: baseUrl.trim(),
+        modelIdRaw,
+        baseUrl,
         ...(options.api !== undefined ? { api: options.api } : {}),
         ...(contextWindow !== undefined ? { contextWindow } : {}),
         ...(options.maxTokens !== undefined ? { maxTokens: options.maxTokens } : {}),
@@ -206,11 +359,6 @@ export async function resolvePiSdkModel(options: {
         ...(options.cost !== undefined ? { cost: options.cost } : {}),
         ...(options.compat !== undefined ? { compat: options.compat } : {}),
       });
-      return {
-        model: syntheticModel,
-        providerId,
-        modelId: syntheticModel.id,
-      };
     }
     throw new Error(`No Pi models found for provider "${providerId}"`);
   }
@@ -218,11 +366,10 @@ export async function resolvePiSdkModel(options: {
   const models = getModels(knownProvider);
   if (!models || models.length === 0) {
     if (typeof baseUrl === 'string' && baseUrl.trim().length > 0) {
-      const modelId = modelIdRaw.trim();
-      const syntheticModel = buildSyntheticPiSdkModel({
+      return buildSyntheticPiSdkModelResolution({
         providerId,
-        modelId,
-        baseUrl: baseUrl.trim(),
+        modelIdRaw,
+        baseUrl,
         ...(options.api !== undefined ? { api: options.api } : {}),
         ...(contextWindow !== undefined ? { contextWindow } : {}),
         ...(options.maxTokens !== undefined ? { maxTokens: options.maxTokens } : {}),
@@ -231,11 +378,6 @@ export async function resolvePiSdkModel(options: {
         ...(options.cost !== undefined ? { cost: options.cost } : {}),
         ...(options.compat !== undefined ? { compat: options.compat } : {}),
       });
-      return {
-        model: syntheticModel,
-        providerId,
-        modelId: syntheticModel.id,
-      };
     }
     throw new Error(`No Pi models found for provider "${providerId}"`);
   }

--- a/packages/agent-server/src/notificationProducers.ts
+++ b/packages/agent-server/src/notificationProducers.ts
@@ -20,7 +20,11 @@ export async function publishFinalResponseNotification(options: {
   if (!options.text.trim()) {
     return;
   }
-  const sessionIndex = options.sessionIndex ?? options.sessionHub?.getSessionIndex();
+  const sessionIndex =
+    options.sessionIndex ??
+    (typeof options.sessionHub?.getSessionIndex === 'function'
+      ? options.sessionHub.getSessionIndex()
+      : undefined);
   try {
     await createNotificationRecord({
       input: {

--- a/packages/agent-server/src/sessionHub.test.ts
+++ b/packages/agent-server/src/sessionHub.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { stat } from 'node:fs/promises';
 import fs from 'node:fs/promises';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { AgentRegistry } from './agents';
 import { AttachmentStore } from './attachments/store';
@@ -640,6 +640,93 @@ describe('SessionHub compactSession guards', () => {
     await expect(
       sessionHub.compactSession({ sessionId: 'pi-no-model-session', reason: 'manual' }),
     ).rejects.toThrow('Pi chat requires at least one model to compact context');
+  });
+
+  it('uses Pi custom-model config when compacting context', async () => {
+    const sessionIndex = new SessionIndex(createTempFile('session-hub-compact-custom-model'));
+    const compat = {
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+    };
+    const agentRegistry = new AgentRegistry([
+      {
+        agentId: 'pi-local',
+        displayName: 'Pi Local',
+        description: 'Pi backed by a local endpoint',
+        chat: {
+          provider: 'pi',
+          models: ['local/scenarios'],
+          config: {
+            provider: 'local',
+            baseUrl: 'http://127.0.0.1:4010/v1',
+            api: 'openai-completions',
+            apiKey: 'local-key',
+            authHeader: true,
+            headers: {
+              'X-Request-Source': 'assistant',
+            },
+            maxTokens: 4096,
+            contextWindow: 65536,
+            reasoning: false,
+            input: ['text', 'image'],
+            cost: {
+              input: 1,
+              output: 2,
+              cacheRead: 3,
+              cacheWrite: 4,
+            },
+            compat,
+          },
+        },
+      },
+    ]);
+    const compact = vi.fn(async (options: { summary: unknown }) => ({
+      summary: options.summary,
+      result: {
+        summary: 'Compacted',
+        firstKeptEntryId: 'entry-1',
+        tokensBefore: 123,
+      },
+    }));
+    const sessionHub = new SessionHub({
+      sessionIndex,
+      agentRegistry,
+      eventStore: createTestEventStore(),
+      piSessionWriter: { compact } as unknown as PiSessionWriter,
+    });
+    await sessionIndex.createSession({
+      sessionId: 'pi-local-session',
+      agentId: 'pi-local',
+    });
+
+    await sessionHub.compactSession({ sessionId: 'pi-local-session', reason: 'manual' });
+
+    expect(compact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'local-key',
+        model: expect.objectContaining({
+          id: 'scenarios',
+          api: 'openai-completions',
+          provider: 'local',
+          baseUrl: 'http://127.0.0.1:4010/v1',
+          maxTokens: 4096,
+          contextWindow: 65536,
+          reasoning: false,
+          input: ['text', 'image'],
+          cost: {
+            input: 1,
+            output: 2,
+            cacheRead: 3,
+            cacheWrite: 4,
+          },
+          compat,
+          headers: {
+            'X-Request-Source': 'assistant',
+            Authorization: 'Bearer local-key',
+          },
+        }),
+      }),
+    );
   });
 });
 

--- a/packages/agent-server/src/sessionHub.ts
+++ b/packages/agent-server/src/sessionHub.ts
@@ -47,7 +47,7 @@ import {
   type CliToolCallRecord,
 } from './ws/cliToolCallRendezvous';
 import { resolveSessionModelForRun } from './sessionModel';
-import { resolvePiSdkAuthApiKey, resolvePiSdkModel } from './llm/piSdkProvider';
+import { resolvePiSdkRuntimeModel } from './llm/piSdkProvider';
 import type { PiSdkChatConfig } from './agents';
 
 export interface LogicalSessionState {
@@ -733,27 +733,17 @@ export class SessionHub {
     if (!modelSpec) {
       throw new Error('Pi chat requires at least one model to compact context');
     }
-    const resolvedModel = await resolvePiSdkModel({
+    const resolvedRuntime = await resolvePiSdkRuntimeModel({
       modelSpec,
-      ...(piConfig?.provider ? { defaultProvider: piConfig.provider } : {}),
-      ...(piConfig?.baseUrl ? { baseUrl: piConfig.baseUrl } : {}),
-      ...(piConfig?.contextWindow !== undefined ? { contextWindow: piConfig.contextWindow } : {}),
+      ...(piConfig ? { config: piConfig } : {}),
+      log: (...args) => console.warn('[sessionHub]', ...args),
     });
-    const configProvider = piConfig?.provider?.trim();
-    const providerMatchesConfig =
-      !configProvider || configProvider.toLowerCase() === resolvedModel.providerId.toLowerCase();
-    const authApiKey = await resolvePiSdkAuthApiKey({ providerId: resolvedModel.providerId });
-    const apiKey = providerMatchesConfig ? (piConfig?.apiKey ?? authApiKey) : authApiKey;
     const compactSignal = signal ?? state?.activeChatRun?.abortController.signal;
     const result = await this.piSessionWriter.compact({
       summary: existing,
       settings: this.resolvePiCompactionSettings(piConfig),
-      model: {
-        ...resolvedModel.model,
-        ...(providerMatchesConfig && piConfig?.baseUrl ? { baseUrl: piConfig.baseUrl } : {}),
-        ...(providerMatchesConfig && piConfig?.headers ? { headers: piConfig.headers } : {}),
-      },
-      ...(apiKey ? { apiKey } : {}),
+      model: resolvedRuntime.runtimeModel,
+      ...(resolvedRuntime.apiKey ? { apiKey: resolvedRuntime.apiKey } : {}),
       ...(compactSignal ? { signal: compactSignal } : {}),
       updateAttributes: (patch) => this.updateSessionAttributes(sessionId, patch),
     });

--- a/packages/agent-server/src/tools/codingToolHost.test.ts
+++ b/packages/agent-server/src/tools/codingToolHost.test.ts
@@ -61,7 +61,11 @@ describe('CodingToolHost', () => {
     }
 
     const content = 'line-one\nline-two';
-    const writeResult = await writeTool.execute('call-write', { path: 'plugin.txt', content }, ctx.signal);
+    const writeResult = await writeTool.execute(
+      'call-write',
+      { path: 'plugin.txt', content },
+      ctx.signal,
+    );
 
     expect(Array.isArray(writeResult.content)).toBe(true);
 
@@ -73,7 +77,7 @@ describe('CodingToolHost', () => {
     const lsResult = await lsTool.execute('call-ls', {}, ctx.signal);
 
     expect((lsResult.content[0] as { text?: string }).text).toContain('plugin.txt');
-  });
+  }, 15_000);
 
   it('exposes a find tool that searches files relative to the search path', async () => {
     const dataDir = createTempDir('coding-tool-host-find');
@@ -208,11 +212,23 @@ describe('CodingToolHost', () => {
       throw new Error('Expected write, read, and bash tools to be registered');
     }
 
-    await writeTool.execute('relative-write', { path: 'relative.txt', content: 'relative file' }, ctx.signal);
-    const readRelative = await readTool.execute('relative-read', { path: 'relative.txt' }, ctx.signal);
+    await writeTool.execute(
+      'relative-write',
+      { path: 'relative.txt', content: 'relative file' },
+      ctx.signal,
+    );
+    const readRelative = await readTool.execute(
+      'relative-read',
+      { path: 'relative.txt' },
+      ctx.signal,
+    );
     const bashPwd = await bashTool.execute('pwd-call', { command: 'pwd' }, ctx.signal);
 
-    await writeTool.execute('outside-write', { path: outsidePath, content: 'outside file' }, ctx.signal);
+    await writeTool.execute(
+      'outside-write',
+      { path: outsidePath, content: 'outside file' },
+      ctx.signal,
+    );
     const outsideContent = await fs.readFile(outsidePath, 'utf8');
 
     expect(readRelative.content[0]?.type).toBe('text');
@@ -220,8 +236,12 @@ describe('CodingToolHost', () => {
     expect(await fs.readFile(path.join(sessionWorkingDir, 'relative.txt'), 'utf8')).toBe(
       'relative file',
     );
-    expect((bashPwd.details as { fullOutputPath?: string } | undefined)?.fullOutputPath).toBeUndefined();
-    expect((bashPwd.content[0] as { text?: string }).text?.trim().split('\n')[0]).toBe(sessionWorkingDir);
+    expect(
+      (bashPwd.details as { fullOutputPath?: string } | undefined)?.fullOutputPath,
+    ).toBeUndefined();
+    expect((bashPwd.content[0] as { text?: string }).text?.trim().split('\n')[0]).toBe(
+      sessionWorkingDir,
+    );
     expect(outsideContent).toBe('outside file');
   });
 
@@ -237,11 +257,10 @@ describe('CodingToolHost', () => {
     });
 
     await expect(
-      host.callTool(
-        'unknown_tool',
-        '{}',
-        { sessionId: 'coding-session', signal: new AbortController().signal },
-      ),
+      host.callTool('unknown_tool', '{}', {
+        sessionId: 'coding-session',
+        signal: new AbortController().signal,
+      }),
     ).rejects.toMatchObject({
       code: 'tool_not_found',
       message: 'Tool not found: unknown_tool',

--- a/packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts
+++ b/packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts
@@ -102,9 +102,41 @@ vi.mock('@earendil-works/pi-agent-core', async () => {
 vi.mock('../llm/piSdkProvider', async () => {
   const actual =
     await vi.importActual<typeof import('../llm/piSdkProvider')>('../llm/piSdkProvider');
+  const resolvePiSdkModel = vi.fn();
+  const resolvePiSdkRuntimeModel = vi.fn(
+    async (options: {
+      modelSpec: string;
+      config?: {
+        provider?: string;
+        apiKey?: string;
+        headers?: Record<string, string>;
+        authHeader?: boolean;
+      };
+    }) => {
+      const resolved = await resolvePiSdkModel({
+        modelSpec: options.modelSpec,
+        ...(options.config?.provider ? { defaultProvider: options.config.provider } : {}),
+      });
+      const headers =
+        options.config?.authHeader && options.config.apiKey
+          ? { ...(options.config.headers ?? {}), Authorization: `Bearer ${options.config.apiKey}` }
+          : options.config?.headers;
+      return {
+        ...resolved,
+        runtimeModel: {
+          ...resolved.model,
+          ...(headers ? { headers } : {}),
+        },
+        providerMatchesConfig: true,
+        ...(options.config?.apiKey ? { apiKey: options.config.apiKey } : {}),
+        ...(headers ? { headers } : {}),
+      };
+    },
+  );
   return {
     ...actual,
-    resolvePiSdkModel: vi.fn(),
+    resolvePiSdkModel,
+    resolvePiSdkRuntimeModel,
     runPiSdkChatCompletionIteration: vi.fn(),
   };
 });


### PR DESCRIPTION
## Summary
- share Pi SDK runtime model resolution between chat runs and context compaction
- apply custom Pi model metadata, auth headers, compat flags, and provider-scoped overrides consistently
- tighten Pi custom config validation and document the resolved-model override behavior

## Validation
- npm test -- packages/agent-server/src/llm/piSdkProvider.test.ts packages/agent-server/src/config.test.ts packages/agent-server/src/sessionHub.test.ts packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts packages/agent-server/src/chatProcessor.test.ts
- npm run build -w @assistant/agent-server
- targeted npx eslint on changed agent-server files
- git diff --check

Note: full monorepo Vitest runs were attempted, but large batches OOM/hang during worker teardown on this machine after many test files print as passing. Focused changed-surface validation passed.
