### PR TITLE
Fix Pi session sync repair and Focus list ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 
 ### Fixed
 
+- Fixed Pi session sync so unreconcilable persisted/live message divergence repairs the canonical JSONL from current messages instead of skipping the write, with diagnostics and failed-rewrite safeguards.
 - Fixed chat session picker search so existing sessions match only the displayed label and session id prefix, not hidden agent metadata. ([#101](https://github.com/kcosr/assistant/pull/101))
 - Fixed note edit compact mode to collapse title/description/tag/pinned/favorite rows and fixed split-pane drag resizing to preserve the visible bottom of chat transcripts while resizing stacked panels. ([#97](https://github.com/kcosr/assistant/pull/97))
 - Fixed header dock + button to pin panels to header instead of adding tabs (regression from e6353e8), and fixed compact panel launcher positioning to anchor below the clicked button. ([#96](https://github.com/kcosr/assistant/pull/96))
@@ -70,7 +71,6 @@
 
 ### Removed
 
-
 ## [0.18.1] - 2026-04-05
 
 ### Breaking Changes
@@ -91,7 +91,6 @@
 - Fixed panel inventory and `panels_selected` to report the actual active chat tab as the selected panel instead of surfacing a stale `empty` placeholder when chat is focused.
 
 ### Removed
-
 
 ## [0.18.0] - 2026-04-05
 
@@ -114,6 +113,7 @@
 - Added installable PWA icons to the mobile web manifest so the mobile app can be added to a home screen with proper `any maskable` icon sizes from 48px through 512px.
 
 ### Changed
+
 - Allowed Pi-backed agents to target custom `provider/model` ids through `chat.config.baseUrl` by
   synthesizing an `openai-responses` model when the provider has no built-in Pi model catalog.
 - Changed Android share-intent chat destinations to prefer the configured native voice session
@@ -163,7 +163,6 @@
 - Removed dead Pi EventStore overlay mirroring; Pi sessions now ignore EventStore persistence on the canonical path instead of duplicating overlay writes into the Pi transcript log.
 - Removed the dead Pi `ChatEvent` reconstruction helper and stale Pi history-provider test matrix; Pi replay validation now targets canonical transcript projection only.
 - Removed Pi replay support for legacy assistant overlay custom entries; canonical replay now restores only from canonical Pi `message` records plus request-boundary markers.
-
 
 ## [0.17.5] - 2026-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,8 @@
 
 ### Fixed
 
-- Fixed Pi session sync so unreconcilable persisted/live message divergence repairs the canonical JSONL from current messages instead of skipping the write, with diagnostics and failed-rewrite safeguards.
-- Fixed the Focus list to rank first in list dropdown/browser ordering and to honor add-to-top when creating items from the Focus list.
+- Fixed Pi session sync so unreconcilable persisted/live message divergence repairs the canonical JSONL from current messages instead of skipping the write, with diagnostics and failed-rewrite safeguards. ([#104](https://github.com/kcosr/assistant/pull/104))
+- Fixed the Focus list to rank first in list dropdown/browser ordering and to honor add-to-top when creating items from the Focus list. ([#104](https://github.com/kcosr/assistant/pull/104))
 - Fixed chat session picker search so existing sessions match only the displayed label and session id prefix, not hidden agent metadata. ([#101](https://github.com/kcosr/assistant/pull/101))
 - Fixed note edit compact mode to collapse title/description/tag/pinned/favorite rows and fixed split-pane drag resizing to preserve the visible bottom of chat transcripts while resizing stacked panels. ([#97](https://github.com/kcosr/assistant/pull/97))
 - Fixed header dock + button to pin panels to header instead of adding tabs (regression from e6353e8), and fixed compact panel launcher positioning to anchor below the clicked button. ([#96](https://github.com/kcosr/assistant/pull/96))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 ### Fixed
 
 - Fixed Pi session sync so unreconcilable persisted/live message divergence repairs the canonical JSONL from current messages instead of skipping the write, with diagnostics and failed-rewrite safeguards.
+- Fixed the Focus list to rank first in list dropdown/browser ordering and to honor add-to-top when creating items from the Focus list.
 - Fixed chat session picker search so existing sessions match only the displayed label and session id prefix, not hidden agent metadata. ([#101](https://github.com/kcosr/assistant/pull/101))
 - Fixed note edit compact mode to collapse title/description/tag/pinned/favorite rows and fixed split-pane drag resizing to preserve the visible bottom of chat transcripts while resizing stacked panels. ([#97](https://github.com/kcosr/assistant/pull/97))
 - Fixed header dock + button to pin panels to header instead of adding tabs (regression from e6353e8), and fixed compact panel launcher positioning to anchor below the clicked button. ([#96](https://github.com/kcosr/assistant/pull/96))

--- a/packages/agent-server/src/history/piSessionWriter.test.ts
+++ b/packages/agent-server/src/history/piSessionWriter.test.ts
@@ -544,10 +544,26 @@ describe('PiSessionWriter', () => {
       },
     });
 
+    const encodedCwd = `--${'/tmp/project'.replace(/^[/\\]/, '').replace(/[\\/:]/g, '-')}--`;
+    const sessionDir = path.join(baseDir, encodedCwd);
+    const files = await fs.readdir(sessionDir);
+    expect(files.length).toBe(1);
+    const filePath = path.join(sessionDir, files[0]!);
+    const staleEntries = parseJsonLines(await fs.readFile(filePath, 'utf8'));
+    staleEntries[0] = {
+      ...staleEntries[0],
+      parentSession: 'parent-session',
+    };
+    await fs.writeFile(
+      filePath,
+      `${staleEntries.map((entry) => JSON.stringify(entry)).join('\n')}\n`,
+      'utf8',
+    );
+
     await writer.appendTurnStart({
       summary,
       turnId: 'current-turn',
-      trigger: 'user',
+      trigger: 'callback',
       updateAttributes: async (patch) => {
         summary.attributes = {
           ...(summary.attributes ?? {}),
@@ -561,7 +577,7 @@ describe('PiSessionWriter', () => {
       summary,
       messages: [
         { role: 'system', content: 'system' },
-        { role: 'user', content: 'current user' },
+        { role: 'user', content: 'current user', meta: { source: 'callback' } },
         { role: 'assistant', content: 'current assistant' },
       ],
       updateAttributes: async (patch) => {
@@ -573,21 +589,20 @@ describe('PiSessionWriter', () => {
       },
     });
 
-    const encodedCwd = `--${'/tmp/project'.replace(/^[/\\]/, '').replace(/[\\/:]/g, '-')}--`;
-    const sessionDir = path.join(baseDir, encodedCwd);
-    const files = await fs.readdir(sessionDir);
-    expect(files.length).toBe(1);
-    const filePath = path.join(sessionDir, files[0]!);
     const entries = parseJsonLines(await fs.readFile(filePath, 'utf8'));
     const messageTexts = extractMessageTexts(entries);
 
+    expect(entries[0]).toMatchObject({
+      type: 'session',
+      parentSession: 'parent-session',
+    });
     expect(messageTexts).toEqual(['current user', 'current assistant']);
     expect(entries).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           type: 'custom',
           customType: 'assistant.request_start',
-          data: expect.objectContaining({ requestId: 'current-turn' }),
+          data: expect.objectContaining({ requestId: 'current-turn', trigger: 'callback' }),
         }),
       ]),
     );
@@ -634,7 +649,7 @@ describe('PiSessionWriter', () => {
       summary,
       messages: [
         { role: 'system', content: 'system' },
-        { role: 'user', content: 'current user' },
+        { role: 'user', content: 'current user', meta: { source: 'callback' } },
         { role: 'assistant', content: 'current assistant' },
       ],
     });
@@ -647,6 +662,93 @@ describe('PiSessionWriter', () => {
       ]),
     );
   });
+
+  it.each(['delete_request', 'trim_after'] as const)(
+    'keeps earlier repaired turns when applying %s to the open request',
+    async (action) => {
+      const baseDir = await createTempDir(`pi-session-writer-repair-${action}`);
+      const now = () => new Date('2026-02-01T00:00:00.000Z');
+      const writer = new PiSessionWriter({ baseDir, now, log: () => undefined });
+
+      const summary: SessionSummary = {
+        sessionId: `session-repair-${action}`,
+        agentId: 'pi',
+        createdAt: now().toISOString(),
+        updatedAt: now().toISOString(),
+        attributes: {
+          core: { workingDir: '/tmp/project' },
+        },
+      };
+      const updateAttributes = async (patch: Record<string, unknown>) => {
+        summary.attributes = {
+          ...(summary.attributes ?? {}),
+          ...(patch as Record<string, unknown>),
+        } as NonNullable<SessionSummary['attributes']>;
+        return summary;
+      };
+
+      await writer.sync({
+        summary,
+        messages: [
+          { role: 'system', content: 'system' },
+          { role: 'user', content: 'stale user' },
+          { role: 'assistant', content: 'stale assistant' },
+        ],
+        updateAttributes,
+      });
+      await writer.appendTurnStart({
+        summary,
+        turnId: 'turn-2',
+        trigger: 'user',
+        updateAttributes,
+      });
+      await writer.sync({
+        summary,
+        messages: [
+          { role: 'system', content: 'system' },
+          { role: 'user', content: 'first turn' },
+          { role: 'assistant', content: 'First reply' },
+          { role: 'user', content: 'second turn' },
+          { role: 'assistant', content: 'Second reply' },
+        ],
+        updateAttributes,
+      });
+
+      const result = await writer.rewriteHistoryByRequest({
+        summary,
+        action,
+        requestId: 'turn-2',
+        updateAttributes,
+      });
+
+      expect(result.changed).toBe(true);
+      expect(result.droppedRequestIds).toEqual(['turn-2']);
+
+      const encodedCwd = `--${'/tmp/project'.replace(/^[/\\]/, '').replace(/[\\/:]/g, '-')}--`;
+      const sessionDir = path.join(baseDir, encodedCwd);
+      const files = await fs.readdir(sessionDir);
+      const filePath = path.join(sessionDir, files[0]!);
+      const content = await fs.readFile(filePath, 'utf8');
+      const entries = parseJsonLines(content);
+
+      expect(content).toContain('first turn');
+      expect(content).toContain('First reply');
+      expect(content).not.toContain('second turn');
+      expect(content).not.toContain('Second reply');
+      expect(content).not.toContain('"requestId":"turn-2"');
+      expect(
+        entries.some(
+          (entry) =>
+            entry['type'] === 'custom' && entry['customType'] === 'assistant.request_start',
+        ),
+      ).toBe(true);
+      expect(
+        entries.some(
+          (entry) => entry['type'] === 'custom' && entry['customType'] === 'assistant.request_end',
+        ),
+      ).toBe(true);
+    },
+  );
 
   it('does not advance rewrite state or revision when the atomic rewrite fails', async () => {
     const baseDir = await createTempDir('pi-session-writer-rewrite-failed');

--- a/packages/agent-server/src/history/piSessionWriter.test.ts
+++ b/packages/agent-server/src/history/piSessionWriter.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { AssistantMessage } from '@earendil-works/pi-ai';
 
@@ -20,6 +20,20 @@ function parseJsonLines(content: string): Array<Record<string, unknown>> {
     .trim()
     .split('\n')
     .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function extractMessageTexts(entries: Array<Record<string, unknown>>): string[] {
+  return entries
+    .filter((entry) => entry['type'] === 'message')
+    .map((entry) => entry['message'] as Record<string, unknown> | undefined)
+    .filter((message): message is Record<string, unknown> => !!message)
+    .flatMap((message) => {
+      const contentBlocks = Array.isArray(message['content']) ? message['content'] : [];
+      return contentBlocks
+        .filter((block): block is Record<string, unknown> => !!block && typeof block === 'object')
+        .map((block) => block['text'])
+        .filter((text): text is string => typeof text === 'string');
+    });
 }
 
 describe('PiSessionWriter', () => {
@@ -156,9 +170,7 @@ describe('PiSessionWriter', () => {
       | undefined;
     expect(toolCallBlock?.name).toBe('read');
 
-    const toolResultMessage = messageEntries[2]?.['message'] as
-      | { toolName?: string }
-      | undefined;
+    const toolResultMessage = messageEntries[2]?.['message'] as { toolName?: string } | undefined;
     expect(toolResultMessage?.toolName).toBe('read');
   });
 
@@ -182,12 +194,22 @@ describe('PiSessionWriter', () => {
       {
         role: 'user',
         content: 'Hello from agent',
-        meta: { source: 'agent', fromAgentId: 'agent-a', fromSessionId: 'sess-a', visibility: 'visible' },
+        meta: {
+          source: 'agent',
+          fromAgentId: 'agent-a',
+          fromSessionId: 'sess-a',
+          visibility: 'visible',
+        },
       },
       {
         role: 'user',
         content: 'Hidden callback input',
-        meta: { source: 'callback', fromAgentId: 'agent-b', fromSessionId: 'sess-b', visibility: 'hidden' },
+        meta: {
+          source: 'callback',
+          fromAgentId: 'agent-b',
+          fromSessionId: 'sess-b',
+          visibility: 'hidden',
+        },
       },
       { role: 'assistant', content: 'Ack' },
     ];
@@ -219,13 +241,17 @@ describe('PiSessionWriter', () => {
       .filter(Boolean)
       .filter((message) => message?.['role'] === 'user');
     expect(userMessageEntries.length).toBe(2);
-    expect(userMessageEntries[0]?.['content']).toEqual([{ type: 'text', text: 'Hello from agent' }]);
+    expect(userMessageEntries[0]?.['content']).toEqual([
+      { type: 'text', text: 'Hello from agent' },
+    ]);
     expect(userMessageEntries[0]?.['meta']).toEqual({
       source: 'agent',
       fromAgentId: 'agent-a',
       fromSessionId: 'sess-a',
     });
-    expect(userMessageEntries[1]?.['content']).toEqual([{ type: 'text', text: 'Hidden callback input' }]);
+    expect(userMessageEntries[1]?.['content']).toEqual([
+      { type: 'text', text: 'Hidden callback input' },
+    ]);
     expect(userMessageEntries[1]?.['meta']).toEqual({
       source: 'callback',
       fromAgentId: 'agent-b',
@@ -330,7 +356,12 @@ describe('PiSessionWriter', () => {
       {
         role: 'user',
         content: 'Hello from agent',
-        meta: { source: 'agent', fromAgentId: 'agent-a', fromSessionId: 'sess-a', visibility: 'visible' },
+        meta: {
+          source: 'agent',
+          fromAgentId: 'agent-a',
+          fromSessionId: 'sess-a',
+          visibility: 'visible',
+        },
       },
       { role: 'assistant', content: 'Ack' },
     ];
@@ -436,8 +467,9 @@ describe('PiSessionWriter', () => {
         (message): message is Record<string, unknown> =>
           !!message &&
           message['role'] === 'user' &&
-          typeof (message['meta'] as Record<string, unknown> | undefined)?.['source'] === 'string' &&
-          ((message['meta'] as Record<string, unknown>)['source'] === 'callback'),
+          typeof (message['meta'] as Record<string, unknown> | undefined)?.['source'] ===
+            'string' &&
+          (message['meta'] as Record<string, unknown>)['source'] === 'callback',
       );
     expect(callbackUserMessages).toHaveLength(2);
 
@@ -480,6 +512,225 @@ describe('PiSessionWriter', () => {
     expect(userTexts).toContain('follow-up two');
   });
 
+  it('rewrites the Pi history when persisted and current messages diverge without overlap', async () => {
+    const baseDir = await createTempDir('pi-session-writer-rewrite-diverged');
+    const now = () => new Date('2026-02-01T00:00:00.000Z');
+    const logRecords: unknown[][] = [];
+    const writer = new PiSessionWriter({ baseDir, now, log: (...args) => logRecords.push(args) });
+
+    const summary: SessionSummary = {
+      sessionId: 'session-diverged',
+      agentId: 'pi',
+      createdAt: now().toISOString(),
+      updatedAt: now().toISOString(),
+      attributes: {
+        core: { workingDir: '/tmp/project' },
+      },
+    };
+
+    await writer.sync({
+      summary,
+      messages: [
+        { role: 'system', content: 'system' },
+        { role: 'user', content: 'stale user' },
+        { role: 'assistant', content: 'stale assistant' },
+      ],
+      updateAttributes: async (patch) => {
+        summary.attributes = {
+          ...(summary.attributes ?? {}),
+          ...(patch as Record<string, unknown>),
+        } as NonNullable<SessionSummary['attributes']>;
+        return summary;
+      },
+    });
+
+    await writer.appendTurnStart({
+      summary,
+      turnId: 'current-turn',
+      trigger: 'user',
+      updateAttributes: async (patch) => {
+        summary.attributes = {
+          ...(summary.attributes ?? {}),
+          ...(patch as Record<string, unknown>),
+        } as NonNullable<SessionSummary['attributes']>;
+        return summary;
+      },
+    });
+
+    await writer.sync({
+      summary,
+      messages: [
+        { role: 'system', content: 'system' },
+        { role: 'user', content: 'current user' },
+        { role: 'assistant', content: 'current assistant' },
+      ],
+      updateAttributes: async (patch) => {
+        summary.attributes = {
+          ...(summary.attributes ?? {}),
+          ...(patch as Record<string, unknown>),
+        } as NonNullable<SessionSummary['attributes']>;
+        return summary;
+      },
+    });
+
+    const encodedCwd = `--${'/tmp/project'.replace(/^[/\\]/, '').replace(/[\\/:]/g, '-')}--`;
+    const sessionDir = path.join(baseDir, encodedCwd);
+    const files = await fs.readdir(sessionDir);
+    expect(files.length).toBe(1);
+    const filePath = path.join(sessionDir, files[0]!);
+    const entries = parseJsonLines(await fs.readFile(filePath, 'utf8'));
+    const messageTexts = extractMessageTexts(entries);
+
+    expect(messageTexts).toEqual(['current user', 'current assistant']);
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'custom',
+          customType: 'assistant.request_start',
+          data: expect.objectContaining({ requestId: 'current-turn' }),
+        }),
+      ]),
+    );
+    expect(logRecords).toEqual(
+      expect.arrayContaining([
+        [
+          'Pi session sync rewriting history after unreconcilable message alignment',
+          expect.objectContaining({
+            sessionId: 'session-diverged',
+            piSessionId: expect.any(String),
+            sessionFile: expect.stringContaining(baseDir),
+            persistedMessageCount: 2,
+            currentMessageCount: 2,
+            diagnostics: expect.objectContaining({
+              firstMismatchIndex: 0,
+              persistedWindow: expect.arrayContaining([
+                expect.objectContaining({
+                  source: 'persisted',
+                  role: 'user',
+                  textPreview: 'stale user',
+                }),
+              ]),
+              currentWindow: expect.arrayContaining([
+                expect.objectContaining({
+                  source: 'current',
+                  role: 'user',
+                  textPreview: 'current user',
+                }),
+              ]),
+            }),
+            syncCallStack: expect.any(Array),
+          }),
+        ],
+      ]),
+    );
+
+    const reloadLogRecords: unknown[][] = [];
+    const reloadedWriter = new PiSessionWriter({
+      baseDir,
+      now,
+      log: (...args) => reloadLogRecords.push(args),
+    });
+    await reloadedWriter.sync({
+      summary,
+      messages: [
+        { role: 'system', content: 'system' },
+        { role: 'user', content: 'current user' },
+        { role: 'assistant', content: 'current assistant' },
+      ],
+    });
+    expect(reloadLogRecords).not.toEqual(
+      expect.arrayContaining([
+        [
+          'Pi session sync rewriting history after unreconcilable message alignment',
+          expect.anything(),
+        ],
+      ]),
+    );
+  });
+
+  it('does not advance rewrite state or revision when the atomic rewrite fails', async () => {
+    const baseDir = await createTempDir('pi-session-writer-rewrite-failed');
+    const now = () => new Date('2026-02-01T00:00:00.000Z');
+    const writer = new PiSessionWriter({ baseDir, now, log: () => undefined });
+    const updateAttributes = vi.fn(async (patch: unknown) => {
+      summary.attributes = {
+        ...(summary.attributes ?? {}),
+        ...(patch as Record<string, unknown>),
+      } as NonNullable<SessionSummary['attributes']>;
+      return summary;
+    });
+
+    const summary: SessionSummary = {
+      sessionId: 'session-rewrite-failed',
+      agentId: 'pi',
+      createdAt: now().toISOString(),
+      updatedAt: now().toISOString(),
+      attributes: {
+        core: { workingDir: '/tmp/project' },
+      },
+    };
+
+    await writer.sync({
+      summary,
+      messages: [
+        { role: 'system', content: 'system' },
+        { role: 'user', content: 'stale user' },
+        { role: 'assistant', content: 'stale assistant' },
+      ],
+      updateAttributes,
+    });
+    await writer.appendTurnStart({
+      summary,
+      turnId: 'current-turn',
+      trigger: 'user',
+      updateAttributes,
+    });
+
+    const encodedCwd = `--${'/tmp/project'.replace(/^[/\\]/, '').replace(/[\\/:]/g, '-')}--`;
+    const sessionDir = path.join(baseDir, encodedCwd);
+    const [fileName] = await fs.readdir(sessionDir);
+    const filePath = path.join(sessionDir, fileName!);
+
+    updateAttributes.mockClear();
+    const renameSpy = vi.spyOn(fs, 'rename').mockRejectedValueOnce(new Error('rename failed'));
+    await expect(
+      writer.sync({
+        summary,
+        messages: [
+          { role: 'system', content: 'system' },
+          { role: 'user', content: 'current user' },
+          { role: 'assistant', content: 'current assistant' },
+        ],
+        updateAttributes,
+      }),
+    ).rejects.toThrow('rename failed');
+    renameSpy.mockRestore();
+
+    expect(updateAttributes).not.toHaveBeenCalled();
+    expect(extractMessageTexts(parseJsonLines(await fs.readFile(filePath, 'utf8')))).toEqual([
+      'stale user',
+      'stale assistant',
+    ]);
+    const tempFilesAfterFailure = (await fs.readdir(sessionDir)).filter((entry) =>
+      entry.includes('.tmp-'),
+    );
+    expect(tempFilesAfterFailure).toEqual([]);
+
+    await writer.sync({
+      summary,
+      messages: [
+        { role: 'system', content: 'system' },
+        { role: 'user', content: 'current user' },
+        { role: 'assistant', content: 'current assistant' },
+      ],
+      updateAttributes,
+    });
+    expect(extractMessageTexts(parseJsonLines(await fs.readFile(filePath, 'utf8')))).toEqual([
+      'current user',
+      'current assistant',
+    ]);
+  });
+
   it('appends explicit assistant custom entries without affecting message sync', async () => {
     const baseDir = await createTempDir('pi-session-writer-custom');
     const now = () => new Date('2026-02-01T00:00:00.000Z');
@@ -497,7 +748,10 @@ describe('PiSessionWriter', () => {
 
     await writer.sync({
       summary,
-      messages: [{ role: 'system', content: 'system' }, { role: 'assistant', content: 'Hello' }],
+      messages: [
+        { role: 'system', content: 'system' },
+        { role: 'assistant', content: 'Hello' },
+      ],
       updateAttributes: async (patch) => {
         summary.attributes = {
           ...(summary.attributes ?? {}),
@@ -524,7 +778,13 @@ describe('PiSessionWriter', () => {
     const last = entries[entries.length - 1] as Record<string, unknown> | undefined;
     expect(last?.['type']).toBe('custom');
     expect(last?.['customType']).toBe('assistant.interrupt');
-    expect(((last?.['data'] as Record<string, unknown> | undefined)?.['payload'] as Record<string, unknown> | undefined)?.['reason']).toBe('user_cancel');
+    expect(
+      (
+        (last?.['data'] as Record<string, unknown> | undefined)?.['payload'] as
+          | Record<string, unknown>
+          | undefined
+      )?.['reason'],
+    ).toBe('user_cancel');
   });
 
   it('appends custom transcript messages for visible Pi diagnostics', async () => {
@@ -599,7 +859,10 @@ describe('PiSessionWriter', () => {
     });
     await writer.sync({
       summary,
-      messages: [{ role: 'system', content: 'system' }, { role: 'assistant', content: 'Hello' }],
+      messages: [
+        { role: 'system', content: 'system' },
+        { role: 'assistant', content: 'Hello' },
+      ],
     });
     await writer.appendTurnEnd({ summary, turnId: 'turn-1', status: 'completed' });
 
@@ -708,7 +971,10 @@ describe('PiSessionWriter', () => {
     });
     await writer.sync({
       summary,
-      messages: [{ role: 'system', content: 'system' }, { role: 'assistant', content: 'Hello' }],
+      messages: [
+        { role: 'system', content: 'system' },
+        { role: 'assistant', content: 'Hello' },
+      ],
     });
 
     const writer2 = new PiSessionWriter({ baseDir, now });
@@ -882,7 +1148,12 @@ describe('PiSessionWriter', () => {
       ],
       updateAttributes,
     });
-    await writer.appendTurnEnd({ summary, turnId: 'turn-1', status: 'completed', updateAttributes });
+    await writer.appendTurnEnd({
+      summary,
+      turnId: 'turn-1',
+      status: 'completed',
+      updateAttributes,
+    });
 
     await writer.appendTurnStart({
       summary,
@@ -901,7 +1172,12 @@ describe('PiSessionWriter', () => {
       ],
       updateAttributes,
     });
-    await writer.appendTurnEnd({ summary, turnId: 'turn-2', status: 'completed', updateAttributes });
+    await writer.appendTurnEnd({
+      summary,
+      turnId: 'turn-2',
+      status: 'completed',
+      updateAttributes,
+    });
 
     const result = await writer.rewriteHistoryByRequest({
       summary,
@@ -1207,8 +1483,16 @@ describe('PiSessionWriter', () => {
     expect(JSON.stringify(entries)).toContain('first turn');
     expect(JSON.stringify(entries)).not.toContain('"se"');
     expect(JSON.stringify(entries)).not.toContain('second turn');
-    expect(entries.some((entry) => entry['type'] === 'custom' && entry['customType'] === 'assistant.request_start')).toBe(true);
-    expect(entries.some((entry) => entry['type'] === 'custom' && entry['customType'] === 'assistant.request_end')).toBe(true);
+    expect(
+      entries.some(
+        (entry) => entry['type'] === 'custom' && entry['customType'] === 'assistant.request_start',
+      ),
+    ).toBe(true);
+    expect(
+      entries.some(
+        (entry) => entry['type'] === 'custom' && entry['customType'] === 'assistant.request_end',
+      ),
+    ).toBe(true);
   });
 
   it('synthesizes request groups when explicit request markers are missing', async () => {
@@ -1284,12 +1568,10 @@ describe('PiSessionWriter', () => {
     const rewrittenContent = await fs.readFile(filePath, 'utf8');
     const rewrittenEntries = parseJsonLines(rewrittenContent);
     const requestStartEntries = rewrittenEntries.filter(
-      (entry) =>
-        entry['type'] === 'custom' && entry['customType'] === 'assistant.request_start',
+      (entry) => entry['type'] === 'custom' && entry['customType'] === 'assistant.request_start',
     );
     const requestEndEntries = rewrittenEntries.filter(
-      (entry) =>
-        entry['type'] === 'custom' && entry['customType'] === 'assistant.request_end',
+      (entry) => entry['type'] === 'custom' && entry['customType'] === 'assistant.request_end',
     );
 
     expect(requestStartEntries.length).toBeGreaterThan(0);
@@ -1368,7 +1650,10 @@ describe('PiSessionWriter', () => {
 
     await writer.sync({
       summary,
-      messages: [{ role: 'system', content: 'system' }, { role: 'assistant', content: 'Hello' }],
+      messages: [
+        { role: 'system', content: 'system' },
+        { role: 'assistant', content: 'Hello' },
+      ],
       updateAttributes: async (patch) => {
         summary.attributes = {
           ...(summary.attributes ?? {}),
@@ -1414,7 +1699,10 @@ describe('PiSessionWriter', () => {
 
     await writer.sync({
       summary,
-      messages: [{ role: 'system', content: 'system' }, { role: 'assistant', content: 'Hello' }],
+      messages: [
+        { role: 'system', content: 'system' },
+        { role: 'assistant', content: 'Hello' },
+      ],
       updateAttributes: async (patch) => {
         summary.attributes = {
           ...(summary.attributes ?? {}),
@@ -1489,7 +1777,9 @@ describe('PiSessionWriter', () => {
 
     const entries = parseJsonLines(first);
     const orphanPlaceholder = entries.find(
-      (entry) => entry['type'] === 'custom_message' && entry['customType'] === 'assistant.orphan_tool_result',
+      (entry) =>
+        entry['type'] === 'custom_message' &&
+        entry['customType'] === 'assistant.orphan_tool_result',
     );
     expect(orphanPlaceholder).toBeTruthy();
     expect(orphanPlaceholder?.['display']).toBe(false);
@@ -1497,7 +1787,11 @@ describe('PiSessionWriter', () => {
     const toolResultEntries = entries.filter((entry) => {
       if (entry['type'] !== 'message') return false;
       const message = entry['message'];
-      return message && typeof message === 'object' && (message as Record<string, unknown>)['role'] === 'toolResult';
+      return (
+        message &&
+        typeof message === 'object' &&
+        (message as Record<string, unknown>)['role'] === 'toolResult'
+      );
     });
     expect(toolResultEntries.length).toBe(0);
 

--- a/packages/agent-server/src/history/piSessionWriter.ts
+++ b/packages/agent-server/src/history/piSessionWriter.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -177,6 +177,41 @@ type MessageSyncAlignment = {
   startIndex: number;
   matchedCount: number;
   mode: 'prefix' | 'suffix' | 'none';
+};
+
+type PiSessionSyncDiagnosticMessage = {
+  index: number;
+  signatureHash: string;
+  source: 'persisted' | 'current';
+  role?: string;
+  entryType?: string;
+  customType?: string;
+  textLength?: number;
+  textPreview?: string;
+  contentTypes?: string[];
+  toolCallIds?: string[];
+  toolCallNames?: string[];
+  toolCallId?: string;
+  toolName?: string;
+  timestamp?: number | string;
+  historyTimestampMs?: number;
+  stopReason?: string;
+  meta?: unknown;
+  hasPiSdkMessage?: boolean;
+  piSdkMessage?: Omit<PiSessionSyncDiagnosticMessage, 'index' | 'signatureHash' | 'source'>;
+};
+
+type PiSessionSyncMismatchDiagnostics = {
+  firstMismatchIndex: number;
+  persistedSignatureHashAtMismatch?: string;
+  currentSignatureHashAtMismatch?: string;
+  persistedWindow: PiSessionSyncDiagnosticMessage[];
+  currentWindow: PiSessionSyncDiagnosticMessage[];
+  persistedTail: PiSessionSyncDiagnosticMessage[];
+  currentTail: PiSessionSyncDiagnosticMessage[];
+  persistedEffectiveEntryCount?: number;
+  persistedDiagnosticEntryCount?: number;
+  persistedRecordsUnavailable?: boolean;
 };
 
 type PiRequestSpan = {
@@ -420,6 +455,135 @@ function stableSerialize(value: unknown): string {
   return JSON.stringify(stableNormalizeJson(value));
 }
 
+function hashDiagnosticSignature(signature: string | undefined): string {
+  if (!signature) {
+    return '';
+  }
+  return createHash('sha256').update(signature).digest('hex').slice(0, 16);
+}
+
+function findFirstSignatureMismatch(left: string[], right: string[]): number {
+  const limit = Math.max(left.length, right.length);
+  for (let index = 0; index < limit; index += 1) {
+    if (left[index] !== right[index]) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function extractDiagnosticText(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => extractDiagnosticText(item)).join('');
+  }
+  if (!isRecord(value)) {
+    return '';
+  }
+  return (
+    getString(value['text']) ||
+    getString(value['thinking']) ||
+    getString(value['content']) ||
+    extractDiagnosticText(value['content'])
+  );
+}
+
+function buildTextDiagnostic(text: string): { textLength?: number; textPreview?: string } {
+  if (!text) {
+    return {};
+  }
+  const previewLimit = 240;
+  return {
+    textLength: text.length,
+    textPreview: text.length > previewLimit ? `${text.slice(0, previewLimit)}...` : text,
+  };
+}
+
+function summarizePiMessageForSyncDiagnostics(
+  message: unknown,
+): Omit<PiSessionSyncDiagnosticMessage, 'index' | 'signatureHash' | 'source'> {
+  if (!isRecord(message)) {
+    return { role: typeof message };
+  }
+  const role = getString(message['role']);
+  const content = Array.isArray(message['content']) ? message['content'] : [];
+  const contentTypes = content.flatMap((block) =>
+    isRecord(block) && getString(block['type']) ? [getString(block['type'])] : [],
+  );
+  const toolCallBlocks = content.filter(
+    (block): block is Record<string, unknown> =>
+      isRecord(block) && getString(block['type']) === 'toolCall',
+  );
+  const text = extractDiagnosticText(content);
+  return {
+    ...(role ? { role } : {}),
+    ...buildTextDiagnostic(text),
+    ...(contentTypes.length > 0 ? { contentTypes } : {}),
+    ...(toolCallBlocks.length > 0
+      ? {
+          toolCallIds: toolCallBlocks.flatMap((block) => {
+            const id = getString(block['id']);
+            return id ? [id] : [];
+          }),
+          toolCallNames: toolCallBlocks.flatMap((block) => {
+            const name = getString(block['name']);
+            return name ? [name] : [];
+          }),
+        }
+      : {}),
+    ...(getString(message['toolCallId']) ? { toolCallId: getString(message['toolCallId']) } : {}),
+    ...(getString(message['toolName']) ? { toolName: getString(message['toolName']) } : {}),
+    ...(typeof message['timestamp'] === 'number' || typeof message['timestamp'] === 'string'
+      ? { timestamp: message['timestamp'] as number | string }
+      : {}),
+    ...(getString(message['stopReason']) ? { stopReason: getString(message['stopReason']) } : {}),
+    ...(message['meta'] !== undefined ? { meta: message['meta'] } : {}),
+  };
+}
+
+function summarizeChatMessageForSyncDiagnostics(options: {
+  index: number;
+  signature: string | undefined;
+  message: ChatCompletionMessage;
+}): PiSessionSyncDiagnosticMessage {
+  const { index, signature, message } = options;
+  const toolCalls =
+    message.role === 'assistant' && Array.isArray(message.tool_calls) ? message.tool_calls : [];
+  return {
+    index,
+    signatureHash: hashDiagnosticSignature(signature),
+    source: 'current',
+    role: message.role,
+    ...(message.role === 'user' || message.role === 'assistant'
+      ? buildTextDiagnostic(message.content ?? '')
+      : {}),
+    ...(message.role === 'tool' ? buildTextDiagnostic(message.content) : {}),
+    ...('historyTimestampMs' in message && typeof message.historyTimestampMs === 'number'
+      ? { historyTimestampMs: message.historyTimestampMs }
+      : {}),
+    ...(message.role === 'user' && message.meta !== undefined ? { meta: message.meta } : {}),
+    ...(toolCalls.length > 0
+      ? {
+          toolCallIds: toolCalls.flatMap((call) => (call.id ? [call.id] : [])),
+          toolCallNames: toolCalls.flatMap((call) =>
+            call.function?.name ? [call.function.name] : [],
+          ),
+        }
+      : {}),
+    ...(message.role === 'tool' ? { toolCallId: message.tool_call_id } : {}),
+    ...(message.role === 'assistant'
+      ? {
+          hasPiSdkMessage: Boolean(message.piSdkMessage),
+          ...(message.piSdkMessage
+            ? { piSdkMessage: summarizePiMessageForSyncDiagnostics(message.piSdkMessage) }
+            : {}),
+        }
+      : {}),
+  };
+}
+
 function normalizePiContentBlockForSignature(block: unknown): unknown {
   if (!isRecord(block)) {
     return block;
@@ -522,6 +686,7 @@ function signatureFromCustomMessageEntry(entry: {
 function signatureFromChatCompletionMessage(
   message: ChatCompletionMessage,
   toolCallNameMap: Map<string, string>,
+  knownToolCallIds?: Set<string>,
 ): string {
   switch (message.role) {
     case 'user': {
@@ -566,7 +731,10 @@ function signatureFromChatCompletionMessage(
     }
     case 'tool': {
       const toolCallId = message.tool_call_id;
-      if (!toolCallNameMap.has(toolCallId)) {
+      const hasKnownToolCall = knownToolCallIds
+        ? knownToolCallIds.has(toolCallId)
+        : toolCallNameMap.has(toolCallId);
+      if (!hasKnownToolCall) {
         return signatureFromCustomMessageEntry({
           customType: ORPHAN_TOOL_RESULT_CUSTOM_TYPE,
           content: '',
@@ -589,6 +757,26 @@ function signatureFromChatCompletionMessage(
     default:
       return stableSerialize({ role: message.role });
   }
+}
+
+function buildMessageSyncSignatures(
+  messages: ChatCompletionMessage[],
+  toolCallNameMap: Map<string, string>,
+): string[] {
+  const knownToolCallIds = new Set<string>();
+  return messages.map((message) => {
+    const signature = signatureFromChatCompletionMessage(
+      message,
+      toolCallNameMap,
+      knownToolCallIds,
+    );
+    if (message.role === 'assistant') {
+      for (const toolCallId of collectToolCallIdsFromAssistantMessage(message)) {
+        knownToolCallIds.add(toolCallId);
+      }
+    }
+    return signature;
+  });
 }
 
 function signaturesEqual(
@@ -1130,6 +1318,177 @@ function buildEffectiveMessageSignatures(entries: PiSessionEntryRecord[]): strin
   });
 }
 
+function summarizePersistedEntryForSyncDiagnostics(options: {
+  index: number;
+  signature: string | undefined;
+  entry: PiSessionEntryRecord;
+}): PiSessionSyncDiagnosticMessage[] {
+  const { index, signature, entry } = options;
+  if (entry.type === 'compaction') {
+    const summary = getString(entry['summary']);
+    if (!summary) {
+      return [];
+    }
+    return [
+      {
+        index,
+        signatureHash: hashDiagnosticSignature(signature),
+        source: 'persisted',
+        entryType: entry.type,
+        role: 'user',
+        ...buildTextDiagnostic(buildCompactionSummaryText(summary)),
+        ...(getString(entry['timestamp']) ? { timestamp: getString(entry['timestamp']) } : {}),
+      },
+    ];
+  }
+  if (entry.type === 'message') {
+    return [
+      {
+        index,
+        signatureHash: hashDiagnosticSignature(signature),
+        source: 'persisted',
+        entryType: entry.type,
+        ...summarizePiMessageForSyncDiagnostics(entry['message']),
+      },
+    ];
+  }
+  if (entry.type === 'custom_message') {
+    const customType = getString(entry['customType']);
+    if (customType !== ORPHAN_TOOL_RESULT_CUSTOM_TYPE) {
+      return [];
+    }
+    return [
+      {
+        index,
+        signatureHash: hashDiagnosticSignature(signature),
+        source: 'persisted',
+        entryType: entry.type,
+        customType,
+        ...buildTextDiagnostic(extractDiagnosticText(entry['content'])),
+        ...(getString(entry['timestamp']) ? { timestamp: getString(entry['timestamp']) } : {}),
+        ...(entry['details'] !== undefined ? { meta: { details: entry['details'] } } : {}),
+      },
+    ];
+  }
+  return [];
+}
+
+function buildPersistedSyncDiagnosticMessages(options: {
+  records: PiSessionFileRecords | null;
+  signatures: string[];
+}): {
+  messages: PiSessionSyncDiagnosticMessage[];
+  effectiveEntryCount?: number;
+  diagnosticEntryCount?: number;
+  recordsUnavailable?: boolean;
+} {
+  const { records, signatures } = options;
+  if (!records) {
+    return {
+      recordsUnavailable: true,
+      messages: signatures.map((signature, index) => ({
+        index,
+        signatureHash: hashDiagnosticSignature(signature),
+        source: 'persisted',
+      })),
+    };
+  }
+  const effectiveEntries = buildEffectiveMessageSignatureEntries(records.entries);
+  let signatureIndex = 0;
+  const messages: PiSessionSyncDiagnosticMessage[] = [];
+  for (const entry of effectiveEntries) {
+    const summaries = summarizePersistedEntryForSyncDiagnostics({
+      index: signatureIndex,
+      signature: signatures[signatureIndex],
+      entry,
+    });
+    if (summaries.length === 0) {
+      continue;
+    }
+    messages.push(...summaries);
+    signatureIndex += summaries.length;
+  }
+  return {
+    messages,
+    effectiveEntryCount: effectiveEntries.length,
+    diagnosticEntryCount: messages.length,
+  };
+}
+
+function sliceDiagnosticWindow<T>(items: T[], mismatchIndex: number, radius = 2): T[] {
+  if (items.length === 0) {
+    return [];
+  }
+  const start = Math.max(0, mismatchIndex - radius);
+  const end = Math.min(items.length, mismatchIndex + radius + 1);
+  return items.slice(start, end);
+}
+
+function buildSyncMismatchDiagnostics(options: {
+  persistedSignatures: string[];
+  currentSignatures: string[];
+  currentMessages: ChatCompletionMessage[];
+  persistedRecords: PiSessionFileRecords | null;
+}): PiSessionSyncMismatchDiagnostics {
+  const { persistedSignatures, currentSignatures, currentMessages, persistedRecords } = options;
+  const firstMismatchIndex = findFirstSignatureMismatch(persistedSignatures, currentSignatures);
+  const mismatchIndex = firstMismatchIndex === -1 ? 0 : firstMismatchIndex;
+  const persisted = buildPersistedSyncDiagnosticMessages({
+    records: persistedRecords,
+    signatures: persistedSignatures,
+  });
+  const current = currentMessages.map((message, index) =>
+    summarizeChatMessageForSyncDiagnostics({
+      index,
+      signature: currentSignatures[index],
+      message,
+    }),
+  );
+  return {
+    firstMismatchIndex,
+    ...(persistedSignatures[mismatchIndex]
+      ? {
+          persistedSignatureHashAtMismatch: hashDiagnosticSignature(
+            persistedSignatures[mismatchIndex],
+          ),
+        }
+      : {}),
+    ...(currentSignatures[mismatchIndex]
+      ? {
+          currentSignatureHashAtMismatch: hashDiagnosticSignature(currentSignatures[mismatchIndex]),
+        }
+      : {}),
+    persistedWindow: sliceDiagnosticWindow(persisted.messages, mismatchIndex),
+    currentWindow: sliceDiagnosticWindow(current, mismatchIndex),
+    persistedTail: persisted.messages.slice(-3),
+    currentTail: current.slice(-3),
+    ...(persisted.effectiveEntryCount !== undefined
+      ? { persistedEffectiveEntryCount: persisted.effectiveEntryCount }
+      : {}),
+    ...(persisted.diagnosticEntryCount !== undefined
+      ? { persistedDiagnosticEntryCount: persisted.diagnosticEntryCount }
+      : {}),
+    ...(persisted.recordsUnavailable ? { persistedRecordsUnavailable: true } : {}),
+  };
+}
+
+function buildSyncDiagnosticStack(): string[] {
+  return (new Error().stack ?? '')
+    .split('\n')
+    .slice(2, 10)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function findRewriteOpenRequestStartIndex(messages: ChatCompletionMessage[]): number | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index]?.role === 'user') {
+      return index;
+    }
+  }
+  return messages.length > 0 ? 0 : null;
+}
+
 function getRequestBoundaryRecord(entry: PiSessionEntryRecord): {
   kind: 'start' | 'end';
   requestId: string;
@@ -1559,15 +1918,8 @@ export class PiSessionWriter {
             fallbackTimestamp: this.now().toISOString(),
           }),
         );
-    const tempFilePath = `${state.sessionFile}.tmp-${randomUUID()}`;
-
     await this.queueWrite(state, async () => {
-      await fs.mkdir(state.sessionDir, { recursive: true });
-      const payload = [records.header, ...keptEntries]
-        .map((entry) => JSON.stringify(entry))
-        .join('\n');
-      await fs.writeFile(tempFilePath, `${payload}\n`, 'utf8');
-      await fs.rename(tempFilePath, state.sessionFile);
+      await this.atomicWriteSessionFile(state, records.header, keptEntries);
     });
 
     this.sessions.delete(summary.sessionId);
@@ -1699,30 +2051,44 @@ export class PiSessionWriter {
 
     const persistableMessages = messages.filter((message) => message.role !== 'system');
     const toolCallNameMap = buildToolCallNameMap(persistableMessages);
-    const currentSignatures = persistableMessages.map((message) =>
-      signatureFromChatCompletionMessage(message, toolCallNameMap),
-    );
+    const currentSignatures = buildMessageSyncSignatures(persistableMessages, toolCallNameMap);
     const alignment = resolveMessageSyncAlignment({
       persistedSignatures: state.messageSignatures,
       currentSignatures,
     });
 
-    if (
+    const shouldRewriteFromCurrentMessages =
       alignment.mode === 'none' &&
       state.messageSignatures.length > 0 &&
-      currentSignatures.length > 0
-    ) {
-      this.log('Pi session sync skipped due to unreconcilable message alignment', {
+      currentSignatures.length > 0;
+    if (shouldRewriteFromCurrentMessages) {
+      const persistedRecords = await loadPiSessionFileRecords(state.sessionFile);
+      const mismatchDiagnostics = buildSyncMismatchDiagnostics({
+        persistedSignatures: state.messageSignatures,
+        currentSignatures,
+        currentMessages: persistableMessages,
+        persistedRecords,
+      });
+      this.log('Pi session sync rewriting history after unreconcilable message alignment', {
         sessionId: summary.sessionId,
         piSessionId: state.piSessionId,
+        sessionFile: state.sessionFile,
         persistedMessageCount: state.messageSignatures.length,
         currentMessageCount: currentSignatures.length,
+        openRequestId: state.openRequestId,
+        leafId: state.leafId,
+        alignment,
+        diagnostics: mismatchDiagnostics,
+        syncCallStack: buildSyncDiagnosticStack(),
       });
-      return currentSummary === summary ? undefined : currentSummary;
     }
 
-    const newMessages = persistableMessages.slice(alignment.startIndex);
-    const newMessageSignatures = currentSignatures.slice(alignment.startIndex);
+    const newMessages = persistableMessages.slice(
+      shouldRewriteFromCurrentMessages ? 0 : alignment.startIndex,
+    );
+    const newMessageSignatures = currentSignatures.slice(
+      shouldRewriteFromCurrentMessages ? 0 : alignment.startIndex,
+    );
     if (newMessages.length === 0) {
       return currentSummary === summary ? undefined : currentSummary;
     }
@@ -1744,18 +2110,44 @@ export class PiSessionWriter {
       ...(defaultProvider ? { defaultProvider } : {}),
     });
 
-    let leafId = state.leafId;
-    let messageCount = state.writtenMessageCount;
-    let hasAssistant = state.hasAssistant;
-    const knownToolCallIds = new Set(state.toolCallIds);
+    let leafId = shouldRewriteFromCurrentMessages ? null : state.leafId;
+    let messageCount = shouldRewriteFromCurrentMessages ? 0 : state.writtenMessageCount;
+    let hasAssistant = shouldRewriteFromCurrentMessages ? false : state.hasAssistant;
+    const knownToolCallIds = shouldRewriteFromCurrentMessages
+      ? new Set<string>()
+      : new Set(state.toolCallIds);
+    let lastModel = shouldRewriteFromCurrentMessages ? undefined : state.lastModel;
+    let lastThinking = shouldRewriteFromCurrentMessages ? undefined : state.lastThinking;
+    const rewriteOpenRequestId = shouldRewriteFromCurrentMessages ? state.openRequestId : null;
+    const rewriteOpenRequestStartIndex = rewriteOpenRequestId
+      ? findRewriteOpenRequestStartIndex(newMessages)
+      : null;
+    let rewriteOpenRequestStarted = false;
 
     const entries: PiSessionEntry[] = [];
+    const appendRewriteOpenRequestStart = () => {
+      if (!rewriteOpenRequestId || rewriteOpenRequestStarted) {
+        return;
+      }
+      const requestStart = this.createRequestBoundaryEntry(
+        leafId,
+        ASSISTANT_REQUEST_START_CUSTOM_TYPE,
+        {
+          v: ASSISTANT_REQUEST_BOUNDARY_VERSION,
+          requestId: rewriteOpenRequestId,
+          trigger: 'user',
+        },
+      );
+      entries.push(requestStart);
+      leafId = requestStart.id;
+      rewriteOpenRequestStarted = true;
+    };
 
     if (
       modelInfo &&
-      (!state.lastModel ||
-        state.lastModel.modelId !== modelInfo.modelId ||
-        state.lastModel.provider !== modelInfo.provider)
+      (!lastModel ||
+        lastModel.modelId !== modelInfo.modelId ||
+        lastModel.provider !== modelInfo.provider)
     ) {
       const modelEntry: PiSessionModelChangeEntry = {
         type: 'model_change',
@@ -1767,10 +2159,10 @@ export class PiSessionWriter {
       };
       entries.push(modelEntry);
       leafId = modelEntry.id;
-      state.lastModel = modelInfo;
+      lastModel = modelInfo;
     }
 
-    if (normalizedThinking && normalizedThinking !== state.lastThinking) {
+    if (normalizedThinking && normalizedThinking !== lastThinking) {
       const thinkingEntry: PiSessionThinkingChangeEntry = {
         type: 'thinking_level_change',
         id: generateEntryId(),
@@ -1780,10 +2172,13 @@ export class PiSessionWriter {
       };
       entries.push(thinkingEntry);
       leafId = thinkingEntry.id;
-      state.lastThinking = normalizedThinking;
+      lastThinking = normalizedThinking;
     }
 
-    for (const message of newMessages) {
+    for (const [messageIndex, message] of newMessages.entries()) {
+      if (rewriteOpenRequestStartIndex === messageIndex) {
+        appendRewriteOpenRequestStart();
+      }
       const messageTimestampValue =
         typeof message.historyTimestampMs === 'number' &&
         Number.isFinite(message.historyTimestampMs)
@@ -1875,6 +2270,12 @@ export class PiSessionWriter {
     }
 
     await this.queueWrite(state, async () => {
+      if (shouldRewriteFromCurrentMessages) {
+        await this.atomicWriteSessionFile(state, state.header, entries);
+        state.flushed = true;
+        return;
+      }
+
       if (!state.flushed) {
         await this.ensureSessionFile(state);
       }
@@ -1884,9 +2285,47 @@ export class PiSessionWriter {
 
     state.leafId = leafId;
     state.writtenMessageCount = messageCount;
-    state.messageSignatures.push(...newMessageSignatures);
+    state.messageSignatures = shouldRewriteFromCurrentMessages
+      ? newMessageSignatures
+      : [...state.messageSignatures, ...newMessageSignatures];
     state.hasAssistant = hasAssistant;
     state.toolCallIds = knownToolCallIds;
+    if (lastModel) {
+      state.lastModel = lastModel;
+    } else {
+      delete state.lastModel;
+    }
+    if (lastThinking) {
+      state.lastThinking = lastThinking;
+    } else {
+      delete state.lastThinking;
+    }
+    if (shouldRewriteFromCurrentMessages) {
+      state.openRequestId = rewriteOpenRequestId;
+      this.log('Pi session sync rewrite completed', {
+        sessionId: summary.sessionId,
+        piSessionId: state.piSessionId,
+        sessionFile: state.sessionFile,
+        rewrittenMessageCount: state.messageSignatures.length,
+        writtenEntryCount: entries.length,
+        openRequestId: state.openRequestId,
+        leafId: state.leafId,
+      });
+      if (updateAttributes) {
+        try {
+          const updated = await updateAttributes(
+            buildPiTranscriptRevisionPatch({
+              revision: getNextPiTranscriptRevision(currentSummary.attributes),
+            }),
+          );
+          if (updated) {
+            currentSummary = updated;
+          }
+        } catch (err) {
+          this.log('Failed to update Pi transcript revision after sync rewrite', err);
+        }
+      }
+    }
 
     return currentSummary === summary ? undefined : currentSummary;
   }
@@ -2292,10 +2731,41 @@ export class PiSessionWriter {
   }
 
   private async queueWrite(state: PiSessionWriterState, task: () => Promise<void>): Promise<void> {
-    state.writeQueue = state.writeQueue.then(task).catch((err) => {
+    const write = state.writeQueue.then(task);
+    state.writeQueue = write.catch((err) => {
       this.log('Pi session write failed', err);
     });
-    await state.writeQueue;
+    await write;
+  }
+
+  private async atomicWriteSessionFile(
+    state: PiSessionWriterState,
+    header: unknown,
+    entries: readonly unknown[],
+  ): Promise<void> {
+    await fs.mkdir(state.sessionDir, { recursive: true });
+    const tempFilePath = `${state.sessionFile}.tmp-${randomUUID()}`;
+    let renamed = false;
+    try {
+      const payload = [header, ...entries].map((entry) => JSON.stringify(entry)).join('\n');
+      await fs.writeFile(tempFilePath, `${payload}\n`, 'utf8');
+      await fs.rename(tempFilePath, state.sessionFile);
+      renamed = true;
+    } finally {
+      if (!renamed) {
+        await fs.unlink(tempFilePath).catch((err) => {
+          const error = err as NodeJS.ErrnoException;
+          if (error.code !== 'ENOENT') {
+            this.log('Failed to remove temporary Pi session rewrite file', {
+              sessionId: state.sessionId,
+              piSessionId: state.piSessionId,
+              tempFilePath,
+              error: error.message,
+            });
+          }
+        });
+      }
+    }
   }
 
   private async ensureSessionFile(state: PiSessionWriterState): Promise<void> {

--- a/packages/agent-server/src/history/piSessionWriter.ts
+++ b/packages/agent-server/src/history/piSessionWriter.ts
@@ -1480,15 +1480,6 @@ function buildSyncDiagnosticStack(): string[] {
     .filter(Boolean);
 }
 
-function findRewriteOpenRequestStartIndex(messages: ChatCompletionMessage[]): number | null {
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    if (messages[index]?.role === 'user') {
-      return index;
-    }
-  }
-  return messages.length > 0 ? 0 : null;
-}
-
 function getRequestBoundaryRecord(entry: PiSessionEntryRecord): {
   kind: 'start' | 'end';
   requestId: string;
@@ -1588,6 +1579,8 @@ function collectSyntheticRequestSpans(entries: PiSessionEntryRecord[]): PiReques
 
   if (startIndexes.length === 0) {
     startIndexes.push(0);
+  } else if (startIndexes[0] !== 0) {
+    startIndexes.unshift(0);
   }
 
   const spans: PiRequestSpan[] = [];
@@ -1639,14 +1632,17 @@ function materializeExplicitRequestBoundaries(options: {
   entries: PiSessionEntryRecord[];
   spans: PiRequestSpan[];
   fallbackTimestamp: string;
+  openRequestId?: string | null;
+  openSpanIndex?: number | null;
 }): PiSessionEntryRecord[] {
-  const { entries, spans, fallbackTimestamp } = options;
+  const { entries, spans, fallbackTimestamp, openRequestId, openSpanIndex } = options;
   if (spans.length === 0) {
     return entries.map((entry) => cloneJson(entry));
   }
 
   const materialized: PiSessionEntryRecord[] = [];
-  for (const span of spans) {
+  for (let spanIndex = 0; spanIndex < spans.length; spanIndex += 1) {
+    const span = spans[spanIndex]!;
     const spanEntries = entries
       .slice(span.startIndex, span.endIndex + 1)
       .map((entry) => cloneJson(entry));
@@ -1655,6 +1651,12 @@ function materializeExplicitRequestBoundaries(options: {
     }
     const firstEntry = spanEntries[0]!;
     const lastEntry = spanEntries[spanEntries.length - 1]!;
+    const isOpenSpan =
+      typeof openSpanIndex === 'number' &&
+      spanIndex === openSpanIndex &&
+      typeof openRequestId === 'string' &&
+      openRequestId.trim().length > 0;
+    const requestId = isOpenSpan ? openRequestId.trim() : span.requestId;
     materialized.push({
       type: 'custom',
       id: generateEntryId(),
@@ -1663,11 +1665,14 @@ function materializeExplicitRequestBoundaries(options: {
       customType: ASSISTANT_REQUEST_START_CUSTOM_TYPE,
       data: {
         v: ASSISTANT_REQUEST_BOUNDARY_VERSION,
-        requestId: span.requestId,
+        requestId,
         trigger: getSyntheticRequestTrigger(firstEntry),
       },
     });
     materialized.push(...spanEntries);
+    if (isOpenSpan) {
+      continue;
+    }
     materialized.push({
       type: 'custom',
       id: generateEntryId(),
@@ -1676,13 +1681,36 @@ function materializeExplicitRequestBoundaries(options: {
       customType: ASSISTANT_REQUEST_END_CUSTOM_TYPE,
       data: {
         v: ASSISTANT_REQUEST_BOUNDARY_VERSION,
-        requestId: span.requestId,
+        requestId,
         status: 'completed',
       },
     });
   }
 
   return materialized;
+}
+
+function toPiSessionEntryRecords(entries: PiSessionEntry[]): PiSessionEntryRecord[] {
+  return entries.map((entry) => cloneJson(entry) as unknown as PiSessionEntryRecord);
+}
+
+function materializeRewrittenRequestBoundaries(options: {
+  entries: PiSessionEntry[];
+  openRequestId: string | null;
+  fallbackTimestamp: string;
+}): PiSessionEntryRecord[] {
+  const entryRecords = toPiSessionEntryRecords(options.entries);
+  const spans = collectSyntheticRequestSpans(entryRecords);
+  const openSpanIndex = options.openRequestId && spans.length > 0 ? spans.length - 1 : null;
+  return rechainEntries(
+    materializeExplicitRequestBoundaries({
+      entries: entryRecords,
+      spans,
+      fallbackTimestamp: options.fallbackTimestamp,
+      ...(options.openRequestId ? { openRequestId: options.openRequestId } : {}),
+      ...(openSpanIndex !== null ? { openSpanIndex } : {}),
+    }),
+  );
 }
 
 function resolveOpenRequestIdFromEntries(entries: PiSessionEntryRecord[]): string | null {
@@ -2061,8 +2089,10 @@ export class PiSessionWriter {
       alignment.mode === 'none' &&
       state.messageSignatures.length > 0 &&
       currentSignatures.length > 0;
+    let rewriteHeader: unknown = state.header;
     if (shouldRewriteFromCurrentMessages) {
       const persistedRecords = await loadPiSessionFileRecords(state.sessionFile);
+      rewriteHeader = persistedRecords?.header ?? state.header;
       const mismatchDiagnostics = buildSyncMismatchDiagnostics({
         persistedSignatures: state.messageSignatures,
         currentSignatures,
@@ -2119,29 +2149,8 @@ export class PiSessionWriter {
     let lastModel = shouldRewriteFromCurrentMessages ? undefined : state.lastModel;
     let lastThinking = shouldRewriteFromCurrentMessages ? undefined : state.lastThinking;
     const rewriteOpenRequestId = shouldRewriteFromCurrentMessages ? state.openRequestId : null;
-    const rewriteOpenRequestStartIndex = rewriteOpenRequestId
-      ? findRewriteOpenRequestStartIndex(newMessages)
-      : null;
-    let rewriteOpenRequestStarted = false;
 
     const entries: PiSessionEntry[] = [];
-    const appendRewriteOpenRequestStart = () => {
-      if (!rewriteOpenRequestId || rewriteOpenRequestStarted) {
-        return;
-      }
-      const requestStart = this.createRequestBoundaryEntry(
-        leafId,
-        ASSISTANT_REQUEST_START_CUSTOM_TYPE,
-        {
-          v: ASSISTANT_REQUEST_BOUNDARY_VERSION,
-          requestId: rewriteOpenRequestId,
-          trigger: 'user',
-        },
-      );
-      entries.push(requestStart);
-      leafId = requestStart.id;
-      rewriteOpenRequestStarted = true;
-    };
 
     if (
       modelInfo &&
@@ -2175,10 +2184,7 @@ export class PiSessionWriter {
       lastThinking = normalizedThinking;
     }
 
-    for (const [messageIndex, message] of newMessages.entries()) {
-      if (rewriteOpenRequestStartIndex === messageIndex) {
-        appendRewriteOpenRequestStart();
-      }
+    for (const message of newMessages) {
       const messageTimestampValue =
         typeof message.historyTimestampMs === 'number' &&
         Number.isFinite(message.historyTimestampMs)
@@ -2268,10 +2274,20 @@ export class PiSessionWriter {
     if (entries.length === 0) {
       return currentSummary === summary ? undefined : currentSummary;
     }
+    const entriesToWrite = shouldRewriteFromCurrentMessages
+      ? materializeRewrittenRequestBoundaries({
+          entries,
+          openRequestId: rewriteOpenRequestId,
+          fallbackTimestamp: this.now().toISOString(),
+        })
+      : entries;
+    if (shouldRewriteFromCurrentMessages) {
+      leafId = entriesToWrite[entriesToWrite.length - 1]?.id ?? null;
+    }
 
     await this.queueWrite(state, async () => {
       if (shouldRewriteFromCurrentMessages) {
-        await this.atomicWriteSessionFile(state, state.header, entries);
+        await this.atomicWriteSessionFile(state, rewriteHeader, entriesToWrite);
         state.flushed = true;
         return;
       }
@@ -2307,7 +2323,7 @@ export class PiSessionWriter {
         piSessionId: state.piSessionId,
         sessionFile: state.sessionFile,
         rewrittenMessageCount: state.messageSignatures.length,
-        writtenEntryCount: entries.length,
+        writtenEntryCount: entriesToWrite.length,
         openRequestId: state.openRequestId,
         leafId: state.leafId,
       });

--- a/packages/web-client/src/controllers/collectionBrowserController.test.ts
+++ b/packages/web-client/src/controllers/collectionBrowserController.test.ts
@@ -285,6 +285,26 @@ describe('CollectionBrowserController list CRUD UI', () => {
     });
   });
 
+  it('keeps the Focus list at the top of browser list results', () => {
+    const { controller, containerEl } = makeController({
+      getAvailableItems: () => [
+        { type: 'list', id: 'agent-pack', name: 'Agent Pack' },
+        { type: 'list', id: '__focus__', name: 'Focus', specialKind: 'focus' },
+        { type: 'list', id: 'today', name: 'Today' },
+      ],
+    });
+
+    controller.show(false);
+
+    const ids = Array.from(
+      containerEl.querySelectorAll<HTMLElement>(
+        '.collection-search-dropdown-item[data-collection-type="list"]',
+      ),
+    ).map((el) => el.dataset['collectionId']);
+
+    expect(ids).toEqual(['__focus__', 'agent-pack', 'today']);
+  });
+
   it('sorts items by last updated and persists the choice', () => {
     window.localStorage.setItem('collectionBrowserTestSortMode', 'updated');
 

--- a/packages/web-client/src/controllers/collectionBrowserController.ts
+++ b/packages/web-client/src/controllers/collectionBrowserController.ts
@@ -922,6 +922,11 @@ export class CollectionBrowserController {
       if (idxA !== idxB) {
         return idxA - idxB;
       }
+      const specialRankA = a.specialKind === 'focus' ? 0 : 1;
+      const specialRankB = b.specialKind === 'focus' ? 0 : 1;
+      if (specialRankA !== specialRankB) {
+        return specialRankA - specialRankB;
+      }
       if (this.sortMode === 'updated') {
         const timeA = parseUpdatedAtMs(a.updatedAt);
         const timeB = parseUpdatedAtMs(b.updatedAt);

--- a/packages/web-client/src/controllers/collectionDropdown.test.ts
+++ b/packages/web-client/src/controllers/collectionDropdown.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { CollectionDropdownController } from './collectionDropdown';
+
+function makeController(
+  overrides?: Partial<ConstructorParameters<typeof CollectionDropdownController>[0]>,
+) {
+  const container = document.createElement('div');
+  const dropdown = document.createElement('div');
+  const trigger = document.createElement('button');
+  const triggerText = document.createElement('span');
+  const searchInput = document.createElement('input');
+  const list = document.createElement('div');
+  const tagsContainer = document.createElement('div');
+  const activeTagsContainer = document.createElement('div');
+  document.body.append(container, dropdown, trigger, triggerText, searchInput, list);
+
+  const options: ConstructorParameters<typeof CollectionDropdownController>[0] = {
+    container,
+    dropdown,
+    trigger,
+    triggerText,
+    searchInput,
+    list,
+    tagsContainer,
+    activeTagsContainer,
+    focusInput: vi.fn(),
+    isDialogOpen: () => false,
+    isPanelOpen: () => true,
+    isMobileViewport: () => false,
+    setPanelOpen: vi.fn(),
+    getAllTags: () => [],
+    getGroupLabel: (type) => (type === 'list' ? 'Lists' : 'Other'),
+    getSupportedTypes: () => ['list'],
+    getSortMode: () => 'alpha',
+    getActiveItemReference: () => null,
+    updateSelection: vi.fn(),
+    selectItem: vi.fn(),
+    ...overrides,
+  };
+
+  const controller = new CollectionDropdownController(options);
+  return { controller, list };
+}
+
+describe('CollectionDropdownController', () => {
+  it('keeps the Focus list at the top of list dropdown results', () => {
+    const { controller, list } = makeController();
+
+    controller.populate([
+      { type: 'list', id: 'agent-pack', name: 'Agent Pack' },
+      { type: 'list', id: '__focus__', name: 'Focus', specialKind: 'focus' },
+      { type: 'list', id: 'today', name: 'Today' },
+    ]);
+
+    const ids = Array.from(
+      list.querySelectorAll<HTMLElement>('.collection-search-dropdown-item'),
+    ).map((el) => el.dataset['collectionId']);
+
+    expect(ids).toEqual(['__focus__', 'agent-pack', 'today']);
+  });
+});

--- a/packages/web-client/src/controllers/collectionDropdown.ts
+++ b/packages/web-client/src/controllers/collectionDropdown.ts
@@ -229,6 +229,11 @@ export class CollectionDropdownController {
       if (idxA !== idxB) {
         return idxA - idxB;
       }
+      const specialRankA = a.specialKind === 'focus' ? 0 : 1;
+      const specialRankB = b.specialKind === 'focus' ? 0 : 1;
+      if (specialRankA !== specialRankB) {
+        return specialRankA - specialRankB;
+      }
       // Then sort within group by selected mode
       if (sortMode === 'updated') {
         const timeA = this.parseUpdatedAtMs(a.updatedAt);

--- a/packages/web-client/src/controllers/listPanelController.test.ts
+++ b/packages/web-client/src/controllers/listPanelController.test.ts
@@ -1380,6 +1380,39 @@ describe('ListPanelController focus view', () => {
     });
   });
 
+  it('adds newly created focus-view items to the top of Focus when inserted at top', async () => {
+    const callOperation = vi.fn(async (operation) => {
+      if (operation === 'item-add') {
+        return { id: 'new-item', title: 'New task' } as unknown;
+      }
+      return {} as unknown;
+    }) as NonNullable<ListPanelControllerOptions['callOperation']>;
+    const controller = buildController({ callOperation });
+    controller.render('__focus__', {
+      id: '__focus__',
+      name: 'Focus',
+      viewKind: 'focus',
+      items: [],
+    });
+
+    const internal = controller as unknown as {
+      createListItem: (listId: string, item: Record<string, unknown>) => Promise<boolean>;
+    };
+
+    await expect(internal.createListItem('work', { title: 'New task', position: 0 })).resolves.toBe(
+      true,
+    );
+    expect(callOperation).toHaveBeenNthCalledWith(1, 'item-add', {
+      listId: 'work',
+      title: 'New task',
+      position: 0,
+    });
+    expect(callOperation).toHaveBeenNthCalledWith(2, 'focus-add', {
+      itemId: 'new-item',
+      position: 0,
+    });
+  });
+
   it('routes the focus header add button through the source-list picker flow', async () => {
     const callOperation = vi.fn(async (operation) => {
       if (operation === 'item-add') {

--- a/packages/web-client/src/controllers/listPanelController.ts
+++ b/packages/web-client/src/controllers/listPanelController.ts
@@ -1313,6 +1313,7 @@ export class ListPanelController {
     try {
       const instanceId = this.addDialogInstanceOverrides.get(listId);
       const shouldFocus = item['focused'] === true;
+      const shouldAddToFocusTop = this.currentData?.viewKind === 'focus' && item['position'] === 0;
       const sourceItem = { ...item };
       delete sourceItem['focused'];
       const created = await this.runOperation<ListPanelItem>(
@@ -1323,7 +1324,7 @@ export class ListPanelController {
       if ((this.currentData?.viewKind === 'focus' || shouldFocus) && created?.id) {
         await this.runOperation(
           'focus-add',
-          { itemId: created.id },
+          { itemId: created.id, ...(shouldAddToFocusTop ? { position: 0 } : {}) },
           instanceId ? { instanceId } : undefined,
         );
       }


### PR DESCRIPTION
## Summary
- add Pi session sync repair logging and preserve complete request boundaries during repaired rewrites
- keep Focus ranked first in list dropdown/browser paths
- pass position: 0 when adding to Focus with add-to-top enabled

## Checks
- npm run build
- systemd deployment verified active/running
- Android default/work flavor deployment completed on connected devices
