### PR TITLE
Add scheduled session wake-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Added
 
-- Added one-shot Pi SDK session wake-ups to the scheduled-sessions plugin, including durable wake-up storage, current-session set/cancel tools, cross-session listing, busy-session queue delivery, and panel visibility/cancel controls.
+- Added one-shot Pi SDK session wake-ups to the scheduled-sessions plugin, including durable wake-up storage, current-session set/cancel tools, cross-session listing, busy-session queue delivery, and panel visibility/cancel controls. ([#105](https://github.com/kcosr/assistant/pull/105))
 - Added a virtual Focus list view with focus toggles, source-list editing, searchable list move/copy pickers, and add/edit list target selection for list items. ([#103](https://github.com/kcosr/assistant/pull/103))
 - Added Pi SDK custom-model config support for `api`, `authHeader`, `compat`, synthesized model metadata, and compaction so Assistant agents can target OpenAI-compatible endpoints that need Pi compatibility flags. ([#102](https://github.com/kcosr/assistant/pull/102))
 - Added Pi SDK session context compaction with Pi-compatible JSONL `compaction` entries, manual chat menu/API compaction, effective replay context, and threshold auto-compaction. ([#98](https://github.com/kcosr/assistant/pull/98))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Added one-shot Pi SDK session wake-ups to the scheduled-sessions plugin, including durable wake-up storage, current-session set/cancel tools, cross-session listing, busy-session queue delivery, and panel visibility/cancel controls.
 - Added a virtual Focus list view with focus toggles, source-list editing, searchable list move/copy pickers, and add/edit list target selection for list items. ([#103](https://github.com/kcosr/assistant/pull/103))
 - Added Pi SDK custom-model config support for `api`, `authHeader`, `compat`, synthesized model metadata, and compaction so Assistant agents can target OpenAI-compatible endpoints that need Pi compatibility flags. ([#102](https://github.com/kcosr/assistant/pull/102))
 - Added Pi SDK session context compaction with Pi-compatible JSONL `compaction` entries, manual chat menu/API compaction, effective replay context, and threshold auto-compaction. ([#98](https://github.com/kcosr/assistant/pull/98))

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -586,6 +586,12 @@ Scheduled sessions are no longer configured on agents. Use the `scheduled-sessio
 create and manage them dynamically. They are stored in the plugin data directory under
 `data/plugins/scheduled-sessions/default/schedules.json`.
 
+The same plugin also stores pending one-shot session wake-ups under
+`data/plugins/scheduled-sessions/default/wakeups.json`. Wake-ups are limited to native Pi SDK
+sessions (`chat.provider: "pi"`), target the current tool session for set/cancel operations, and
+send the configured message back to that session at the requested time. If the session is busy when
+the wake-up fires, the message is added to the existing per-session message queue.
+
 Each persisted schedule record includes:
 
 - `agentId`
@@ -615,7 +621,22 @@ Notes:
   after edits.
 - When `reuseSession` is `false`, each run creates a fresh backing session.
 - `maxConcurrent` only matters when `reuseSession` is `false`.
-- Enable the `scheduled-sessions` plugin to create, edit, delete, run, and toggle schedules.
+- Enable the `scheduled-sessions` plugin to create, edit, delete, run, and toggle schedules, and to
+  list/set/cancel pending session wake-ups.
+
+Wake-up tools:
+
+- `scheduled_sessions_wakeup_set`
+  - `message`
+  - exactly one of `runAt` or `delaySeconds`
+  - `runAt` must be an absolute ISO timestamp with an explicit timezone offset or `Z`, for example
+    `2026-06-03T08:56:00-05:00` or `2026-06-03T13:56:00Z`
+  - optional `replace` to replace the current session's existing pending wake-up
+- `scheduled_sessions_wakeup_cancel`
+- `scheduled_sessions_wakeup_list`
+
+`set` and `cancel` intentionally do not accept a `sessionId`; they use the current tool context.
+`list` returns pending wake-ups across sessions for user visibility.
 
 #### `pi` Provider
 

--- a/packages/agent-server/src/scheduledSessions/index.ts
+++ b/packages/agent-server/src/scheduledSessions/index.ts
@@ -1,4 +1,5 @@
 export { ScheduledSessionService, ScheduleNotFoundError } from './scheduledSessionService';
 export { ScheduledSessionStore } from './scheduledSessionStore';
+export { SessionWakeupStore } from './sessionWakeupStore';
 export * from './types';
 export * from './cronUtils';

--- a/packages/agent-server/src/scheduledSessions/scheduledSessionService.test.ts
+++ b/packages/agent-server/src/scheduledSessions/scheduledSessionService.test.ts
@@ -172,6 +172,10 @@ function createSessionIndexStub() {
 
   return {
     sessions,
+    getSession: vi.fn(async (sessionId: string) => {
+      const session = sessions.find((item) => item.sessionId === sessionId);
+      return session ? { ...session } : null;
+    }),
     listSessions: vi.fn(async () => sessions.filter((session) => !session.deleted)),
     createSession: vi.fn(
       async ({
@@ -402,8 +406,155 @@ function createServiceWithSessions(
   return { service, schedule, sessionIndex, sessionHub, startSessionMessageFn, storeDir };
 }
 
+function createWakeupService(options?: {
+  provider?: 'pi' | 'codex-cli';
+  active?: boolean;
+  startStatus?: 'complete' | 'busy' | 'error';
+}) {
+  const storeDir = mkdtempSync(path.join(os.tmpdir(), 'session-wakeups-'));
+  mkdirSync(storeDir, { recursive: true });
+  const registry = new AgentRegistry([
+    {
+      agentId: 'agent',
+      displayName: 'Agent',
+      description: 'Test agent',
+      chat: {
+        provider: options?.provider ?? 'pi',
+        models: ['gpt-5.4'],
+        thinking: ['low'],
+      },
+    },
+  ]);
+  const sessionIndex = createSessionIndexStub();
+  const timestamp = new Date().toISOString();
+  sessionIndex.sessions.push({
+    sessionId: 'session-1',
+    agentId: 'agent',
+    name: 'Issue Watch',
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  });
+
+  const startSessionMessageFn = vi.fn(
+    async (): Promise<SessionMessageStartResult> => {
+      if (options?.startStatus === 'busy') {
+        return {
+          response: {
+            sessionId: 'session-1',
+            sessionName: 'Issue Watch',
+            agentId: 'agent',
+            created: false,
+            status: 'busy',
+            code: 'session_busy',
+            message: 'busy',
+          },
+        };
+      }
+      if (options?.startStatus === 'error') {
+        return {
+          response: {
+            sessionId: 'session-1',
+            sessionName: 'Issue Watch',
+            agentId: 'agent',
+            created: false,
+            status: 'error',
+            responseId: 'resp-error',
+            error: 'delivery failed',
+            durationMs: 0,
+          },
+        };
+      }
+      return {
+        response: {
+          sessionId: 'session-1',
+          sessionName: 'Issue Watch',
+          agentId: 'agent',
+          created: false,
+          status: 'complete',
+          responseId: 'resp-1',
+          response: 'ok',
+          truncated: false,
+          durationMs: 0,
+          toolCallCount: 0,
+          toolCalls: [],
+        },
+      };
+    },
+  );
+
+  const queuedTasks: Array<() => Promise<void>> = [];
+  const sessionHub = {
+    ensureSessionState: vi.fn(async (sessionId: string) => ({
+      summary:
+        sessionIndex.sessions.find((session) => session.sessionId === sessionId) ??
+        (() => {
+          throw new Error(`Session not found: ${sessionId}`);
+        })(),
+      chatMessages: [],
+      ...(options?.active
+        ? {
+            activeChatRun: {
+              responseId: 'active-response',
+              abortController: new AbortController(),
+              accumulatedText: '',
+            },
+          }
+        : {}),
+      messageQueue: [],
+    })),
+    queueMessage: vi.fn(
+      async (queueOptions: {
+        sessionId: string;
+        text: string;
+        source: 'user' | 'agent';
+        execute: () => Promise<void>;
+      }) => {
+        queuedTasks.push(queueOptions.execute);
+        return {
+          id: 'queued-1',
+          text: queueOptions.text,
+          queuedAt: new Date().toISOString(),
+          source: queueOptions.source,
+        };
+      },
+    ),
+  };
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+  const broadcast = vi.fn();
+  const service = new ScheduledSessionService({
+    agentRegistry: registry,
+    logger,
+    store: new ScheduledSessionStore(storeDir),
+    sessionIndex: sessionIndex as unknown as SessionIndex,
+    sessionHub: sessionHub as unknown as SessionHub,
+    envConfig: {} as EnvConfig,
+    toolHost: {} as ToolHost,
+    startSessionMessageFn,
+    broadcast,
+  });
+
+  return {
+    service,
+    sessionIndex,
+    sessionHub,
+    startSessionMessageFn,
+    queuedTasks,
+    broadcast,
+    storeDir,
+  };
+}
+
 async function tick(): Promise<void> {
   await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function wait(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 describe('ScheduledSessionService', () => {
@@ -744,6 +895,315 @@ describe('ScheduledSessionService', () => {
         scheduledSession: { agentId: 'agent', scheduleId: 'daily-review' },
       },
     });
+
+    service.shutdown();
+  });
+
+  it('sets, lists, and cancels one current-session wake-up', async () => {
+    const { service } = createWakeupService();
+    await service.initialize();
+
+    const runAt = new Date(Date.now() + 60_000);
+    const created = await service.setWakeupForSession({
+      sessionId: 'session-1',
+      message: 'Check the status of the issue',
+      runAt,
+    });
+
+    expect(created).toMatchObject({
+      sessionId: 'session-1',
+      sessionName: 'Issue Watch',
+      agentId: 'agent',
+      message: 'Check the status of the issue',
+      runAt: runAt.toISOString(),
+    });
+    await expect(service.listWakeups()).resolves.toHaveLength(1);
+
+    const cancel = await service.cancelWakeupForSession('session-1');
+    expect(cancel).toEqual({
+      cancelled: true,
+      sessionId: 'session-1',
+      wakeupId: created.wakeupId,
+    });
+    await expect(service.listWakeups()).resolves.toEqual([]);
+
+    service.shutdown();
+  });
+
+  it('rejects a second wake-up for the same session unless replace is true', async () => {
+    const { service } = createWakeupService();
+    await service.initialize();
+
+    const runAt = new Date(Date.now() + 60_000);
+    await service.setWakeupForSession({
+      sessionId: 'session-1',
+      message: 'First',
+      runAt,
+    });
+
+    await expect(
+      service.setWakeupForSession({
+        sessionId: 'session-1',
+        message: 'Second',
+        runAt,
+      }),
+    ).rejects.toThrow(/already has a pending wake-up/i);
+
+    const replacement = await service.setWakeupForSession({
+      sessionId: 'session-1',
+      message: 'Second',
+      runAt,
+      replace: true,
+    });
+    expect(replacement.message).toBe('Second');
+    await expect(service.listWakeups()).resolves.toHaveLength(1);
+
+    service.shutdown();
+  });
+
+  it('preserves one wake-up per session under concurrent set calls', async () => {
+    const { service } = createWakeupService();
+    await service.initialize();
+
+    const runAt = new Date(Date.now() + 60_000);
+    const results = await Promise.allSettled([
+      service.setWakeupForSession({
+        sessionId: 'session-1',
+        message: 'First',
+        runAt,
+      }),
+      service.setWakeupForSession({
+        sessionId: 'session-1',
+        message: 'Second',
+        runAt,
+      }),
+    ]);
+
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1);
+    await expect(service.listWakeups()).resolves.toHaveLength(1);
+
+    service.shutdown();
+  });
+
+  it('rejects wake-ups for non-native Pi sessions', async () => {
+    const { service } = createWakeupService({ provider: 'codex-cli' });
+    await service.initialize();
+
+    await expect(
+      service.setWakeupForSession({
+        sessionId: 'session-1',
+        message: 'Check the issue',
+        runAt: new Date(Date.now() + 60_000),
+      }),
+    ).rejects.toThrow(/only supported for native Pi SDK sessions/i);
+
+    service.shutdown();
+  });
+
+  it('retries queued wake-ups after restart and prunes already-claimed wake-ups', async () => {
+    const { service, sessionIndex, storeDir } = createWakeupService();
+    const timestamp = new Date().toISOString();
+    sessionIndex.sessions.push({
+      sessionId: 'session-2',
+      agentId: 'agent',
+      name: 'Claimed Wakeup',
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+    const runAt = new Date(Date.now() + 60_000).toISOString();
+    writeFileSync(
+      path.join(storeDir, 'wakeups.json'),
+      `${JSON.stringify({
+        version: 1,
+        wakeups: [
+          {
+            wakeupId: 'wakeup-queued',
+            sessionId: 'session-1',
+            agentId: 'agent',
+            message: 'Queued retry',
+            runAt,
+            createdAt: timestamp,
+            status: 'queued',
+          },
+          {
+            wakeupId: 'wakeup-delivering',
+            sessionId: 'session-2',
+            agentId: 'agent',
+            message: 'Already claimed',
+            runAt,
+            createdAt: timestamp,
+            status: 'delivering',
+          },
+        ],
+      })}\n`,
+      'utf8',
+    );
+
+    await service.initialize();
+
+    await expect(service.listWakeups()).resolves.toEqual([
+      expect.objectContaining({
+        wakeupId: 'wakeup-queued',
+        status: 'pending',
+      }),
+    ]);
+    const persisted = JSON.parse(
+      await fs.readFile(path.join(storeDir, 'wakeups.json'), 'utf8'),
+    ) as { wakeups: Array<{ wakeupId: string; status: string }> };
+    expect(persisted.wakeups).toEqual([
+      expect.objectContaining({
+        wakeupId: 'wakeup-queued',
+        status: 'pending',
+      }),
+    ]);
+
+    service.shutdown();
+  });
+
+  it('continues startup when the wake-up store is corrupt', async () => {
+    const { service, storeDir } = createWakeupService();
+    writeFileSync(path.join(storeDir, 'wakeups.json'), '{bad json\n', 'utf8');
+
+    await expect(service.initialize()).resolves.toBeUndefined();
+    await expect(service.listWakeups()).resolves.toEqual([]);
+
+    service.shutdown();
+  });
+
+  it('delivers due wake-ups to the target session and removes them', async () => {
+    const { service, startSessionMessageFn } = createWakeupService();
+    await service.initialize();
+
+    await service.setWakeupForSession({
+      sessionId: 'session-1',
+      message: 'Check the issue',
+      runAt: new Date(Date.now() + 5),
+    });
+    await wait(40);
+
+    expect(startSessionMessageFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          sessionId: 'session-1',
+          content: 'Check the issue',
+          mode: 'sync',
+        }),
+      }),
+    );
+    await expect(service.listWakeups()).resolves.toEqual([]);
+
+    service.shutdown();
+  });
+
+  it('claims due wake-ups before synchronous delivery completes', async () => {
+    const { service, startSessionMessageFn } = createWakeupService();
+    let resolveDelivery!: (result: SessionMessageStartResult) => void;
+    const delivery = new Promise<SessionMessageStartResult>((resolve) => {
+      resolveDelivery = resolve;
+    });
+    startSessionMessageFn.mockImplementationOnce(async () => delivery);
+    await service.initialize();
+
+    await service.setWakeupForSession({
+      sessionId: 'session-1',
+      message: 'Check the issue',
+      runAt: new Date(Date.now() + 5),
+    });
+    await wait(40);
+
+    expect(startSessionMessageFn).toHaveBeenCalled();
+    await expect(service.listWakeups()).resolves.toEqual([
+      expect.objectContaining({
+        sessionId: 'session-1',
+        status: 'delivering',
+      }),
+    ]);
+
+    resolveDelivery({
+      response: {
+        sessionId: 'session-1',
+        sessionName: 'Issue Watch',
+        agentId: 'agent',
+        created: false,
+        status: 'complete',
+        responseId: 'resp-1',
+        response: 'ok',
+        truncated: false,
+        durationMs: 0,
+        toolCallCount: 0,
+        toolCalls: [],
+      },
+    });
+    await tick();
+    await expect(service.listWakeups()).resolves.toEqual([]);
+
+    service.shutdown();
+  });
+
+  it('keeps failed wake-up deliveries pending for retry', async () => {
+    const { service, startSessionMessageFn } = createWakeupService({
+      startStatus: 'error',
+    });
+    await service.initialize();
+
+    await service.setWakeupForSession({
+      sessionId: 'session-1',
+      message: 'Check the issue',
+      runAt: new Date(Date.now() + 5),
+    });
+    await wait(40);
+
+    expect(startSessionMessageFn).toHaveBeenCalled();
+    await expect(service.listWakeups()).resolves.toEqual([
+      expect.objectContaining({
+        sessionId: 'session-1',
+        status: 'pending',
+      }),
+    ]);
+
+    service.shutdown();
+  });
+
+  it('queues due wake-ups when the target session is busy', async () => {
+    const { service, sessionHub, startSessionMessageFn, queuedTasks } = createWakeupService({
+      active: true,
+    });
+    await service.initialize();
+
+    await service.setWakeupForSession({
+      sessionId: 'session-1',
+      message: 'Check the issue',
+      runAt: new Date(Date.now() + 5),
+    });
+    await wait(40);
+
+    expect(sessionHub.queueMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-1',
+        text: 'Check the issue',
+        source: 'user',
+      }),
+    );
+    expect(startSessionMessageFn).not.toHaveBeenCalled();
+    await expect(service.listWakeups()).resolves.toEqual([
+      expect.objectContaining({
+        sessionId: 'session-1',
+        message: 'Check the issue',
+        status: 'queued',
+      }),
+    ]);
+
+    await queuedTasks[0]?.();
+    expect(startSessionMessageFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          sessionId: 'session-1',
+          content: 'Check the issue',
+        }),
+      }),
+    );
+    await expect(service.listWakeups()).resolves.toEqual([]);
 
     service.shutdown();
   });

--- a/packages/agent-server/src/scheduledSessions/scheduledSessionService.ts
+++ b/packages/agent-server/src/scheduledSessions/scheduledSessionService.ts
@@ -21,9 +21,11 @@ import { buildCliEnv } from '../ws/cliEnv';
 
 import { describeCron, parseNextRun } from './cronUtils';
 import { ScheduledSessionStore } from './scheduledSessionStore';
+import { SessionWakeupStore } from './sessionWakeupStore';
 import type {
   LastRunInfo,
   PersistedScheduleRecord,
+  PersistedSessionWakeupRecord,
   ScheduleCreateInput,
   ScheduleDeletedEvent,
   PreCheckResult,
@@ -33,6 +35,11 @@ import type {
   ScheduleStatusEvent,
   TriggerResult,
   ScheduleUpdateInput,
+  SessionWakeupConfig,
+  SessionWakeupCreateInput,
+  SessionWakeupDeletedEvent,
+  SessionWakeupInfo,
+  SessionWakeupSetEvent,
 } from './types';
 
 type ScheduledRunProvider = NonNullable<NonNullable<AgentDefinition['chat']>['provider']>;
@@ -59,6 +66,7 @@ export interface ScheduledSessionServiceOptions {
   agentRegistry: AgentRegistry;
   logger: Logger;
   store: ScheduledSessionStore;
+  wakeupStore?: SessionWakeupStore;
   sessionHub?: SessionHub;
   sessionIndex?: SessionIndex;
   envConfig?: EnvConfig;
@@ -66,7 +74,13 @@ export interface ScheduledSessionServiceOptions {
   eventStore?: EventStore;
   searchService?: SearchService;
   defaultSessionTimeoutSeconds?: number;
-  broadcast?: (event: ScheduleStatusEvent | ScheduleDeletedEvent) => void;
+  broadcast?: (
+    event:
+      | ScheduleStatusEvent
+      | ScheduleDeletedEvent
+      | SessionWakeupSetEvent
+      | SessionWakeupDeletedEvent,
+  ) => void;
   spawnFn?: typeof spawn;
   startSessionMessageFn?: typeof startSessionMessage;
 }
@@ -88,13 +102,18 @@ export class ScheduleValidationError extends Error {
 export class ScheduledSessionService {
   private static readonly MAX_TIMEOUT_MS = 2_147_483_647;
   private readonly schedules = new Map<string, ScheduleState>();
+  private readonly wakeups = new Map<string, SessionWakeupConfig>();
+  private readonly wakeupTimers = new Map<string, NodeJS.Timeout>();
+  private readonly wakeupSessionLocks = new Map<string, Promise<unknown>>();
   private initialized = false;
   private readonly spawnFn: typeof spawn;
   private readonly startSessionMessageFn: typeof startSessionMessage;
+  private readonly wakeupStore: SessionWakeupStore;
 
   constructor(private readonly options: ScheduledSessionServiceOptions) {
     this.spawnFn = options.spawnFn ?? spawn;
     this.startSessionMessageFn = options.startSessionMessageFn ?? startSessionMessage;
+    this.wakeupStore = options.wakeupStore ?? new SessionWakeupStore(options.store.getDataDir());
   }
 
   async initialize(): Promise<void> {
@@ -133,6 +152,10 @@ export class ScheduledSessionService {
       this.broadcastStatus(state);
     }
 
+    if (this.hasSessionDependencies()) {
+      await this.initializeWakeups();
+    }
+
     this.initialized = true;
   }
 
@@ -144,6 +167,11 @@ export class ScheduledSessionService {
       }
     }
     this.schedules.clear();
+    for (const timer of this.wakeupTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.wakeupTimers.clear();
+    this.wakeups.clear();
     this.initialized = false;
   }
 
@@ -309,6 +337,99 @@ export class ScheduledSessionService {
     }
     state.nextRunAt = null;
     this.broadcastStatus(state);
+  }
+
+  async listWakeups(): Promise<SessionWakeupInfo[]> {
+    const sessions = await this.buildSessionSummaryMap();
+    return Array.from(this.wakeups.values())
+      .map((wakeup) => this.buildWakeupInfo(wakeup, sessions))
+      .sort((left, right) => left.runAt.localeCompare(right.runAt));
+  }
+
+  async setWakeupForSession(input: SessionWakeupCreateInput): Promise<SessionWakeupInfo> {
+    const sessionId = this.normalizeRequiredString(input.sessionId, 'sessionId');
+    const message = this.normalizeRequiredString(input.message, 'message');
+    const runAt = this.normalizeWakeupRunAt(input.runAt);
+    return this.withWakeupSessionLock(sessionId, async () => {
+      const session = await this.requireWakeupSession(sessionId);
+      const existing = this.findWakeupForSession(sessionId);
+      if (existing && input.replace !== true) {
+        throw new ScheduleValidationError('session already has a pending wake-up');
+      }
+
+      if (existing) {
+        this.removeWakeupInMemory(existing.wakeupId);
+      }
+
+      const wakeup: SessionWakeupConfig = {
+        wakeupId: `wakeup-${randomUUID().slice(0, 8)}`,
+        sessionId,
+        agentId: session.agentId,
+        message,
+        runAt,
+        createdAt: new Date(),
+        status: 'pending',
+      };
+
+      this.wakeups.set(wakeup.wakeupId, wakeup);
+      try {
+        await this.persistWakeups();
+      } catch (error) {
+        this.removeWakeupInMemory(wakeup.wakeupId);
+        if (existing) {
+          this.wakeups.set(existing.wakeupId, existing);
+          this.scheduleWakeup(existing);
+        }
+        throw error;
+      }
+
+      this.scheduleWakeup(wakeup);
+      if (existing) {
+        this.broadcastWakeupDeleted(existing);
+      }
+      const info = this.buildWakeupInfo(wakeup, new Map([[sessionId, session]]));
+      this.broadcastWakeupSet(info);
+      return info;
+    });
+  }
+
+  async cancelWakeupForSession(
+    sessionIdInput: string,
+  ): Promise<{ cancelled: boolean; sessionId: string; wakeupId: string | null }> {
+    const sessionId = this.normalizeRequiredString(sessionIdInput, 'sessionId');
+    return this.withWakeupSessionLock(sessionId, async () => {
+      const existing = this.findWakeupForSession(sessionId);
+      if (!existing) {
+        return { cancelled: false, sessionId, wakeupId: null };
+      }
+      await this.deleteWakeup(existing.wakeupId);
+      return { cancelled: true, sessionId, wakeupId: existing.wakeupId };
+    });
+  }
+
+  private async withWakeupSessionLock<T>(
+    sessionId: string,
+    task: () => Promise<T>,
+  ): Promise<T> {
+    const previous = this.wakeupSessionLocks.get(sessionId) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const next = previous
+      .catch(() => undefined)
+      .then(() => current);
+    this.wakeupSessionLocks.set(sessionId, next);
+
+    await previous.catch(() => undefined);
+    try {
+      return await task();
+    } finally {
+      release();
+      if (this.wakeupSessionLocks.get(sessionId) === next) {
+        this.wakeupSessionLocks.delete(sessionId);
+      }
+    }
   }
 
   private scheduleNext(key: string, state: ScheduleState): void {
@@ -656,6 +777,379 @@ export class ScheduledSessionService {
     }
 
     return { result: 'failed', error: 'Unexpected session response status' };
+  }
+
+  private async initializeWakeups(): Promise<void> {
+    let persisted: PersistedSessionWakeupRecord[];
+    try {
+      persisted = await this.wakeupStore.load();
+    } catch (err) {
+      this.options.logger.error(
+        `[scheduled-sessions] Failed to load session wake-ups; starting without wake-ups: ${String(err)}`,
+      );
+      this.wakeups.clear();
+      return;
+    }
+    let pruned = false;
+    this.wakeups.clear();
+
+    for (const record of persisted) {
+      const wakeup = await this.normalizePersistedWakeup(record);
+      if (!wakeup) {
+        pruned = true;
+        continue;
+      }
+      if (this.findWakeupForSession(wakeup.sessionId)) {
+        this.options.logger.warn(
+          `[scheduled-sessions] Dropping duplicate wake-up for session "${wakeup.sessionId}"`,
+        );
+        pruned = true;
+        continue;
+      }
+      if (wakeup.status === 'delivering') {
+        this.options.logger.warn(
+          `[scheduled-sessions] Dropping already-claimed wake-up "${wakeup.wakeupId}" after restart`,
+        );
+        pruned = true;
+        continue;
+      }
+      if (wakeup.status === 'queued') {
+        wakeup.status = 'pending';
+        pruned = true;
+      }
+      this.wakeups.set(wakeup.wakeupId, wakeup);
+      this.scheduleWakeup(wakeup);
+      this.broadcastWakeupSet(this.buildWakeupInfo(wakeup));
+    }
+
+    if (pruned) {
+      await this.persistWakeups();
+    }
+  }
+
+  private async normalizePersistedWakeup(
+    record: PersistedSessionWakeupRecord,
+  ): Promise<SessionWakeupConfig | null> {
+    const runAt = new Date(record.runAt);
+    const createdAt = new Date(record.createdAt);
+    if (!Number.isFinite(runAt.getTime()) || !Number.isFinite(createdAt.getTime())) {
+      return null;
+    }
+    try {
+      const session = await this.requireWakeupSession(record.sessionId);
+      if (session.agentId !== record.agentId) {
+        this.options.logger.warn(
+          `[scheduled-sessions] Dropping wake-up for session "${record.sessionId}" because its agent changed`,
+        );
+        return null;
+      }
+    } catch (err) {
+      this.options.logger.warn(
+        `[scheduled-sessions] Dropping wake-up for unavailable session "${record.sessionId}": ${String(err)}`,
+      );
+      return null;
+    }
+    return {
+      wakeupId: record.wakeupId,
+      sessionId: record.sessionId,
+      agentId: record.agentId,
+      message: record.message,
+      runAt,
+      createdAt,
+      status: record.status,
+    };
+  }
+
+  private scheduleWakeup(wakeup: SessionWakeupConfig): void {
+    if (wakeup.status !== 'pending') {
+      return;
+    }
+    const existingTimer = this.wakeupTimers.get(wakeup.wakeupId);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+      this.wakeupTimers.delete(wakeup.wakeupId);
+    }
+
+    const delayRaw = wakeup.runAt.getTime() - Date.now();
+    const delay = Math.max(0, delayRaw);
+    const timeoutMs = Math.min(delay, ScheduledSessionService.MAX_TIMEOUT_MS);
+    const timer = setTimeout(() => {
+      if (delay > ScheduledSessionService.MAX_TIMEOUT_MS) {
+        this.scheduleWakeup(wakeup);
+        return;
+      }
+      void this.executeWakeup(wakeup.wakeupId);
+    }, timeoutMs);
+    this.wakeupTimers.set(wakeup.wakeupId, timer);
+  }
+
+  private async executeWakeup(wakeupId: string): Promise<void> {
+    const wakeup = this.wakeups.get(wakeupId);
+    this.wakeupTimers.delete(wakeupId);
+    if (!wakeup || wakeup.status !== 'pending') {
+      return;
+    }
+
+    const sessionHub = this.options.sessionHub;
+    if (!sessionHub) {
+      this.options.logger.error('[scheduled-sessions] Session hub unavailable for wake-up');
+      return;
+    }
+
+    try {
+      const state = await sessionHub.ensureSessionState(wakeup.sessionId);
+      if (state.activeChatRun) {
+        await this.queueWakeupDelivery(wakeup);
+        this.options.logger.info(
+          `[scheduled-sessions] Queued wake-up "${wakeup.wakeupId}" for busy session "${wakeup.sessionId}"`,
+        );
+        return;
+      }
+
+      await this.updateWakeupStatus(wakeup, 'delivering');
+      const result = await this.startWakeupMessage(wakeup);
+      if (result === 'busy') {
+        await this.queueWakeupDelivery(wakeup);
+        this.options.logger.info(
+          `[scheduled-sessions] Queued wake-up "${wakeup.wakeupId}" after busy response for session "${wakeup.sessionId}"`,
+        );
+        return;
+      }
+      await this.deleteWakeup(wakeup.wakeupId);
+    } catch (err) {
+      this.options.logger.error(
+        `[scheduled-sessions] Failed to deliver wake-up "${wakeup.wakeupId}": ${String(err)}`,
+      );
+      if (this.wakeups.has(wakeup.wakeupId)) {
+        await this.updateWakeupStatus(wakeup, 'pending').catch(() => undefined);
+        this.scheduleWakeupRetry(wakeup);
+      }
+    }
+  }
+
+  private async queueWakeupDelivery(wakeup: SessionWakeupConfig): Promise<void> {
+    const sessionHub = this.options.sessionHub;
+    if (!sessionHub) {
+      throw new Error('Session hub unavailable for wake-up');
+    }
+    await this.updateWakeupStatus(wakeup, 'queued');
+    await sessionHub.queueMessage({
+      sessionId: wakeup.sessionId,
+      text: wakeup.message,
+      source: 'user',
+      execute: async () => {
+        const current = this.wakeups.get(wakeup.wakeupId);
+        if (!current || current.status !== 'queued') {
+          return;
+        }
+        try {
+          await this.updateWakeupStatus(current, 'delivering');
+          const result = await this.startWakeupMessage(current);
+          if (result === 'busy') {
+            await this.queueWakeupDelivery(current);
+            return;
+          }
+          await this.deleteWakeup(current.wakeupId);
+        } catch (err) {
+          this.options.logger.error(
+            `[scheduled-sessions] Failed to deliver queued wake-up "${current.wakeupId}": ${String(err)}`,
+          );
+          if (this.wakeups.has(current.wakeupId)) {
+            await this.updateWakeupStatus(current, 'pending').catch(() => undefined);
+            this.scheduleWakeupRetry(current);
+          }
+        }
+      },
+    });
+  }
+
+  private async updateWakeupStatus(
+    wakeup: SessionWakeupConfig,
+    status: SessionWakeupConfig['status'],
+  ): Promise<void> {
+    const current = this.wakeups.get(wakeup.wakeupId);
+    if (!current) {
+      return;
+    }
+    current.status = status;
+    wakeup.status = status;
+    await this.persistWakeups();
+    this.broadcastWakeupSet(this.buildWakeupInfo(current));
+  }
+
+  private scheduleWakeupRetry(wakeup: SessionWakeupConfig): void {
+    const existingTimer = this.wakeupTimers.get(wakeup.wakeupId);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+    }
+    const timer = setTimeout(() => {
+      void this.executeWakeup(wakeup.wakeupId);
+    }, 60_000);
+    this.wakeupTimers.set(wakeup.wakeupId, timer);
+  }
+
+  private async startWakeupMessage(wakeup: SessionWakeupConfig): Promise<'accepted' | 'busy'> {
+    const sessionIndex = this.options.sessionIndex;
+    const sessionHub = this.options.sessionHub;
+    const toolHost = this.options.toolHost;
+    const envConfig = this.options.envConfig;
+    if (!sessionIndex || !sessionHub || !toolHost || !envConfig) {
+      throw new Error('Scheduled session dependencies are missing');
+    }
+
+    const timeoutSeconds = this.options.defaultSessionTimeoutSeconds ?? 300;
+    const { response } = await this.startSessionMessageFn({
+      input: {
+        sessionId: wakeup.sessionId,
+        content: wakeup.message,
+        mode: 'sync',
+        timeoutSeconds,
+      },
+      sessionIndex,
+      sessionHub,
+      agentRegistry: this.options.agentRegistry,
+      toolHost,
+      envConfig,
+      ...(this.options.eventStore ? { eventStore: this.options.eventStore } : {}),
+      ...(this.options.searchService ? { searchService: this.options.searchService } : {}),
+      scheduledSessionService: this,
+    });
+
+    if (response.status === 'busy') {
+      return 'busy';
+    }
+    if (response.status === 'error') {
+      throw new Error(response.error);
+    }
+    if (response.status === 'timeout') {
+      throw new Error(response.message);
+    }
+    return 'accepted';
+  }
+
+  private async requireWakeupSession(
+    sessionId: string,
+  ): Promise<SessionSummary & { agentId: string }> {
+    const sessionIndex = this.options.sessionIndex;
+    if (!sessionIndex) {
+      throw new ScheduleValidationError('session index is not available');
+    }
+    const summary = await sessionIndex.getSession(sessionId);
+    if (!summary || summary.deleted) {
+      throw new ScheduleNotFoundError(`Session not found: ${sessionId}`);
+    }
+    const agentId = summary.agentId;
+    if (!agentId) {
+      throw new ScheduleValidationError('session must belong to an agent');
+    }
+    const agent = this.options.agentRegistry.getAgent(agentId);
+    if (!agent || agent.type === 'external') {
+      throw new ScheduleValidationError('session agent is not available for wake-ups');
+    }
+    const provider = agent.chat?.provider ?? 'pi';
+    if (provider !== 'pi') {
+      throw new ScheduleValidationError('wake-ups are only supported for native Pi SDK sessions');
+    }
+    return { ...summary, agentId };
+  }
+
+  private normalizeWakeupRunAt(value: Date): Date {
+    if (!(value instanceof Date) || !Number.isFinite(value.getTime())) {
+      throw new ScheduleValidationError('runAt must be a valid timestamp');
+    }
+    if (value.getTime() < Date.now() - 1000) {
+      throw new ScheduleValidationError('runAt must not be in the past');
+    }
+    return value;
+  }
+
+  private findWakeupForSession(sessionId: string): SessionWakeupConfig | null {
+    for (const wakeup of this.wakeups.values()) {
+      if (wakeup.sessionId === sessionId) {
+        return wakeup;
+      }
+    }
+    return null;
+  }
+
+  private removeWakeupInMemory(wakeupId: string): SessionWakeupConfig | null {
+    const wakeup = this.wakeups.get(wakeupId) ?? null;
+    const timer = this.wakeupTimers.get(wakeupId);
+    if (timer) {
+      clearTimeout(timer);
+      this.wakeupTimers.delete(wakeupId);
+    }
+    this.wakeups.delete(wakeupId);
+    return wakeup;
+  }
+
+  private async deleteWakeup(wakeupId: string): Promise<SessionWakeupConfig | null> {
+    const wakeup = this.removeWakeupInMemory(wakeupId);
+    if (!wakeup) {
+      return null;
+    }
+    await this.persistWakeups();
+    this.broadcastWakeupDeleted(wakeup);
+    return wakeup;
+  }
+
+  private buildPersistedWakeups(): PersistedSessionWakeupRecord[] {
+    return Array.from(this.wakeups.values()).map((wakeup) => ({
+      wakeupId: wakeup.wakeupId,
+      sessionId: wakeup.sessionId,
+      agentId: wakeup.agentId,
+      message: wakeup.message,
+      runAt: wakeup.runAt.toISOString(),
+      createdAt: wakeup.createdAt.toISOString(),
+      status: wakeup.status,
+    }));
+  }
+
+  private async persistWakeups(): Promise<void> {
+    await this.wakeupStore.save(this.buildPersistedWakeups());
+  }
+
+  private async buildSessionSummaryMap(): Promise<Map<string, SessionSummary>> {
+    const sessionIndex = this.options.sessionIndex;
+    if (!sessionIndex) {
+      return new Map();
+    }
+    const sessions = await sessionIndex.listSessions();
+    return new Map(sessions.map((session) => [session.sessionId, session]));
+  }
+
+  private buildWakeupInfo(
+    wakeup: SessionWakeupConfig,
+    sessions?: Map<string, SessionSummary>,
+  ): SessionWakeupInfo {
+    const summary = sessions?.get(wakeup.sessionId);
+    return {
+      wakeupId: wakeup.wakeupId,
+      sessionId: wakeup.sessionId,
+      sessionName: summary?.name ?? null,
+      agentId: wakeup.agentId,
+      message: wakeup.message,
+      runAt: wakeup.runAt.toISOString(),
+      createdAt: wakeup.createdAt.toISOString(),
+      status: wakeup.status,
+    };
+  }
+
+  private broadcastWakeupSet(info: SessionWakeupInfo): void {
+    this.options.broadcast?.({
+      type: 'session_wakeup:set',
+      payload: info,
+    });
+  }
+
+  private broadcastWakeupDeleted(wakeup: SessionWakeupConfig): void {
+    this.options.broadcast?.({
+      type: 'session_wakeup:deleted',
+      payload: {
+        wakeupId: wakeup.wakeupId,
+        sessionId: wakeup.sessionId,
+      },
+    });
   }
 
   private async resolveScheduledSession(

--- a/packages/agent-server/src/scheduledSessions/sessionWakeupStore.test.ts
+++ b/packages/agent-server/src/scheduledSessions/sessionWakeupStore.test.ts
@@ -1,0 +1,89 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { SessionWakeupStore } from './sessionWakeupStore';
+
+function createStoreDir(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'session-wakeup-store-'));
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe('SessionWakeupStore', () => {
+  it('returns an empty list when the store file does not exist', async () => {
+    const store = new SessionWakeupStore(createStoreDir());
+    await expect(store.load()).resolves.toEqual([]);
+  });
+
+  it('persists and reloads wake-up records', async () => {
+    const storeDir = createStoreDir();
+    const store = new SessionWakeupStore(storeDir);
+
+    await store.save([
+      {
+        wakeupId: 'wakeup-a',
+        sessionId: 'session-a',
+        agentId: 'agent',
+        message: 'Check the issue',
+        runAt: '2026-06-03T12:00:00.000Z',
+        createdAt: '2026-06-03T11:00:00.000Z',
+        status: 'pending',
+      },
+    ]);
+
+    await expect(store.load()).resolves.toEqual([
+      {
+        wakeupId: 'wakeup-a',
+        sessionId: 'session-a',
+        agentId: 'agent',
+        message: 'Check the issue',
+        runAt: '2026-06-03T12:00:00.000Z',
+        createdAt: '2026-06-03T11:00:00.000Z',
+        status: 'pending',
+      },
+    ]);
+
+    const raw = JSON.parse(
+      await fs.readFile(path.join(storeDir, 'wakeups.json'), 'utf8'),
+    ) as { version: number; wakeups: Array<{ wakeupId: string }> };
+    expect(raw.version).toBe(1);
+    expect(raw.wakeups[0]?.wakeupId).toBe('wakeup-a');
+  });
+
+  it('throws on invalid JSON content', async () => {
+    const storeDir = createStoreDir();
+    writeFileSync(path.join(storeDir, 'wakeups.json'), '{bad json\n', 'utf8');
+    const store = new SessionWakeupStore(storeDir);
+
+    await expect(store.load()).rejects.toThrow(/Failed to parse session wakeups store/i);
+  });
+
+  it('rejects invalid timestamps', async () => {
+    const storeDir = createStoreDir();
+    writeFileSync(
+      path.join(storeDir, 'wakeups.json'),
+      `${JSON.stringify({
+        version: 1,
+        wakeups: [
+          {
+            wakeupId: 'wakeup-a',
+            sessionId: 'session-a',
+            agentId: 'agent',
+            message: 'Check the issue',
+            runAt: 'not-a-date',
+            createdAt: '2026-06-03T11:00:00.000Z',
+            status: 'pending',
+          },
+        ],
+      })}\n`,
+      'utf8',
+    );
+    const store = new SessionWakeupStore(storeDir);
+
+    await expect(store.load()).rejects.toThrow(/runAt must be a valid ISO timestamp/i);
+  });
+});

--- a/packages/agent-server/src/scheduledSessions/sessionWakeupStore.ts
+++ b/packages/agent-server/src/scheduledSessions/sessionWakeupStore.ts
@@ -1,0 +1,133 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import type { PersistedSessionWakeupRecord } from './types';
+
+type PersistedWakeupsFile = {
+  version: 1;
+  wakeups: PersistedSessionWakeupRecord[];
+};
+
+const CURRENT_VERSION = 1 as const;
+
+export class SessionWakeupStore {
+  private readonly filePath: string;
+  private writeQueue: Promise<void> = Promise.resolve();
+
+  constructor(private readonly dataDir: string) {
+    this.filePath = path.join(dataDir, 'wakeups.json');
+  }
+
+  getFilePath(): string {
+    return this.filePath;
+  }
+
+  async load(): Promise<PersistedSessionWakeupRecord[]> {
+    await this.writeQueue.catch(() => undefined);
+
+    let raw: string;
+    try {
+      raw = await fs.readFile(this.filePath, 'utf8');
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code === 'ENOENT') {
+        return [];
+      }
+      throw error;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw) as unknown;
+    } catch (error) {
+      throw new Error(
+        `Failed to parse session wakeups store at ${this.filePath}: ${(error as Error).message}`,
+      );
+    }
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error(`Session wakeups store at ${this.filePath} must be a JSON object`);
+    }
+
+    const file = parsed as Partial<PersistedWakeupsFile>;
+    if (file.version !== CURRENT_VERSION) {
+      throw new Error(
+        `Session wakeups store at ${this.filePath} has unsupported version: ${String(file.version)}`,
+      );
+    }
+    if (!Array.isArray(file.wakeups)) {
+      throw new Error(`Session wakeups store at ${this.filePath} must contain a wakeups array`);
+    }
+
+    return file.wakeups.map((entry, index) => this.validateRecord(entry, index));
+  }
+
+  async save(records: PersistedSessionWakeupRecord[]): Promise<void> {
+    const normalized = records
+      .map((record) => this.validateRecord(record, -1))
+      .sort((left, right) => left.runAt.localeCompare(right.runAt));
+
+    const next = this.writeQueue
+      .catch(() => undefined)
+      .then(async () => {
+        await fs.mkdir(this.dataDir, { recursive: true });
+        const payload: PersistedWakeupsFile = {
+          version: CURRENT_VERSION,
+          wakeups: normalized,
+        };
+        const content = `${JSON.stringify(payload, null, 2)}\n`;
+        const tempPath = `${this.filePath}.tmp-${process.pid}-${Date.now()}`;
+        await fs.writeFile(tempPath, content, 'utf8');
+        await fs.rename(tempPath, this.filePath);
+      });
+
+    this.writeQueue = next;
+    await next;
+  }
+
+  private validateRecord(value: unknown, index: number): PersistedSessionWakeupRecord {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      throw new Error(this.describeError(index, 'must be an object'));
+    }
+    const record = value as Partial<PersistedSessionWakeupRecord>;
+    const requireString = (field: keyof PersistedSessionWakeupRecord): string => {
+      const raw = record[field];
+      if (typeof raw !== 'string' || raw.trim().length === 0) {
+        throw new Error(this.describeError(index, `${String(field)} must be a non-empty string`));
+      }
+      return raw.trim();
+    };
+    const runAt = requireString('runAt');
+    const createdAt = requireString('createdAt');
+    const status = requireString('status');
+    this.requireValidIsoDate(runAt, index, 'runAt');
+    this.requireValidIsoDate(createdAt, index, 'createdAt');
+    if (status !== 'pending' && status !== 'queued' && status !== 'delivering') {
+      throw new Error(
+        this.describeError(index, 'status must be pending, queued, or delivering'),
+      );
+    }
+    return {
+      wakeupId: requireString('wakeupId'),
+      sessionId: requireString('sessionId'),
+      agentId: requireString('agentId'),
+      message: requireString('message'),
+      runAt,
+      createdAt,
+      status,
+    };
+  }
+
+  private requireValidIsoDate(value: string, index: number, field: string): void {
+    const timestamp = Date.parse(value);
+    if (!Number.isFinite(timestamp)) {
+      throw new Error(this.describeError(index, `${field} must be a valid ISO timestamp`));
+    }
+  }
+
+  private describeError(index: number, message: string): string {
+    return index >= 0
+      ? `Session wakeups store record ${index} ${message}`
+      : `Session wakeups store record ${message}`;
+  }
+}

--- a/packages/agent-server/src/scheduledSessions/types.ts
+++ b/packages/agent-server/src/scheduledSessions/types.ts
@@ -112,3 +112,54 @@ export interface ScheduleDeletedEvent {
     scheduleId: string;
   };
 }
+
+export interface SessionWakeupConfig {
+  wakeupId: string;
+  sessionId: string;
+  agentId: string;
+  message: string;
+  runAt: Date;
+  createdAt: Date;
+  status: 'pending' | 'queued' | 'delivering';
+}
+
+export interface PersistedSessionWakeupRecord {
+  wakeupId: string;
+  sessionId: string;
+  agentId: string;
+  message: string;
+  runAt: string;
+  createdAt: string;
+  status: 'pending' | 'queued' | 'delivering';
+}
+
+export interface SessionWakeupCreateInput {
+  sessionId: string;
+  message: string;
+  runAt: Date;
+  replace?: boolean;
+}
+
+export interface SessionWakeupInfo {
+  wakeupId: string;
+  sessionId: string;
+  sessionName: string | null;
+  agentId: string;
+  message: string;
+  runAt: string;
+  createdAt: string;
+  status: 'pending' | 'queued' | 'delivering';
+}
+
+export interface SessionWakeupSetEvent {
+  type: 'session_wakeup:set';
+  payload: SessionWakeupInfo;
+}
+
+export interface SessionWakeupDeletedEvent {
+  type: 'session_wakeup:deleted';
+  payload: {
+    wakeupId: string;
+    sessionId: string;
+  };
+}

--- a/packages/plugins/official/scheduled-sessions/README.md
+++ b/packages/plugins/official/scheduled-sessions/README.md
@@ -26,6 +26,9 @@ Schedules are stored in the plugin default instance data directory at
 `data/plugins/scheduled-sessions/default/schedules.json`.
 They are persisted immediately on create, update, delete, enable, and disable.
 
+Pending one-shot session wake-ups are stored in the same plugin instance under
+`data/plugins/scheduled-sessions/default/wakeups.json`.
+
 Each schedule can also carry an optional `sessionConfig` block with:
 - `model`
 - `thinking`
@@ -38,6 +41,11 @@ These values are validated against the selected agent when the schedule is creat
 then revalidated again when the schedule runs. When `reuseSession` is enabled, the backing
 session is created up front and reconciled from the schedule on later runs after edits.
 
+Wake-ups target native Pi SDK sessions only. `wakeup-set` and `wakeup-cancel` operate on the
+current session context; `wakeup-list` returns pending wake-ups across sessions so users can see
+what is armed. When a wake-up fires while its target session is busy, the wake-up message is added
+to the session message queue.
+
 ## Source files
 
 - `packages/plugins/official/scheduled-sessions/manifest.json`
@@ -48,7 +56,7 @@ session is created up front and reconciled from the schedule on later runs after
 ## Panel
 
 - Panel type: `scheduled-sessions` (multi-instance, global scope).
-- Shows schedules in a flat compact list with collapsed-by-default details, a live title/agent filter, and enable/disable plus run controls.
+- Shows pending wake-ups and schedules in a flat compact list with collapsed-by-default schedule details, a live title/session/message/agent filter, wake-up cancel controls, and schedule enable/disable plus run controls.
 - Live updates via WebSocket events from the server.
 
 ## Tools
@@ -62,6 +70,9 @@ Tools are exposed when plugin tools are enabled:
 - `scheduled_sessions_run`: trigger a run by agentId + scheduleId.
 - `scheduled_sessions_enable`: enable a schedule at runtime.
 - `scheduled_sessions_disable`: disable a schedule at runtime.
+- `scheduled_sessions_wakeup_list`: list pending session wake-ups across sessions.
+- `scheduled_sessions_wakeup_set`: schedule a wake-up for the current session using `delaySeconds` or an absolute `runAt` ISO timestamp with a timezone offset or `Z` (for example `2026-06-03T08:56:00-05:00` or `2026-06-03T13:56:00Z`).
+- `scheduled_sessions_wakeup_cancel`: cancel the current session's pending wake-up.
 
 ## HTTP
 
@@ -74,6 +85,9 @@ Endpoints:
 - `POST /api/plugins/scheduled-sessions/operations/run`
 - `POST /api/plugins/scheduled-sessions/operations/enable`
 - `POST /api/plugins/scheduled-sessions/operations/disable`
+- `POST /api/plugins/scheduled-sessions/operations/wakeup-list`
+- `POST /api/plugins/scheduled-sessions/operations/wakeup-set`
+- `POST /api/plugins/scheduled-sessions/operations/wakeup-cancel`
 
 Responses use the standard generated plugin operations envelope:
 

--- a/packages/plugins/official/scheduled-sessions/manifest.json
+++ b/packages/plugins/official/scheduled-sessions/manifest.json
@@ -145,6 +145,33 @@
         "required": ["agentId", "scheduleId"]
       },
       "capabilities": ["scheduled-sessions.write"]
+    },
+    {
+      "id": "wakeup-list",
+      "summary": "List pending one-shot session wake-ups across sessions.",
+      "inputSchema": { "type": "object", "properties": {} },
+      "capabilities": ["scheduled-sessions.read"]
+    },
+    {
+      "id": "wakeup-set",
+      "summary": "Schedule one wake-up message for the current session. Provide exactly one of runAt or delaySeconds. runAt must be an absolute ISO timestamp with a timezone offset or Z.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "message": { "type": "string", "description": "Wake-up message to send to the current session." },
+          "runAt": { "type": "string", "description": "Absolute ISO timestamp for the wake-up with timezone offset or Z, for example 2026-06-03T08:56:00-05:00 or 2026-06-03T13:56:00Z." },
+          "delaySeconds": { "type": "number", "description": "Offset from now in seconds." },
+          "replace": { "type": "boolean", "description": "Replace the current session's existing pending wake-up." }
+        },
+        "required": ["message"]
+      },
+      "capabilities": ["scheduled-sessions.write"]
+    },
+    {
+      "id": "wakeup-cancel",
+      "summary": "Cancel the current session's pending one-shot wake-up.",
+      "inputSchema": { "type": "object", "properties": {} },
+      "capabilities": ["scheduled-sessions.write"]
     }
   ],
   "web": {

--- a/packages/plugins/official/scheduled-sessions/server/index.test.ts
+++ b/packages/plugins/official/scheduled-sessions/server/index.test.ts
@@ -33,6 +33,9 @@ describe('scheduled-sessions plugin operations', () => {
     expect(typeof plugin.operations?.run).toBe('function');
     expect(typeof plugin.operations?.enable).toBe('function');
     expect(typeof plugin.operations?.disable).toBe('function');
+    expect(typeof plugin.operations?.['wakeup-list']).toBe('function');
+    expect(typeof plugin.operations?.['wakeup-set']).toBe('function');
+    expect(typeof plugin.operations?.['wakeup-cancel']).toBe('function');
   });
 
   it('returns schedules from the list operation', async () => {
@@ -180,5 +183,210 @@ describe('scheduled-sessions plugin operations', () => {
       code: 'schedule_not_found',
       message: 'Schedule not found: missing',
     } satisfies Partial<ToolError>);
+  });
+
+  it('lists wake-ups across sessions', async () => {
+    const plugin = createPlugin({
+      manifest: manifestJson as CombinedPluginManifest,
+    });
+    const list = plugin.operations?.['wakeup-list'];
+    if (!list) {
+      throw new Error('Expected wakeup-list operation');
+    }
+
+    const result = await list(
+      {},
+      createCtx({
+        scheduledSessionService: {
+          listWakeups: vi.fn().mockResolvedValue([{ wakeupId: 'wakeup-1' }]),
+        },
+      }),
+    );
+
+    expect(result).toEqual({ wakeups: [{ wakeupId: 'wakeup-1' }] });
+  });
+
+  it('sets a wake-up for the current session using delaySeconds', async () => {
+    const plugin = createPlugin({
+      manifest: manifestJson as CombinedPluginManifest,
+    });
+    const set = plugin.operations?.['wakeup-set'];
+    if (!set) {
+      throw new Error('Expected wakeup-set operation');
+    }
+
+    const setWakeupForSession = vi.fn().mockResolvedValue({ wakeupId: 'wakeup-1' });
+    const before = Date.now();
+    const result = await set(
+      {
+        message: 'Check issue status',
+        delaySeconds: 60,
+        replace: true,
+      },
+      createCtx({
+        sessionId: 'session-1',
+        scheduledSessionService: {
+          setWakeupForSession,
+        },
+      }),
+    );
+
+    expect(setWakeupForSession).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      message: 'Check issue status',
+      runAt: expect.any(Date),
+      replace: true,
+    });
+    const runAt = setWakeupForSession.mock.calls[0]?.[0]?.runAt as Date;
+    expect(runAt.getTime()).toBeGreaterThanOrEqual(before + 60_000);
+    expect(result).toEqual({ wakeupId: 'wakeup-1' });
+  });
+
+  it('sets a wake-up for the current session using runAt', async () => {
+    const plugin = createPlugin({
+      manifest: manifestJson as CombinedPluginManifest,
+    });
+    const set = plugin.operations?.['wakeup-set'];
+    if (!set) {
+      throw new Error('Expected wakeup-set operation');
+    }
+
+    const runAt = '2026-06-03T12:00:00.000Z';
+    const setWakeupForSession = vi.fn().mockResolvedValue({ wakeupId: 'wakeup-1' });
+    await set(
+      {
+        message: 'Check issue status',
+        runAt,
+      },
+      createCtx({
+        sessionId: 'session-1',
+        scheduledSessionService: {
+          setWakeupForSession,
+        },
+      }),
+    );
+
+    expect(setWakeupForSession).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      message: 'Check issue status',
+      runAt: new Date(runAt),
+    });
+  });
+
+  it('sets a wake-up using runAt with an explicit timezone offset', async () => {
+    const plugin = createPlugin({
+      manifest: manifestJson as CombinedPluginManifest,
+    });
+    const set = plugin.operations?.['wakeup-set'];
+    if (!set) {
+      throw new Error('Expected wakeup-set operation');
+    }
+
+    const runAt = '2026-06-03T08:56:00-05:00';
+    const setWakeupForSession = vi.fn().mockResolvedValue({ wakeupId: 'wakeup-1' });
+    await set(
+      {
+        message: 'Check issue status',
+        runAt,
+      },
+      createCtx({
+        sessionId: 'session-1',
+        scheduledSessionService: {
+          setWakeupForSession,
+        },
+      }),
+    );
+
+    expect(setWakeupForSession).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      message: 'Check issue status',
+      runAt: new Date(runAt),
+    });
+  });
+
+  it('rejects wake-up set without exactly one time input', async () => {
+    const plugin = createPlugin({
+      manifest: manifestJson as CombinedPluginManifest,
+    });
+    const set = plugin.operations?.['wakeup-set'];
+    if (!set) {
+      throw new Error('Expected wakeup-set operation');
+    }
+
+    await expect(
+      set(
+        {
+          message: 'Check issue status',
+        },
+        createCtx({
+          scheduledSessionService: {
+            setWakeupForSession: vi.fn(),
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: 'invalid_arguments',
+      message: 'Provide exactly one of runAt or delaySeconds',
+    } satisfies Partial<ToolError>);
+  });
+
+  it('rejects wake-up runAt without a timezone offset', async () => {
+    const plugin = createPlugin({
+      manifest: manifestJson as CombinedPluginManifest,
+    });
+    const set = plugin.operations?.['wakeup-set'];
+    if (!set) {
+      throw new Error('Expected wakeup-set operation');
+    }
+
+    await expect(
+      set(
+        {
+          message: 'Check issue status',
+          runAt: '2026-06-03T08:56:00',
+        },
+        createCtx({
+          scheduledSessionService: {
+            setWakeupForSession: vi.fn(),
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: 'invalid_arguments',
+      message:
+        'runAt must include a timezone offset or Z, for example 2026-06-03T08:56:00-05:00 or 2026-06-03T13:56:00Z',
+    } satisfies Partial<ToolError>);
+  });
+
+  it('cancels the current session wake-up', async () => {
+    const plugin = createPlugin({
+      manifest: manifestJson as CombinedPluginManifest,
+    });
+    const cancel = plugin.operations?.['wakeup-cancel'];
+    if (!cancel) {
+      throw new Error('Expected wakeup-cancel operation');
+    }
+
+    const cancelWakeupForSession = vi.fn().mockResolvedValue({
+      cancelled: true,
+      sessionId: 'session-1',
+      wakeupId: 'wakeup-1',
+    });
+    const result = await cancel(
+      {},
+      createCtx({
+        sessionId: 'session-1',
+        scheduledSessionService: {
+          cancelWakeupForSession,
+        },
+      }),
+    );
+
+    expect(cancelWakeupForSession).toHaveBeenCalledWith('session-1');
+    expect(result).toEqual({
+      cancelled: true,
+      sessionId: 'session-1',
+      wakeupId: 'wakeup-1',
+    });
   });
 });

--- a/packages/plugins/official/scheduled-sessions/server/index.ts
+++ b/packages/plugins/official/scheduled-sessions/server/index.ts
@@ -40,6 +40,16 @@ function parseOptionalBoolean(value: unknown, field: string): boolean | undefine
   return value;
 }
 
+function parseOptionalNumber(value: unknown, field: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new ToolError('invalid_arguments', `${field} must be a finite number`);
+  }
+  return value;
+}
+
 function parseOptionalInteger(value: unknown, field: string): number | undefined {
   if (value === undefined) {
     return undefined;
@@ -53,6 +63,51 @@ function parseOptionalInteger(value: unknown, field: string): number | undefined
     throw new ToolError('invalid_arguments', `${field} must be an integer >= 1`);
   }
   return value;
+}
+
+function parseRequiredSessionId(ctx: ToolContext): string {
+  const sessionId = ctx.sessionId?.trim();
+  if (!sessionId) {
+    throw new ToolError('session_unavailable', 'Current session is not available');
+  }
+  return sessionId;
+}
+
+function parseWakeupRunAt(parsed: Record<string, unknown>): Date {
+  const runAtRaw = parsed['runAt'];
+  const delaySeconds = parseOptionalNumber(parsed['delaySeconds'], 'delaySeconds');
+  const hasRunAt = runAtRaw !== undefined;
+  const hasDelay = delaySeconds !== undefined;
+  if (hasRunAt === hasDelay) {
+    throw new ToolError('invalid_arguments', 'Provide exactly one of runAt or delaySeconds');
+  }
+  if (hasDelay) {
+    if (delaySeconds <= 0) {
+      throw new ToolError('invalid_arguments', 'delaySeconds must be greater than zero');
+    }
+    return new Date(Date.now() + Math.ceil(delaySeconds * 1000));
+  }
+  if (typeof runAtRaw !== 'string') {
+    throw new ToolError(
+      'invalid_arguments',
+      'runAt must be an absolute ISO timestamp string with timezone offset or Z',
+    );
+  }
+  const trimmedRunAt = runAtRaw.trim();
+  if (!/(?:Z|[+-]\d{2}:\d{2})$/i.test(trimmedRunAt)) {
+    throw new ToolError(
+      'invalid_arguments',
+      'runAt must include a timezone offset or Z, for example 2026-06-03T08:56:00-05:00 or 2026-06-03T13:56:00Z',
+    );
+  }
+  const runAt = new Date(trimmedRunAt);
+  if (!Number.isFinite(runAt.getTime())) {
+    throw new ToolError(
+      'invalid_arguments',
+      'runAt must be a valid absolute ISO timestamp string with timezone offset or Z',
+    );
+  }
+  return runAt;
 }
 
 function parseOptionalNullableString(
@@ -107,7 +162,9 @@ function wrapServiceError(err: unknown): never {
   if (err instanceof ScheduleNotFoundError) {
     const code = err.message.startsWith('Agent not found:')
       ? 'agent_not_found'
-      : 'schedule_not_found';
+      : err.message.startsWith('Session not found:')
+        ? 'session_not_found'
+        : 'schedule_not_found';
     throw new ToolError(code, err.message);
   }
   throw err;
@@ -213,6 +270,32 @@ export function createPlugin(_options: PluginFactoryArgs): PluginModule {
         try {
           await requireService(ctx).setEnabled(agentId, scheduleId, false);
           return { agentId, scheduleId, enabled: false };
+        } catch (err) {
+          wrapServiceError(err);
+        }
+      },
+      'wakeup-list': async (_args, ctx) => {
+        return { wakeups: await requireService(ctx).listWakeups() };
+      },
+      'wakeup-set': async (args, ctx) => {
+        const parsed = asObject(args);
+        const message = requireNonEmptyString(parsed['message'], 'message');
+        const runAt = parseWakeupRunAt(parsed);
+        const replace = parseOptionalBoolean(parsed['replace'], 'replace');
+        try {
+          return await requireService(ctx).setWakeupForSession({
+            sessionId: parseRequiredSessionId(ctx),
+            message,
+            runAt,
+            ...(replace !== undefined ? { replace } : {}),
+          });
+        } catch (err) {
+          wrapServiceError(err);
+        }
+      },
+      'wakeup-cancel': async (_args, ctx) => {
+        try {
+          return await requireService(ctx).cancelWakeupForSession(parseRequiredSessionId(ctx));
         } catch (err) {
           wrapServiceError(err);
         }

--- a/packages/plugins/official/scheduled-sessions/web/index.test.ts
+++ b/packages/plugins/official/scheduled-sessions/web/index.test.ts
@@ -41,6 +41,17 @@ type ScheduleInfo = {
   } | null;
 };
 
+type SessionWakeupInfo = {
+  wakeupId: string;
+  sessionId: string;
+  sessionName: string | null;
+  agentId: string;
+  message: string;
+  runAt: string;
+  createdAt: string;
+  status: 'pending' | 'queued' | 'delivering';
+};
+
 const SCHEDULES: ScheduleInfo[] = [
   {
     agentId: 'agent-a',
@@ -83,18 +94,43 @@ describe('scheduled sessions panel', () => {
   const originalRegistry = (globalThis as { ASSISTANT_PANEL_REGISTRY?: unknown })
     .ASSISTANT_PANEL_REGISTRY;
   let panelFactory: PanelFactory | null = null;
+  let wakeups: SessionWakeupInfo[] = [];
 
   beforeEach(() => {
     panelFactory = null;
+    wakeups = [];
     apiFetch.mockReset();
-    apiFetch.mockImplementation(async () => ({
-      ok: true,
-      status: 200,
-      json: async () => ({
+    apiFetch.mockImplementation(async (url: RequestInfo | URL) => {
+      const path = String(url);
+      if (path.includes('/operations/wakeup-list')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            ok: true,
+            result: { wakeups },
+          }),
+        };
+      }
+      if (path.includes('/operations/wakeup-cancel')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            ok: true,
+            result: { cancelled: true },
+          }),
+        };
+      }
+      return {
         ok: true,
-        result: { schedules: SCHEDULES },
-      }),
-    }));
+        status: 200,
+        json: async () => ({
+          ok: true,
+          result: { schedules: SCHEDULES },
+        }),
+      };
+    });
 
     (globalThis as { ASSISTANT_PANEL_REGISTRY?: unknown }).ASSISTANT_PANEL_REGISTRY = {
       registerPanel: (panelType: string, factory: PanelFactory) => {
@@ -287,7 +323,7 @@ describe('scheduled sessions panel', () => {
       ).toBe('schedule-2');
       expect(
         container.querySelector<HTMLElement>('[data-role="summary"]')?.textContent?.trim(),
-      ).toBe('1 of 2 schedules | 0 running | 1 disabled');
+      ).toBe('1 of 2 schedules | 0 of 0 wake-ups | 0 running | 1 disabled');
 
       search!.value = 'morning';
       search!.dispatchEvent(new Event('input', { bubbles: true }));
@@ -300,7 +336,52 @@ describe('scheduled sessions panel', () => {
       search!.dispatchEvent(new Event('input', { bubbles: true }));
       expect(container.querySelectorAll('.scheduled-sessions-item')).toHaveLength(0);
       expect(container.querySelector('.scheduled-sessions-empty')?.textContent).toContain(
-        'No schedules match',
+        'No schedules or wake-ups match',
+      );
+    } finally {
+      handle.unmount();
+    }
+  });
+
+  it('renders pending wake-ups and cancels them by session context', async () => {
+    wakeups = [
+      {
+        wakeupId: 'wakeup-1',
+        sessionId: 'session-1',
+        sessionName: 'Issue Watch',
+        agentId: 'agent-a',
+        message: 'Check the issue status',
+        runAt: '2026-04-01T12:00:00.000Z',
+        createdAt: '2026-04-01T11:00:00.000Z',
+        status: 'pending',
+      },
+    ];
+
+    const { container, handle } = await mountPanel();
+
+    try {
+      expect(container.querySelectorAll('.scheduled-sessions-wakeup-item')).toHaveLength(1);
+      expect(container.querySelector('.scheduled-sessions-section-title')?.textContent).toBe(
+        'Wake-ups',
+      );
+      expect(container.querySelector('.scheduled-sessions-wakeup-item')?.textContent).toContain(
+        'Check the issue status',
+      );
+
+      const cancel = container.querySelector<HTMLButtonElement>(
+        '[data-action="cancel-wakeup"][data-session-id="session-1"]',
+      );
+      expect(cancel).not.toBeNull();
+      cancel?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushPromises();
+
+      expect(apiFetch).toHaveBeenCalledWith(
+        '/api/plugins/scheduled-sessions/operations/wakeup-cancel',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'x-session-id': 'session-1',
+          }),
+        }),
       );
     } finally {
       handle.unmount();

--- a/packages/plugins/official/scheduled-sessions/web/index.ts
+++ b/packages/plugins/official/scheduled-sessions/web/index.ts
@@ -57,8 +57,8 @@ const SCHEDULED_SESSIONS_TEMPLATE = `
         type="search"
         class="scheduled-sessions-search"
         data-role="search"
-        placeholder="Filter by title or agent..."
-        aria-label="Filter schedules by title or agent"
+        placeholder="Filter by title, session, message, or agent..."
+        aria-label="Filter scheduled sessions and wake-ups"
         autocomplete="off"
       />
     </div>
@@ -97,6 +97,21 @@ type SchedulesResponse = {
   schedules: ScheduleInfo[];
 };
 
+type SessionWakeupInfo = {
+  wakeupId: string;
+  sessionId: string;
+  sessionName: string | null;
+  agentId: string;
+  message: string;
+  runAt: string;
+  createdAt: string;
+  status: 'pending' | 'queued' | 'delivering';
+};
+
+type WakeupsResponse = {
+  wakeups: SessionWakeupInfo[];
+};
+
 type OperationResponse<T> = {
   ok: boolean;
   result: T;
@@ -112,6 +127,19 @@ type ScheduleDeletedEvent = {
   payload: {
     agentId: string;
     scheduleId: string;
+  };
+};
+
+type SessionWakeupSetEvent = {
+  type: 'session_wakeup:set';
+  payload: SessionWakeupInfo;
+};
+
+type SessionWakeupDeletedEvent = {
+  type: 'session_wakeup:deleted';
+  payload: {
+    wakeupId: string;
+    sessionId: string;
   };
 };
 
@@ -236,6 +264,10 @@ function sortSchedules(schedules: ScheduleInfo[]): ScheduleInfo[] {
   });
 }
 
+function sortWakeups(wakeups: SessionWakeupInfo[]): SessionWakeupInfo[] {
+  return [...wakeups].sort((a, b) => a.runAt.localeCompare(b.runAt));
+}
+
 function getScheduleTitle(schedule: ScheduleInfo): string {
   return schedule.sessionTitle?.trim() || schedule.scheduleId;
 }
@@ -261,6 +293,24 @@ async function fetchSchedules(): Promise<ScheduleInfo[]> {
     throw new Error(`Request failed (${response.status})`);
   }
   return payload.result.schedules;
+}
+
+async function fetchWakeups(): Promise<SessionWakeupInfo[]> {
+  const response = await apiFetch('/api/plugins/scheduled-sessions/operations/wakeup-list', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+  let payload: OperationResponse<WakeupsResponse> | null = null;
+  try {
+    payload = (await response.json()) as OperationResponse<WakeupsResponse>;
+  } catch {
+    // ignore
+  }
+  if (!response.ok || !payload?.ok || !payload.result || !Array.isArray(payload.result.wakeups)) {
+    throw new Error(`Request failed (${response.status})`);
+  }
+  return payload.result.wakeups;
 }
 
 async function runSchedule(agentId: string, scheduleId: string): Promise<RunResponse> {
@@ -299,6 +349,20 @@ async function setScheduleEnabled(agentId: string, scheduleId: string, enabled: 
   }
 }
 
+async function cancelWakeup(sessionId: string): Promise<void> {
+  const response = await apiFetch('/api/plugins/scheduled-sessions/operations/wakeup-cancel', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-session-id': sessionId,
+    },
+    body: JSON.stringify({}),
+  });
+  if (!response.ok) {
+    throw new Error(`Request failed (${response.status})`);
+  }
+}
+
 if (!registry || typeof registry.registerPanel !== 'function') {
   console.warn('ASSISTANT_PANEL_REGISTRY is not available for scheduled-sessions plugin.');
 } else {
@@ -329,6 +393,7 @@ if (!registry || typeof registry.registerPanel !== 'function') {
       });
 
       let schedules = new Map<string, ScheduleInfo>();
+      let wakeups = new Map<string, SessionWakeupInfo>();
       let loading = false;
       let message = '';
       let searchQuery = '';
@@ -377,6 +442,11 @@ if (!registry || typeof registry.registerPanel !== 'function') {
         render();
       };
 
+      const updateWakeups = (nextWakeups: SessionWakeupInfo[]): void => {
+        wakeups = new Map(nextWakeups.map((wakeup) => [wakeup.wakeupId, wakeup]));
+        render();
+      };
+
       const refresh = async (): Promise<void> => {
         if (loading) {
           return;
@@ -384,8 +454,9 @@ if (!registry || typeof registry.registerPanel !== 'function') {
         loading = true;
         setMessage('Loading schedules...');
         try {
-          const data = await fetchSchedules();
-          updateSchedules(data);
+          const [scheduleData, wakeupData] = await Promise.all([fetchSchedules(), fetchWakeups()]);
+          updateSchedules(scheduleData);
+          updateWakeups(wakeupData);
           message = '';
         } catch (err) {
           message = (err as Error).message || 'Failed to fetch schedules';
@@ -411,6 +482,24 @@ if (!registry || typeof registry.registerPanel !== 'function') {
           render();
           return;
         }
+        if (payload['type'] === 'session_wakeup:deleted') {
+          const deleted = (payload as SessionWakeupDeletedEvent).payload;
+          if (!deleted?.wakeupId) {
+            return;
+          }
+          wakeups.delete(deleted.wakeupId);
+          render();
+          return;
+        }
+        if (payload['type'] === 'session_wakeup:set') {
+          const wakeup = (payload as SessionWakeupSetEvent).payload;
+          if (!wakeup?.wakeupId || !wakeup.sessionId) {
+            return;
+          }
+          wakeups.set(wakeup.wakeupId, wakeup);
+          render();
+          return;
+        }
         if (payload['type'] !== 'scheduled_session:status') {
           return;
         }
@@ -424,6 +513,7 @@ if (!registry || typeof registry.registerPanel !== 'function') {
 
       const render = (): void => {
         const allSchedules = Array.from(schedules.values());
+        const allWakeups = Array.from(wakeups.values());
         const normalizedQuery = searchQuery.trim().toLowerCase();
         const orderedSchedules = sortSchedules(allSchedules).filter((schedule) => {
           if (!normalizedQuery) {
@@ -433,24 +523,93 @@ if (!registry || typeof registry.registerPanel !== 'function') {
           const agent = schedule.agentId.toLowerCase();
           return title.includes(normalizedQuery) || agent.includes(normalizedQuery);
         });
+        const orderedWakeups = sortWakeups(allWakeups).filter((wakeup) => {
+          if (!normalizedQuery) {
+            return true;
+          }
+          const sessionName = (wakeup.sessionName ?? '').toLowerCase();
+          const sessionId = wakeup.sessionId.toLowerCase();
+          const messageText = wakeup.message.toLowerCase();
+          const agent = wakeup.agentId.toLowerCase();
+          return (
+            sessionName.includes(normalizedQuery) ||
+            sessionId.includes(normalizedQuery) ||
+            messageText.includes(normalizedQuery) ||
+            agent.includes(normalizedQuery)
+          );
+        });
         const runningCount = orderedSchedules.filter((schedule) => schedule.status === 'running').length;
         const disabledCount = orderedSchedules.filter((schedule) => schedule.status === 'disabled').length;
         summaryEl.textContent = normalizedQuery
-          ? `${orderedSchedules.length} of ${allSchedules.length} schedules | ${runningCount} running | ${disabledCount} disabled`
-          : `${allSchedules.length} schedules | ${runningCount} running | ${disabledCount} disabled`;
+          ? `${orderedSchedules.length} of ${allSchedules.length} schedules | ${orderedWakeups.length} of ${allWakeups.length} wake-ups | ${runningCount} running | ${disabledCount} disabled`
+          : `${allSchedules.length} schedules | ${allWakeups.length} wake-ups | ${runningCount} running | ${disabledCount} disabled`;
         statusEl.textContent = message;
         chromeController?.scheduleLayoutCheck();
 
-        if (allSchedules.length === 0 && !loading) {
-          bodyEl.innerHTML = '<div class="scheduled-sessions-empty">No schedules configured.</div>';
+        if (allSchedules.length === 0 && allWakeups.length === 0 && !loading) {
+          bodyEl.innerHTML = '<div class="scheduled-sessions-empty">No schedules or wake-ups configured.</div>';
           return;
         }
-        if (orderedSchedules.length === 0 && !loading) {
-          bodyEl.innerHTML = `<div class="scheduled-sessions-empty">No schedules match "${escapeHtml(searchQuery.trim())}".</div>`;
+        if (orderedSchedules.length === 0 && orderedWakeups.length === 0 && !loading) {
+          bodyEl.innerHTML = `<div class="scheduled-sessions-empty">No schedules or wake-ups match "${escapeHtml(searchQuery.trim())}".</div>`;
           return;
         }
 
         let html = '';
+        if (orderedWakeups.length > 0) {
+          html += '<div class="scheduled-sessions-section-title">Wake-ups</div>';
+          html += '<div class="scheduled-sessions-list scheduled-sessions-wakeup-list">';
+          for (const wakeup of orderedWakeups) {
+            const sessionTitle = wakeup.sessionName?.trim() || wakeup.sessionId;
+            const wakeupStatus =
+              wakeup.status === 'queued'
+                ? 'Queued'
+                : wakeup.status === 'delivering'
+                  ? 'Delivering'
+                  : 'Wake-up';
+            html += `
+              <section class="scheduled-sessions-item scheduled-sessions-wakeup-item" data-wakeup-id="${escapeHtml(wakeup.wakeupId)}" data-session-id="${escapeHtml(wakeup.sessionId)}">
+                <div class="scheduled-sessions-row">
+                  <span class="status-dot status-dot--wakeup"></span>
+                  <div class="scheduled-sessions-row-main">
+                    <div class="scheduled-sessions-row-title-line">
+                      <div class="scheduled-sessions-row-title">${escapeHtml(sessionTitle)}</div>
+                      <span class="scheduled-sessions-agent">${escapeHtml(wakeup.agentId)}</span>
+                    </div>
+                    <div class="scheduled-sessions-row-sub">${escapeHtml(wakeup.message)}</div>
+                  </div>
+                  <div class="scheduled-sessions-row-meta">
+                    <div class="scheduled-sessions-row-next">${escapeHtml(formatRelative(wakeup.runAt))}</div>
+                    <div class="scheduled-sessions-row-status">${escapeHtml(wakeupStatus)}</div>
+                  </div>
+                  <div class="scheduled-sessions-row-actions">
+                    <button type="button" class="scheduled-sessions-button" data-action="cancel-wakeup" data-session-id="${escapeHtml(wakeup.sessionId)}">Cancel</button>
+                  </div>
+                </div>
+                <div class="scheduled-sessions-details">
+                  <div class="scheduled-sessions-detail-grid">
+                    <div class="scheduled-sessions-detail">
+                      <div class="scheduled-sessions-detail-label">Run at</div>
+                      <div class="scheduled-sessions-detail-value">${escapeHtml(formatTimestamp(wakeup.runAt))} (${escapeHtml(formatRelative(wakeup.runAt))})</div>
+                    </div>
+                    <div class="scheduled-sessions-detail">
+                      <div class="scheduled-sessions-detail-label">Session</div>
+                      <div class="scheduled-sessions-detail-value">${escapeHtml(wakeup.sessionId)}</div>
+                    </div>
+                    <div class="scheduled-sessions-detail scheduled-sessions-detail-wide">
+                      <div class="scheduled-sessions-detail-label">Message</div>
+                      <div class="scheduled-sessions-detail-value">${escapeHtml(wakeup.message)}</div>
+                    </div>
+                  </div>
+                </div>
+              </section>
+            `;
+          }
+          html += '</div>';
+        }
+        if (orderedSchedules.length > 0) {
+          html += '<div class="scheduled-sessions-section-title">Cron Schedules</div>';
+        }
         html += '<div class="scheduled-sessions-list">';
         for (const schedule of orderedSchedules) {
           const scheduleKey = `${schedule.agentId}:${schedule.scheduleId}`;
@@ -549,6 +708,7 @@ if (!registry || typeof registry.registerPanel !== 'function') {
         const action = actionEl.dataset.action;
         const agentId = actionEl.dataset.agentId ?? '';
         const scheduleId = actionEl.dataset.scheduleId ?? '';
+        const sessionId = actionEl.dataset.sessionId ?? '';
 
         if (action === 'toggle-schedule') {
           if (!agentId || !scheduleId) {
@@ -601,6 +761,20 @@ if (!registry || typeof registry.registerPanel !== 'function') {
           }
           return;
         }
+
+        if (action === 'cancel-wakeup') {
+          event.preventDefault();
+          event.stopPropagation();
+          if (!sessionId) {
+            return;
+          }
+          try {
+            await cancelWakeup(sessionId);
+            setMessage('Wake-up cancelled');
+          } catch (err) {
+            setMessage((err as Error).message || 'Failed to cancel wake-up');
+          }
+        }
       };
 
       loadPanelState();
@@ -628,7 +802,7 @@ if (!registry || typeof registry.registerPanel !== 'function') {
       });
 
       const timer = window.setInterval(() => {
-        if (schedules.size > 0) {
+        if (schedules.size > 0 || wakeups.size > 0) {
           render();
         }
       }, 30_000);

--- a/packages/plugins/official/scheduled-sessions/web/styles.css
+++ b/packages/plugins/official/scheduled-sessions/web/styles.css
@@ -63,6 +63,15 @@
   gap: var(--spacing-xs);
 }
 
+.scheduled-sessions-section-title {
+  margin: var(--spacing-sm) 0 var(--spacing-xs);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
 .scheduled-sessions-empty {
   border: 1px dashed var(--color-border-subtle);
   border-radius: var(--radius-md);
@@ -205,6 +214,10 @@
 
 .status-dot--disabled {
   background-color: var(--color-text-muted);
+}
+
+.status-dot--wakeup {
+  background-color: var(--color-accent-primary);
 }
 
 .scheduled-sessions-details {


### PR DESCRIPTION
## Summary
- add one-shot Pi SDK session wake-ups with durable pending/queued/delivering state
- expose wake-up list/set/cancel tools through the scheduled-sessions plugin
- show and cancel wake-ups from the scheduled-sessions panel
- document wake-up usage, timezone-aware runAt input, and storage behavior

## Verification
- npx vitest --run packages/agent-server/src/scheduledSessions/sessionWakeupStore.test.ts packages/agent-server/src/scheduledSessions/scheduledSessionService.test.ts packages/plugins/official/scheduled-sessions/server/index.test.ts packages/plugins/official/scheduled-sessions/web/index.test.ts
- npm run build
- deployed and restarted assistant.service
