### PR TITLE
Add native Android text replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Added native Android voice replay for assistant turns and text/markdown attachments, using the existing local voice queue with front-of-queue, non-interrupting playback. ([#106](https://github.com/kcosr/assistant/pull/106))
 - Added one-shot Pi SDK session wake-ups to the scheduled-sessions plugin, including durable wake-up storage, current-session set/cancel tools, cross-session listing, busy-session queue delivery, and panel visibility/cancel controls. ([#105](https://github.com/kcosr/assistant/pull/105))
 - Added a virtual Focus list view with focus toggles, source-list editing, searchable list move/copy pickers, and add/edit list target selection for list items. ([#103](https://github.com/kcosr/assistant/pull/103))
 - Added Pi SDK custom-model config support for `api`, `authHeader`, `compat`, synthesized model metadata, and compaction so Assistant agents can target OpenAI-compatible endpoints that need Pi compatibility flags. ([#102](https://github.com/kcosr/assistant/pull/102))

--- a/packages/mobile-web/README.md
+++ b/packages/mobile-web/README.md
@@ -217,6 +217,11 @@ adb -s <device> exec-out run-as com.assistant.work cat files/voice-runtime.log
   system notification shade and from the in-app Notifications panel cards. Manual actions
   reconstruct fresh local queue items from the stored notification, jump ahead of automatic work,
   and discard interrupted automatic playback instead of requeueing it.
+- When Android native voice mode is enabled, Pi request divider menus expose `Play` for the
+  assistant text in that request, and text/markdown attachment actions expose `Play` for rendered
+  text content, loading the full attachment text when the preview is truncated. These
+  app-initiated replay actions use the same native local queue, jump to the front of queued work,
+  and do not interrupt the currently active playback or recognition pass.
 - Automatic voice admission remains local-only. If the Android runtime was not alive when a
   notification arrived, the notification stays durable for manual recovery later, but missed
   automatic playback is not replayed by default when the app comes back.

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoicePlugin.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoicePlugin.java
@@ -228,6 +228,34 @@ public final class AssistantVoicePlugin extends Plugin {
     }
 
     @PluginMethod
+    public void playText(PluginCall call) {
+        String text = trim(call.getString("text"));
+        if (text.isEmpty()) {
+            call.reject("text is required");
+            return;
+        }
+        String sessionId = call.getString("sessionId");
+        String title = call.getString("title");
+        String sourceEventId = call.getString("sourceEventId");
+        JSONObject details = AssistantVoiceEventLog.details();
+        AssistantVoiceEventLog.put(details, "sessionId", safe(sessionId));
+        AssistantVoiceEventLog.put(details, "sourceEventId", safe(sourceEventId));
+        AssistantVoiceEventLog.put(details, "textLength", text.length());
+        AssistantVoiceEventLog.record(getContext(), "plugin_play_text", details);
+        ContextCompat.startForegroundService(
+            getContext(),
+            AssistantVoiceRuntimeService.playTextIntent(
+                getContext(),
+                sessionId,
+                text,
+                title,
+                sourceEventId
+            )
+        );
+        call.resolve(buildStatePayload());
+    }
+
+    @PluginMethod
     public void performNotificationSpeaker(PluginCall call) {
         AssistantVoiceNotificationRecord notification = extractNotification(call);
         if (notification == null) {
@@ -570,5 +598,9 @@ public final class AssistantVoicePlugin extends Plugin {
     private static String safe(String value) {
         String trimmed = value == null ? "" : value.trim();
         return trimmed.isEmpty() ? "<empty>" : trimmed;
+    }
+
+    private static String trim(String value) {
+        return value == null ? "" : value.trim();
     }
 }

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceQueueItem.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceQueueItem.java
@@ -119,6 +119,33 @@ final class AssistantVoiceQueueItem {
         );
     }
 
+    static AssistantVoiceQueueItem fromManualText(
+        String sourceEventId,
+        String sessionId,
+        String sessionTitle,
+        String displayTitle,
+        String spokenText
+    ) {
+        String normalizedSpeech = trim(spokenText);
+        if (normalizedSpeech.isEmpty()) {
+            return null;
+        }
+        return new AssistantVoiceQueueItem(
+            "",
+            "manual_text",
+            "app",
+            sourceEventId,
+            sessionId,
+            sessionTitle,
+            displayTitle,
+            normalizedSpeech,
+            "speak",
+            null,
+            true,
+            true
+        );
+    }
+
     private static String resolvePromptSpokenText(
         AssistantVoicePromptEvent prompt,
         boolean includeTitle,

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
@@ -63,10 +63,15 @@ public final class AssistantVoiceRuntimeService extends Service {
         "com.assistant.mobile.voice.RETARGET_ACTIVE_RECOGNITION";
     static final String ACTION_TOGGLE_MEDIA_BUTTONS = "com.assistant.mobile.voice.TOGGLE_MEDIA_BUTTONS";
     static final String ACTION_CYCLE_AUDIO_MODE = "com.assistant.mobile.voice.CYCLE_AUDIO_MODE";
+    static final String ACTION_PLAY_TEXT = "com.assistant.mobile.voice.PLAY_TEXT";
     static final String ACTION_NOTIFICATION_SPEAKER = "com.assistant.mobile.voice.NOTIFICATION_SPEAKER";
     static final String ACTION_NOTIFICATION_MIC = "com.assistant.mobile.voice.NOTIFICATION_MIC";
     static final String ACTION_NOTIFICATION_DISMISS = "com.assistant.mobile.voice.NOTIFICATION_DISMISS";
     static final String EXTRA_MANUAL_LISTEN_SESSION_ID = "manualListenSessionId";
+    static final String EXTRA_PLAY_TEXT_SESSION_ID = "playTextSessionId";
+    static final String EXTRA_PLAY_TEXT_TEXT = "playTextText";
+    static final String EXTRA_PLAY_TEXT_TITLE = "playTextTitle";
+    static final String EXTRA_PLAY_TEXT_SOURCE_EVENT_ID = "playTextSourceEventId";
     static final String EXTRA_NOTIFICATION_ID = "notificationId";
     static final String EXTRA_NOTIFICATION_KIND = "notificationKind";
     static final String EXTRA_NOTIFICATION_SOURCE = "notificationSource";
@@ -234,6 +239,21 @@ public final class AssistantVoiceRuntimeService extends Service {
             .putExtra(AssistantVoiceConfig.EXTRA_AUDIO_MODE, trim(audioMode));
     }
 
+    public static Intent playTextIntent(
+        Context context,
+        String sessionId,
+        String text,
+        String title,
+        String sourceEventId
+    ) {
+        return new Intent(context, AssistantVoiceRuntimeService.class)
+            .setAction(ACTION_PLAY_TEXT)
+            .putExtra(EXTRA_PLAY_TEXT_SESSION_ID, trim(sessionId))
+            .putExtra(EXTRA_PLAY_TEXT_TEXT, trim(text))
+            .putExtra(EXTRA_PLAY_TEXT_TITLE, trim(title))
+            .putExtra(EXTRA_PLAY_TEXT_SOURCE_EVENT_ID, trim(sourceEventId));
+    }
+
     static Intent notificationSpeakerIntent(
         Context context,
         AssistantVoiceNotificationRecord notification
@@ -343,6 +363,11 @@ public final class AssistantVoiceRuntimeService extends Service {
                 ? intent.getStringExtra(AssistantVoiceConfig.EXTRA_AUDIO_MODE)
                 : config.audioMode;
             applyConfig(config.withAudioMode(nextNotificationAudioMode(currentMode)));
+            return START_STICKY;
+        }
+        if (ACTION_PLAY_TEXT.equals(action)) {
+            recordVoiceEvent("service_action_play_text", eventDetailsWithPlayText(intent));
+            handlePlayTextAction(intent);
             return START_STICKY;
         }
         if (ACTION_NOTIFICATION_SPEAKER.equals(action)) {
@@ -2842,19 +2867,21 @@ public final class AssistantVoiceRuntimeService extends Service {
             );
             return;
         }
-        if (!config.isEnabled()) {
-            Log.d(TAG, "handleManualNotificationAction skipped voice mode disabled " + describeNotification(notification));
-            emitRuntimeError("Voice mode is off");
+        String voiceModeBlock = explainVoiceModeBlock(config);
+        if (!voiceModeBlock.isEmpty()) {
+            Log.d(TAG, "handleManualNotificationAction skipped voice blocked=" + voiceModeBlock + " " + describeNotification(notification));
+            emitRuntimeError(voiceModeBlock);
             return;
         }
+        String playActionBlock = explainPlayActionBlock(config);
         if (microphoneAction && !config.allowsNotificationSpeak()) {
             Log.d(TAG, "handleManualNotificationAction skipped speak not allowed in " + config.audioMode + " " + describeNotification(notification));
             emitRuntimeError("Speak is not available in this audio mode");
             return;
         }
-        if (!microphoneAction && !config.allowsNotificationPlay()) {
-            Log.d(TAG, "handleManualNotificationAction skipped play not allowed in " + config.audioMode + " " + describeNotification(notification));
-            emitRuntimeError("Play is not available in this audio mode");
+        if (!microphoneAction && !playActionBlock.isEmpty()) {
+            Log.d(TAG, "handleManualNotificationAction skipped play blocked=" + playActionBlock + " " + describeNotification(notification));
+            emitRuntimeError(playActionBlock);
             return;
         }
         Log.d(
@@ -2899,6 +2926,42 @@ public final class AssistantVoiceRuntimeService extends Service {
         enqueueQueueItem(item, true);
     }
 
+    private void handlePlayTextAction(Intent intent) {
+        if (intent == null) {
+            return;
+        }
+        String playActionBlock = explainPlayActionBlock(config);
+        if (!playActionBlock.isEmpty()) {
+            Log.d(TAG, "handlePlayTextAction skipped play blocked=" + playActionBlock);
+            emitRuntimeError(playActionBlock);
+            return;
+        }
+        String sessionId = trim(intent.getStringExtra(EXTRA_PLAY_TEXT_SESSION_ID));
+        String text = trim(intent.getStringExtra(EXTRA_PLAY_TEXT_TEXT));
+        String title = trim(intent.getStringExtra(EXTRA_PLAY_TEXT_TITLE));
+        String sourceEventId = trim(intent.getStringExtra(EXTRA_PLAY_TEXT_SOURCE_EVENT_ID));
+        String sessionTitle = sessionId.isEmpty() ? "" : config.getSessionTitle(sessionId);
+        String displayTitle = title.isEmpty() ? sessionTitle : title;
+        AssistantVoiceQueueItem item = AssistantVoiceQueueItem.fromManualText(
+            sourceEventId,
+            sessionId,
+            sessionTitle,
+            displayTitle,
+            text
+        );
+        if (item == null) {
+            Log.d(TAG, "handlePlayTextAction skipped empty text");
+            emitRuntimeError("Nothing to play");
+            return;
+        }
+        Log.d(TAG, "handlePlayTextAction enqueueing " + describeQueueItem(item));
+        JSONObject details = AssistantVoiceEventLog.details();
+        AssistantVoiceEventLog.put(details, "queueItem", describeQueueItem(item));
+        AssistantVoiceEventLog.put(details, "textLength", text.length());
+        recordVoiceEvent("manual_text_action", details);
+        enqueueQueueItem(item, true);
+    }
+
     static boolean canHandleManualNotificationAction(
         AssistantVoiceNotificationRecord notification,
         boolean microphoneAction
@@ -2907,6 +2970,24 @@ public final class AssistantVoiceRuntimeService extends Service {
             return false;
         }
         return !microphoneAction || !notification.sessionId.isEmpty();
+    }
+
+    static String explainPlayActionBlock(AssistantVoiceConfig config) {
+        String voiceModeBlock = explainVoiceModeBlock(config);
+        if (!voiceModeBlock.isEmpty()) {
+            return voiceModeBlock;
+        }
+        if (!config.allowsNotificationPlay()) {
+            return "Play is not available in this audio mode";
+        }
+        return "";
+    }
+
+    static String explainVoiceModeBlock(AssistantVoiceConfig config) {
+        if (config == null || !config.isEnabled()) {
+            return "Voice mode is off";
+        }
+        return "";
     }
 
     private void dismissDurableNotification(Intent intent) {
@@ -3149,6 +3230,23 @@ public final class AssistantVoiceRuntimeService extends Service {
             "notificationId",
             safe(intent == null ? null : intent.getStringExtra(EXTRA_NOTIFICATION_ID))
         );
+        return details;
+    }
+
+    private JSONObject eventDetailsWithPlayText(Intent intent) {
+        JSONObject details = AssistantVoiceEventLog.details();
+        AssistantVoiceEventLog.put(
+            details,
+            "sessionId",
+            safe(intent == null ? null : intent.getStringExtra(EXTRA_PLAY_TEXT_SESSION_ID))
+        );
+        AssistantVoiceEventLog.put(
+            details,
+            "sourceEventId",
+            safe(intent == null ? null : intent.getStringExtra(EXTRA_PLAY_TEXT_SOURCE_EVENT_ID))
+        );
+        String text = intent == null ? "" : trim(intent.getStringExtra(EXTRA_PLAY_TEXT_TEXT));
+        AssistantVoiceEventLog.put(details, "textLength", text.length());
         return details;
     }
 

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceQueueItemTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceQueueItemTest.java
@@ -197,4 +197,31 @@ public final class AssistantVoiceQueueItemTest {
         assertNotNull(item);
         assertEquals("Project Alpha: Speak me", item.spokenText);
     }
+
+    @Test
+    public void manualTextBuildsSpeakOnlyQueueItemWithoutSessionRequirement() {
+        AssistantVoiceQueueItem item = AssistantVoiceQueueItem.fromManualText(
+            "turn-1",
+            "",
+            "",
+            "Replay",
+            "Read this"
+        );
+
+        assertNotNull(item);
+        assertEquals("manual_text", item.notificationKind);
+        assertEquals("app", item.source);
+        assertEquals("turn-1", item.dedupKey());
+        assertEquals("", item.sessionId);
+        assertEquals("Replay", item.displayTitle);
+        assertEquals("Read this", item.spokenText);
+        assertEquals("speak", item.executionMode);
+        assertTrue(item.manual);
+        assertTrue(!item.requiresSession());
+    }
+
+    @Test
+    public void manualTextReturnsNullForBlankSpeech() {
+        assertNull(AssistantVoiceQueueItem.fromManualText("turn-2", "session-2", "Session", "", " "));
+    }
 }

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRuntimeServiceTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRuntimeServiceTest.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -32,6 +33,96 @@ import static org.junit.Assert.assertFalse;
 
 @RunWith(RobolectricTestRunner.class)
 public final class AssistantVoiceRuntimeServiceTest {
+    @Test
+    @Config(sdk = Build.VERSION_CODES.N)
+    public void playTextIntentCarriesManualPlaybackPayload() {
+        Context context = RuntimeEnvironment.getApplication();
+
+        Intent intent = AssistantVoiceRuntimeService.playTextIntent(
+            context,
+            " session-1 ",
+            " Read this ",
+            " Replay ",
+            " turn-1 "
+        );
+
+        assertEquals(AssistantVoiceRuntimeService.ACTION_PLAY_TEXT, intent.getAction());
+        assertEquals(
+            "session-1",
+            intent.getStringExtra(AssistantVoiceRuntimeService.EXTRA_PLAY_TEXT_SESSION_ID)
+        );
+        assertEquals(
+            "Read this",
+            intent.getStringExtra(AssistantVoiceRuntimeService.EXTRA_PLAY_TEXT_TEXT)
+        );
+        assertEquals(
+            "Replay",
+            intent.getStringExtra(AssistantVoiceRuntimeService.EXTRA_PLAY_TEXT_TITLE)
+        );
+        assertEquals(
+            "turn-1",
+            intent.getStringExtra(AssistantVoiceRuntimeService.EXTRA_PLAY_TEXT_SOURCE_EVENT_ID)
+        );
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.N)
+    public void explainPlayActionBlockMatchesVoicePlaybackAdmission() {
+        assertEquals(
+            "",
+            AssistantVoiceRuntimeService.explainPlayActionBlock(
+                createConfig(AssistantVoiceConfig.AUDIO_MODE_TOOL, Collections.emptyMap())
+            )
+        );
+        assertEquals(
+            "Voice mode is off",
+            AssistantVoiceRuntimeService.explainPlayActionBlock(
+                createConfig(AssistantVoiceConfig.AUDIO_MODE_OFF, Collections.emptyMap())
+            )
+        );
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.N)
+    public void handlePlayTextActionQueuesManualTextAtFrontWhileBusy() throws Exception {
+        Context context = RuntimeEnvironment.getApplication();
+        AssistantVoiceRuntimeService service = new AssistantVoiceRuntimeService();
+        setRuntimeConfig(
+            service,
+            createConfig(AssistantVoiceConfig.AUDIO_MODE_TOOL, sessionTitles("session-1", "Assistant"))
+        );
+        setPrivateField(service, "activeTtsRequestId", "tts-active");
+        List<AssistantVoiceQueueItem> queue = getQueuedVoiceItems(service);
+        queue.add(AssistantVoiceQueueItem.fromManualText(
+            "queued-old",
+            "",
+            "",
+            "Existing",
+            "Existing speech"
+        ));
+
+        invokeHandlePlayTextAction(
+            service,
+            AssistantVoiceRuntimeService.playTextIntent(
+                context,
+                "session-1",
+                "Replay this",
+                "Replay",
+                "turn-1"
+            )
+        );
+
+        assertEquals(2, queue.size());
+        AssistantVoiceQueueItem item = queue.get(0);
+        assertEquals("manual_text", item.notificationKind);
+        assertEquals("turn-1", item.sourceEventId);
+        assertEquals("session-1", item.sessionId);
+        assertEquals("Assistant", item.sessionTitle);
+        assertEquals("Replay", item.displayTitle);
+        assertEquals("Replay this", item.spokenText);
+        assertEquals("queued-old", queue.get(1).sourceEventId);
+    }
+
     @Test
     @Config(sdk = Build.VERSION_CODES.N)
     public void buildNotificationUsesPublicVisibilityDefaultPriorityAndServiceCategory() {
@@ -912,8 +1003,15 @@ public final class AssistantVoiceRuntimeServiceTest {
     }
 
     private static AssistantVoiceConfig createConfig(Map<String, String> sessionTitles) {
+        return createConfig(AssistantVoiceConfig.AUDIO_MODE_TOOL, sessionTitles);
+    }
+
+    private static AssistantVoiceConfig createConfig(
+        String audioMode,
+        Map<String, String> sessionTitles
+    ) {
         return new AssistantVoiceConfig(
-            AssistantVoiceConfig.AUDIO_MODE_TOOL,
+            audioMode,
             true,
             "",
             AssistantVoiceConfig.DEFAULT_RECOGNITION_START_TIMEOUT_MS,
@@ -955,6 +1053,37 @@ public final class AssistantVoiceRuntimeServiceTest {
         Field field = AssistantVoiceRuntimeService.class.getDeclaredField("config");
         field.setAccessible(true);
         field.set(service, config);
+    }
+
+    private static void setPrivateField(
+        AssistantVoiceRuntimeService service,
+        String fieldName,
+        Object value
+    ) throws Exception {
+        Field field = AssistantVoiceRuntimeService.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(service, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<AssistantVoiceQueueItem> getQueuedVoiceItems(
+        AssistantVoiceRuntimeService service
+    ) throws Exception {
+        Field field = AssistantVoiceRuntimeService.class.getDeclaredField("queuedVoiceItems");
+        field.setAccessible(true);
+        return (List<AssistantVoiceQueueItem>) field.get(service);
+    }
+
+    private static void invokeHandlePlayTextAction(
+        AssistantVoiceRuntimeService service,
+        Intent intent
+    ) throws Exception {
+        Method method = AssistantVoiceRuntimeService.class.getDeclaredMethod(
+            "handlePlayTextAction",
+            Intent.class
+        );
+        method.setAccessible(true);
+        method.invoke(service, intent);
     }
 
     private static String invokePrivateStringMethod(

--- a/packages/web-client/src/controllers/chatRenderer.test.ts
+++ b/packages/web-client/src/controllers/chatRenderer.test.ts
@@ -1367,6 +1367,154 @@ describe('ChatRenderer', () => {
     expect(writeText.mock.calls[1]?.[0]).not.toContain('#');
   });
 
+  it('plays markdown attachments as rendered plain text when native playback is available', async () => {
+    const container = document.createElement('div');
+    container.className = 'chat-log';
+    document.body.appendChild(container);
+
+    const playText = vi.fn(() => true);
+    const renderer = new ChatRenderer(container, {
+      getTextPlaybackAvailable: () => true,
+      playText,
+    });
+
+    replayLegacyEvents(renderer, [
+      createBaseEvent('turn_start', {
+        id: 'e-attachment-play-turn',
+        turnId: 't-attachment-play',
+        payload: { trigger: 'user' },
+      }),
+      createBaseEvent('tool_call', {
+        id: 'e-attachment-play-call',
+        turnId: 't-attachment-play',
+        responseId: 'r-attachment-play',
+        payload: {
+          toolCallId: 'tc-attachment-play',
+          toolName: 'attachment_send',
+          args: {
+            fileName: 'note.md',
+            text: '# Hello\n\nWorld',
+          },
+        },
+      }),
+      createBaseEvent('tool_result', {
+        id: 'e-attachment-play-result',
+        turnId: 't-attachment-play',
+        responseId: 'r-attachment-play',
+        payload: {
+          toolCallId: 'tc-attachment-play',
+          result: {
+            ok: true,
+            attachment: {
+              attachmentId: 'att-play',
+              fileName: 'note.md',
+              title: 'Note',
+              contentType: 'text/markdown',
+              size: 14,
+              downloadUrl: '/api/attachments/session-1/att-play?download=1',
+              previewType: 'markdown',
+              previewText: '# Hello\n\nWorld',
+            },
+          },
+        },
+      }),
+    ]);
+
+    const playButton = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('.attachment-tool-actions button'),
+    ).find((button) => button.textContent === 'Play');
+    expect(playButton).toBeDefined();
+
+    playButton?.click();
+
+    await vi.waitFor(() => {
+      expect(playText).toHaveBeenCalled();
+    });
+    expect(playText).toHaveBeenCalledWith({
+      sessionId: null,
+      text: 'Hello\nWorld',
+      title: 'Note',
+      sourceEventId: 'attachment:att-play',
+    });
+  });
+
+  it('shows an attachment play error when native playback becomes unavailable', async () => {
+    const container = document.createElement('div');
+    container.className = 'chat-log';
+    document.body.appendChild(container);
+
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const playText = vi.fn(() => false);
+    const renderer = new ChatRenderer(container, {
+      getTextPlaybackAvailable: () => true,
+      playText,
+    });
+
+    replayLegacyEvents(renderer, [
+      createBaseEvent('turn_start', {
+        id: 'e-attachment-play-unavailable-turn',
+        turnId: 't-attachment-play-unavailable',
+        payload: { trigger: 'user' },
+      }),
+      createBaseEvent('tool_call', {
+        id: 'e-attachment-play-unavailable-call',
+        turnId: 't-attachment-play-unavailable',
+        responseId: 'r-attachment-play-unavailable',
+        payload: {
+          toolCallId: 'tc-attachment-play-unavailable',
+          toolName: 'attachment_send',
+          args: {
+            fileName: 'note.txt',
+            text: 'Read me',
+          },
+        },
+      }),
+      createBaseEvent('tool_result', {
+        id: 'e-attachment-play-unavailable-result',
+        turnId: 't-attachment-play-unavailable',
+        responseId: 'r-attachment-play-unavailable',
+        payload: {
+          toolCallId: 'tc-attachment-play-unavailable',
+          result: {
+            ok: true,
+            attachment: {
+              attachmentId: 'att-unavailable',
+              fileName: 'note.txt',
+              title: 'Note',
+              contentType: 'text/plain',
+              size: 7,
+              downloadUrl: '/api/attachments/session-1/att-unavailable?download=1',
+              previewType: 'text',
+              previewText: 'Read me',
+            },
+          },
+        },
+      }),
+    ]);
+
+    const bubble = container.querySelector<HTMLDivElement>('.attachment-tool-bubble');
+    const playButton = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('.attachment-tool-actions button'),
+    ).find((button) => button.textContent === 'Play');
+    expect(playButton).toBeDefined();
+
+    playButton?.click();
+
+    await vi.waitFor(() => {
+      expect(bubble?.querySelector('.attachment-tool-action-error')?.textContent).toContain(
+        'Failed to play attachment.',
+      );
+    });
+    expect(playText).toHaveBeenCalledWith({
+      sessionId: null,
+      text: 'Read me',
+      title: 'Note',
+      sourceEventId: 'attachment:att-unavailable',
+    });
+    expect(playButton?.disabled).toBe(false);
+    expect(playButton?.textContent).toBe('Play');
+  });
+
   it('shows attachment expand failures inline and keeps the expand action available', async () => {
     const container = document.createElement('div');
     container.className = 'chat-log';
@@ -1624,7 +1772,7 @@ describe('ChatRenderer', () => {
 
     const renderer = new ChatRenderer(container);
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('turn_start', {
         id: 'e-audio-turn-start',
         turnId: 't-audio',
@@ -1632,7 +1780,7 @@ describe('ChatRenderer', () => {
       }),
     );
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('user_audio', {
         id: 'e-audio',
         turnId: 't-audio',
@@ -1660,7 +1808,7 @@ describe('ChatRenderer', () => {
 
     const renderer = new ChatRenderer(container);
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('user_audio', {
         id: 'e-audio-context',
         turnId: 't-audio-context',
@@ -1686,7 +1834,7 @@ describe('ChatRenderer', () => {
 
     const renderer = new ChatRenderer(container);
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('user_audio', {
         id: 'e-audio-context-visible',
         turnId: 't-audio-context-visible',
@@ -1746,7 +1894,7 @@ describe('ChatRenderer', () => {
     const renderer = new ChatRenderer(container);
     const timestamp = new Date('2026-03-29T15:26:00.000Z').getTime();
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('turn_start', {
         id: 'e-turn',
         turnId: 't-turn',
@@ -1755,7 +1903,7 @@ describe('ChatRenderer', () => {
       }),
     );
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('user_message', {
         id: 'e-user',
         turnId: 't-turn',
@@ -1787,7 +1935,7 @@ describe('ChatRenderer', () => {
     const renderer = new ChatRenderer(container);
     renderer.setRequestDividerActionHandler(onRequestDividerActivate);
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('turn_start', {
         id: 'e-turn-1',
         turnId: 't-turn-1',
@@ -1795,14 +1943,14 @@ describe('ChatRenderer', () => {
         payload: { trigger: 'user' },
       }),
     );
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('user_message', {
         id: 'e-user-1',
         turnId: 't-turn-1',
         payload: { text: 'First' },
       }),
     );
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('turn_start', {
         id: 'e-turn-2',
         turnId: 't-turn-2',
@@ -1810,7 +1958,7 @@ describe('ChatRenderer', () => {
         payload: { trigger: 'user' },
       }),
     );
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('user_message', {
         id: 'e-user-2',
         turnId: 't-turn-2',
@@ -1835,6 +1983,45 @@ describe('ChatRenderer', () => {
     );
   });
 
+  it('passes assistant text from the request to the request divider action handler', () => {
+    const container = document.createElement('div');
+    container.className = 'chat-log';
+    document.body.appendChild(container);
+
+    const onRequestDividerActivate = vi.fn();
+    const renderer = new ChatRenderer(container);
+    renderer.setRequestDividerActionHandler(onRequestDividerActivate);
+
+    renderLegacyEvent(renderer,
+      createBaseEvent('turn_start', {
+        id: 'e-turn-play',
+        turnId: 't-turn-play',
+        timestamp: new Date('2026-03-29T15:26:00.000Z').getTime(),
+        payload: { trigger: 'user' },
+      }),
+    );
+    renderLegacyEvent(renderer,
+      createBaseEvent('assistant_done', {
+        id: 'e-assistant-play',
+        turnId: 't-turn-play',
+        responseId: 'r-turn-play',
+        payload: { text: '## Summary\n\nRead this again.' },
+      }),
+    );
+
+    container
+      .querySelector<HTMLButtonElement>('.turn[data-turn-id="t-turn-play"] .turn-divider-button')
+      ?.click();
+
+    expect(onRequestDividerActivate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: 't-turn-play',
+        playableText: 'Summary\nRead this again.',
+        sourceEventId: 'turn:t-turn-play',
+      }),
+    );
+  });
+
   it('groups contiguous tool calls within the same segment', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -1843,7 +2030,7 @@ describe('ChatRenderer', () => {
       getExpandToolOutput: () => true,
     });
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_call', {
         id: 'e1',
         payload: {
@@ -1854,7 +2041,7 @@ describe('ChatRenderer', () => {
       }),
     );
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_call', {
         id: 'e2',
         payload: {
@@ -1930,7 +2117,7 @@ describe('ChatRenderer', () => {
       getExpandToolOutput: () => true,
     });
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_call', {
         id: 'e1',
         payload: {
@@ -1941,7 +2128,7 @@ describe('ChatRenderer', () => {
       }),
     );
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_result', {
         id: 'e2',
         payload: {
@@ -1974,7 +2161,7 @@ describe('ChatRenderer', () => {
       getExpandToolOutput: () => true,
     });
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_call', {
         id: 'e1',
         payload: {
@@ -1988,7 +2175,7 @@ describe('ChatRenderer', () => {
       }),
     );
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_call', {
         id: 'e2',
         payload: {
@@ -2324,13 +2511,13 @@ describe('ChatRenderer', () => {
 
     const renderer = new ChatRenderer(container);
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('assistant_chunk', {
         id: 'e1',
         payload: { text: 'Hello ' },
       }),
     );
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('assistant_chunk', {
         id: 'e2',
         payload: { text: 'world' },
@@ -2341,7 +2528,7 @@ describe('ChatRenderer', () => {
     expect(assistantText).not.toBeNull();
     expect(assistantText?.textContent).toContain('Hello world');
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('assistant_done', {
         id: 'e3',
         payload: { text: 'Hello world!' },
@@ -2360,7 +2547,7 @@ describe('ChatRenderer', () => {
 
     const renderer = new ChatRenderer(container);
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('assistant_chunk', {
         id: 'e1',
         payload: { text: 'Hello **wor' },
@@ -2369,7 +2556,7 @@ describe('ChatRenderer', () => {
     let assistantText = container.querySelector<HTMLDivElement>('.assistant-text');
     expect(assistantText?.querySelector('strong')?.textContent).toBe('wor');
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('assistant_chunk', {
         id: 'e2',
         payload: { text: 'ld**' },
@@ -2388,7 +2575,7 @@ describe('ChatRenderer', () => {
       getExpandToolOutput: () => true,
     });
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('assistant_chunk', {
         id: 'e1',
         responseId: 'r1',
@@ -2396,7 +2583,7 @@ describe('ChatRenderer', () => {
       }),
     );
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_call', {
         id: 'e2',
         responseId: 'r1',
@@ -2421,7 +2608,7 @@ describe('ChatRenderer', () => {
       getExpandToolOutput: () => true,
     });
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('assistant_chunk', {
         id: 'e1',
         responseId: 'r1',
@@ -2429,7 +2616,7 @@ describe('ChatRenderer', () => {
       }),
     );
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_call', {
         id: 'e2',
         responseId: 'r1',
@@ -2441,7 +2628,7 @@ describe('ChatRenderer', () => {
       }),
     );
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('assistant_done', {
         id: 'e3',
         responseId: 'r1',
@@ -2460,21 +2647,21 @@ describe('ChatRenderer', () => {
 
     const renderer = new ChatRenderer(container);
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('assistant_chunk', {
         id: 'e1',
         responseId: 'r1',
         payload: { text: 'Drink water', phase: 'final_answer' },
       }),
     );
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('assistant_chunk', {
         id: 'e2',
         responseId: 'r1',
         payload: { text: ' now', phase: 'final_answer' },
       }),
     );
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('assistant_done', {
         id: 'e3',
         responseId: 'r1',
@@ -2531,7 +2718,7 @@ describe('ChatRenderer', () => {
 
     const renderer = new ChatRenderer(container);
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('turn_start', {
         id: 'e0',
         turnId: 't-turn',
@@ -2539,7 +2726,7 @@ describe('ChatRenderer', () => {
       }),
     );
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('interrupt', {
         id: 'e1',
         turnId: 't-turn',
@@ -2563,7 +2750,7 @@ describe('ChatRenderer', () => {
 
     const renderer = new ChatRenderer(container);
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('user_message', {
         id: 'e1',
         turnId: 't1',
@@ -2580,7 +2767,7 @@ describe('ChatRenderer', () => {
     expect(container.querySelector('.message.user')).toBeNull();
 
     // Rendering after clear should work normally again.
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('user_message', {
         id: 'e2',
         turnId: 't2',
@@ -2600,7 +2787,7 @@ describe('ChatRenderer', () => {
     });
 
     // First, render the tool_call
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_call', {
         id: 'e1',
         payload: {
@@ -2616,7 +2803,7 @@ describe('ChatRenderer', () => {
     expect(toolBlock?.classList.contains('pending')).toBe(true);
 
     // Stream some output chunks
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_output_chunk', {
         id: 'e2',
         payload: {
@@ -2634,7 +2821,7 @@ describe('ChatRenderer', () => {
     expect(outputBody?.textContent).toContain('hello');
 
     // Stream more output
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_output_chunk', {
         id: 'e3',
         payload: {
@@ -2651,7 +2838,7 @@ describe('ChatRenderer', () => {
     expect(outputBody?.textContent).toContain('hello world');
 
     // Complete the tool
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_result', {
         id: 'e4',
         payload: {
@@ -2673,7 +2860,7 @@ describe('ChatRenderer', () => {
       getExpandToolOutput: () => true,
     });
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_output_chunk', {
         id: 'e1',
         payload: {
@@ -2687,7 +2874,7 @@ describe('ChatRenderer', () => {
 
     expect(container.querySelector('.tool-output-block')).toBeNull();
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_call', {
         id: 'e2',
         payload: {
@@ -2970,7 +3157,7 @@ describe('ChatRenderer', () => {
       sendQuestionnaireSubmit,
     });
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('questionnaire_request', {
         id: 'q1',
         payload: {
@@ -3154,7 +3341,7 @@ describe('ChatRenderer', () => {
 
     const renderer = new ChatRenderer(container);
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_call', {
         id: 'e1',
         payload: {
@@ -3164,7 +3351,7 @@ describe('ChatRenderer', () => {
         },
       }),
     );
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_call', {
         id: 'e2',
         payload: {
@@ -3178,7 +3365,7 @@ describe('ChatRenderer', () => {
     const grouped = container.querySelectorAll('.tool-call-group');
     expect(grouped.length).toBeGreaterThan(0);
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('interaction_request', {
         id: 'e3',
         payload: {
@@ -3302,7 +3489,7 @@ describe('ChatRenderer', () => {
     const group = container.querySelector<HTMLDivElement>('.tool-call-group');
     expect(group).toBeNull();
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('interaction_response', {
         id: 'e4',
         payload: {
@@ -3617,7 +3804,7 @@ describe('ChatRenderer', () => {
       getExpandToolOutput: () => true,
     });
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_call', {
         id: 'e1',
         payload: {
@@ -3629,7 +3816,7 @@ describe('ChatRenderer', () => {
     );
 
     // First chunk
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_output_chunk', {
         id: 'e2',
         payload: {
@@ -3646,7 +3833,7 @@ describe('ChatRenderer', () => {
     expect(outputBody?.textContent).toContain('first');
 
     // Duplicate chunk (same offset) - should be ignored
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_output_chunk', {
         id: 'e3',
         payload: {
@@ -3664,7 +3851,7 @@ describe('ChatRenderer', () => {
     expect(outputBody?.textContent).toContain('first');
 
     // Stale chunk (lower offset) - should be ignored
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_output_chunk', {
         id: 'e4',
         payload: {
@@ -3680,7 +3867,7 @@ describe('ChatRenderer', () => {
     expect(outputBody?.textContent).not.toContain('stale');
 
     // Valid next chunk (higher offset) - should be appended
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_output_chunk', {
         id: 'e5',
         payload: {
@@ -3706,7 +3893,7 @@ describe('ChatRenderer', () => {
     });
 
     // First, create the response container via a turn_start
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('turn_start', {
         id: 't1',
         turnId: 'turn1',
@@ -3715,7 +3902,7 @@ describe('ChatRenderer', () => {
     );
 
     // Stream input chunks before tool_call arrives
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_input_chunk', {
         id: 'e1',
         turnId: 'turn1',
@@ -3735,7 +3922,7 @@ describe('ChatRenderer', () => {
     expect(toolBlock?.classList.contains('streaming-input')).toBe(true);
 
     // Stream more input
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_input_chunk', {
         id: 'e2',
         turnId: 'turn1',
@@ -3758,7 +3945,7 @@ describe('ChatRenderer', () => {
     expect(headerLabel?.textContent).toContain('echo hello');
 
     // Now the final tool_call event arrives with complete args
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_call', {
         id: 'e3',
         turnId: 'turn1',
@@ -3782,7 +3969,7 @@ describe('ChatRenderer', () => {
 
     const renderer = new ChatRenderer(container);
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_call', {
         id: 'e1',
         payload: {
@@ -3878,7 +4065,7 @@ describe('ChatRenderer', () => {
 
     const renderer = new ChatRenderer(container);
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_call', {
         id: 'e1',
         payload: {
@@ -3926,7 +4113,7 @@ describe('ChatRenderer', () => {
 
     const renderer = new ChatRenderer(container);
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_call', {
         id: 'e1',
         payload: {
@@ -3937,7 +4124,7 @@ describe('ChatRenderer', () => {
       }),
     );
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_result', {
         id: 'e2',
         payload: {
@@ -4233,7 +4420,7 @@ describe('ChatRenderer', () => {
       getExpandToolOutput: () => true,
     });
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_call', {
         id: 'e1',
         payload: {
@@ -4244,7 +4431,7 @@ describe('ChatRenderer', () => {
       }),
     );
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('interaction_request', {
         id: 'e2',
         payload: {
@@ -4261,7 +4448,7 @@ describe('ChatRenderer', () => {
       }),
     );
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('interaction_response', {
         id: 'e3',
         payload: {
@@ -4309,7 +4496,7 @@ describe('ChatRenderer', () => {
       getExpandToolOutput: () => true,
     });
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_call', {
         id: 'e1',
         payload: {
@@ -4320,7 +4507,7 @@ describe('ChatRenderer', () => {
       }),
     );
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_result', {
         id: 'e2',
         payload: {
@@ -4358,7 +4545,7 @@ describe('ChatRenderer', () => {
       getExpandToolOutput: () => true,
     });
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_call', {
         id: 'e1',
         payload: {
@@ -4369,7 +4556,7 @@ describe('ChatRenderer', () => {
       }),
     );
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_output_chunk', {
         id: 'e2',
         payload: {
@@ -4395,7 +4582,7 @@ describe('ChatRenderer', () => {
 
     const renderer = new ChatRenderer(container);
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_input_chunk', {
         id: 'e1',
         payload: {
@@ -4407,7 +4594,7 @@ describe('ChatRenderer', () => {
       }),
     );
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('tool_input_chunk', {
         id: 'e2',
         payload: {
@@ -4531,7 +4718,7 @@ describe('ChatRenderer', () => {
     const focusInput = vi.fn();
     renderer.setFocusInputHandler(focusInput);
 
-    renderLegacyEvent(renderer, 
+    renderLegacyEvent(renderer,
       createBaseEvent('interaction_request', {
         id: 'e1',
         payload: {
@@ -4633,7 +4820,7 @@ it('renders multiple questionnaires via handleNewEvent without removing earlier 
   const renderer = new ChatRenderer(container);
 
   // First questionnaire
-  renderLegacyEvent(renderer, 
+  renderLegacyEvent(renderer,
     createBaseEvent('interaction_request', {
       id: 'e1',
       turnId: 'turn1',
@@ -4653,7 +4840,7 @@ it('renders multiple questionnaires via handleNewEvent without removing earlier 
   );
 
   // Response to first
-  renderLegacyEvent(renderer, 
+  renderLegacyEvent(renderer,
     createBaseEvent('interaction_response', {
       id: 'e2',
       payload: {
@@ -4666,7 +4853,7 @@ it('renders multiple questionnaires via handleNewEvent without removing earlier 
   );
 
   // Second questionnaire
-  renderLegacyEvent(renderer, 
+  renderLegacyEvent(renderer,
     createBaseEvent('interaction_request', {
       id: 'e3',
       turnId: 'turn1',

--- a/packages/web-client/src/controllers/chatRenderer.ts
+++ b/packages/web-client/src/controllers/chatRenderer.ts
@@ -57,10 +57,31 @@ import {
   type QuestionnaireRequestView,
 } from '../utils/interactionRenderer';
 import { dedupeProjectedTranscriptEvents } from '../utils/transcriptReplay';
+export interface ChatTextPlaybackOptions {
+  sessionId?: string | null;
+  text: string;
+  title?: string | null;
+  sourceEventId?: string | null;
+}
+
+export type ChatTextPlaybackHandler = (options: ChatTextPlaybackOptions) => boolean;
+
+export interface RequestDividerActionOptions {
+  requestId: string;
+  timestamp: number;
+  anchorEl: HTMLElement;
+  hasBefore: boolean;
+  hasAfter: boolean;
+  playableText?: string;
+  sourceEventId?: string;
+}
+
 export interface ChatRendererOptions {
   getAgentDisplayName?: (agentId: string) => string | undefined;
   getExpandToolOutput?: () => boolean;
   getInteractionEnabled?: () => boolean;
+  getTextPlaybackAvailable?: () => boolean;
+  playText?: ChatTextPlaybackHandler;
   getShouldAutoFocusQuestionnaire?: () => boolean;
   getShouldRestoreFocusAfterInteraction?: () => boolean;
   sendInteractionResponse?: (options: {
@@ -79,13 +100,7 @@ export interface ChatRendererOptions {
     questionnaireRequestId: string;
     reason?: string;
   }) => void;
-  onRequestDividerActivate?: (options: {
-    requestId: string;
-    timestamp: number;
-    anchorEl: HTMLElement;
-    hasBefore: boolean;
-    hasAfter: boolean;
-  }) => void;
+  onRequestDividerActivate?: (options: RequestDividerActionOptions) => void;
 }
 
 export type ProjectedTranscriptApplyResult = 'applied' | 'ignored' | 'reload';
@@ -231,6 +246,8 @@ export class ChatRenderer {
         anchorEl: HTMLElement;
         hasBefore: boolean;
         hasAfter: boolean;
+        playableText?: string;
+        sourceEventId?: string;
       }) => void)
     | null;
   private readonly turnTimestampFormatter = new Intl.DateTimeFormat(undefined, {
@@ -817,6 +834,8 @@ export class ChatRenderer {
           anchorEl: HTMLElement;
           hasBefore: boolean;
           hasAfter: boolean;
+          playableText?: string;
+          sourceEventId?: string;
         }) => void)
       | null,
   ): void {
@@ -2909,12 +2928,15 @@ export class ChatRenderer {
       }
       const previousTurn = turnEl.previousElementSibling;
       const nextTurn = turnEl.nextElementSibling;
+      const playableText = this.getPlayableTurnText(turnEl);
       this.requestDividerActionHandler({
         requestId,
         timestamp,
         anchorEl: label,
         hasBefore: previousTurn instanceof HTMLElement && previousTurn.classList.contains('turn'),
         hasAfter: nextTurn instanceof HTMLElement && nextTurn.classList.contains('turn'),
+        ...(playableText ? { playableText } : {}),
+        sourceEventId: `turn:${requestId}`,
       });
     });
     const rightLine = document.createElement('span');
@@ -3511,6 +3533,72 @@ export class ChatRenderer {
     return temp.textContent ?? '';
   }
 
+  private isTextPlaybackAvailable(): boolean {
+    return Boolean(this.options.getTextPlaybackAvailable?.() && this.options.playText);
+  }
+
+  private getPlayableTurnText(turnEl: HTMLDivElement): string | undefined {
+    const parts = Array.from(turnEl.querySelectorAll<HTMLElement>('.assistant-text'))
+      .map((element) => {
+        const clone = element.cloneNode(true) as HTMLElement;
+        clone.querySelectorAll('.markdown-code-copy-wrapper').forEach((copyEl) => copyEl.remove());
+        return (clone.textContent ?? '').trim();
+      })
+      .filter((text) => text.length > 0);
+    const text = parts.join('\n\n').trim();
+    return text.length > 0 ? text : undefined;
+  }
+
+  private async resolveAttachmentPlayText(
+    bubble: HTMLDivElement,
+    attachment: AttachmentDescriptor,
+  ): Promise<string> {
+    const text = await this.resolveAttachmentCopyText(bubble, attachment);
+    return attachment.previewType === 'markdown'
+      ? this.renderMarkdownAttachmentAsPlainText(text)
+      : text;
+  }
+
+  private createAttachmentPlayButton(
+    bubble: HTMLDivElement,
+    attachment: AttachmentDescriptor,
+  ): HTMLButtonElement {
+    const button = this.createAttachmentActionButton('Play', () => {
+      const originalLabel = button.textContent ?? 'Play';
+      button.disabled = true;
+      button.textContent = 'Playing…';
+      this.clearAttachmentToolActionError(bubble);
+      void this.resolveAttachmentPlayText(bubble, attachment)
+        .then((text) => {
+          const trimmed = text.trim();
+          if (!trimmed) {
+            throw new Error('Attachment has no playable text');
+          }
+          const queued = this.options.playText?.({
+            sessionId: null,
+            text: trimmed,
+            title: attachment.title || attachment.fileName,
+            sourceEventId: `attachment:${attachment.attachmentId}`,
+          });
+          if (!queued) {
+            throw new Error('Text playback is unavailable');
+          }
+          button.textContent = 'Queued';
+          window.setTimeout(() => {
+            button.disabled = false;
+            button.textContent = originalLabel;
+          }, 1500);
+        })
+        .catch((error) => {
+          console.error('[attachments] Failed to play attachment', error);
+          button.disabled = false;
+          button.textContent = originalLabel;
+          this.showAttachmentToolActionError(bubble, 'Failed to play attachment.');
+        });
+    });
+    return button;
+  }
+
   private async resolveAttachmentCopyText(
     bubble: HTMLDivElement,
     attachment: AttachmentDescriptor,
@@ -3878,6 +3966,10 @@ export class ChatRenderer {
           this.renderAttachmentToolBubble(bubble, attachment);
         });
         actionsEl.appendChild(collapseButton);
+      }
+
+      if (this.isTextPlaybackAvailable() && this.isAttachmentInlinePreviewable(attachment)) {
+        actionsEl.appendChild(this.createAttachmentPlayButton(bubble, attachment));
       }
 
       if (attachment.previewType === 'markdown') {

--- a/packages/web-client/src/controllers/speechAudioController.test.ts
+++ b/packages/web-client/src/controllers/speechAudioController.test.ts
@@ -148,6 +148,7 @@ describe('AssistantNativeVoiceBridge', () => {
       retargetActiveRecognition: vi.fn(),
       setSessionTitles: vi.fn(),
       setAssistantBaseUrl: vi.fn(),
+      playText: vi.fn(),
     };
 
     const bridge = new AssistantNativeVoiceBridge(() => ({
@@ -168,6 +169,14 @@ describe('AssistantNativeVoiceBridge', () => {
     await expect(bridge.retargetActiveRecognition('session-2')).resolves.toBe(true);
     await expect(bridge.setSessionTitles({ 'session-1': 'Daily Assistant' })).resolves.toBe(true);
     await expect(bridge.setAssistantBaseUrl('https://assistant')).resolves.toBe(true);
+    expect(
+      bridge.playText({
+        sessionId: 'session-1',
+        text: 'Read this',
+        title: 'Daily Assistant',
+        sourceEventId: 'turn:1',
+      }),
+    ).toBe(true);
     expect(target.setVoiceSettings).toHaveBeenCalledWith({
       settings: createInitialVoiceSettings({
         audioMode: 'tool',
@@ -189,6 +198,12 @@ describe('AssistantNativeVoiceBridge', () => {
       },
     });
     expect(target.setAssistantBaseUrl).toHaveBeenCalledWith({ url: 'https://assistant' });
+    expect(target.playText).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      text: 'Read this',
+      title: 'Daily Assistant',
+      sourceEventId: 'turn:1',
+    });
   });
 
   it('passes null selected session through the direct bridge', async () => {

--- a/packages/web-client/src/controllers/speechAudioController.ts
+++ b/packages/web-client/src/controllers/speechAudioController.ts
@@ -58,6 +58,13 @@ export interface AssistantNativeVoiceStartListenArgs {
   sessionId?: string | null;
 }
 
+export interface AssistantNativeVoicePlayTextArgs {
+  sessionId?: string | null;
+  text: string;
+  title?: string | null;
+  sourceEventId?: string | null;
+}
+
 export type AssistantNativeVoiceRuntimeState =
   | 'disabled'
   | 'connecting'
@@ -97,6 +104,7 @@ export interface AssistantNativeVoiceBridgeTarget {
   setAssistantBaseUrl?: (args: AssistantNativeVoiceUrlArgs) => void | Promise<void>;
   stopCurrentInteraction?: () => void | Promise<void>;
   startManualListen?: (args?: AssistantNativeVoiceStartListenArgs) => void | Promise<void>;
+  playText?: (args: AssistantNativeVoicePlayTextArgs) => void | Promise<void>;
   listInputDevices?: () =>
     | AssistantNativeVoiceInputDevice[]
     | Promise<AssistantNativeVoiceInputDevice[]>;
@@ -198,6 +206,15 @@ export class AssistantNativeVoiceBridge {
 
   startManualListen(sessionId?: string | null): boolean {
     return this.invoke('startManualListen', { sessionId: sessionId ?? null });
+  }
+
+  playText(args: AssistantNativeVoicePlayTextArgs): boolean {
+    return this.invoke('playText', {
+      sessionId: args.sessionId ?? null,
+      text: args.text,
+      title: args.title ?? null,
+      sourceEventId: args.sourceEventId ?? null,
+    });
   }
 
   isAvailable(): boolean {

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -1083,6 +1083,33 @@ async function main(): Promise<void> {
     return getPrimaryChatInputRuntime()?.getVoiceSettings() ?? currentVoiceSettings;
   }
 
+  function canPlayNativeVoiceText(): boolean {
+    return (
+      useNativeVoiceRuntime &&
+      nativeVoiceBridge.isAvailable() &&
+      getCurrentVoiceSettings().audioMode !== 'off'
+    );
+  }
+
+  function playNativeVoiceText(options: {
+    sessionId?: string | null;
+    text: string;
+    title?: string | null;
+    sourceEventId?: string | null;
+  }): boolean {
+    const text = options.text.trim();
+    if (!text || !canPlayNativeVoiceText()) {
+      return false;
+    }
+    void nativeVoiceBridge.setSessionTitles(getNativeVoiceSessionTitles());
+    return nativeVoiceBridge.playText({
+      sessionId: normalizeSessionId(options.sessionId ?? null),
+      text,
+      title: options.title ?? null,
+      sourceEventId: options.sourceEventId ?? null,
+    });
+  }
+
   function getPreferredVoiceSessionLabel(settings: VoiceSettings): string {
     const selectedSessionId = settings.preferredVoiceSessionId;
     if (!selectedSessionId) {
@@ -1762,7 +1789,7 @@ async function main(): Promise<void> {
       inputRuntime.focusInput();
     });
     runtime.chatRenderer.setRequestDividerActionHandler(
-      ({ requestId, anchorEl, hasBefore, hasAfter }) => {
+      ({ requestId, anchorEl, hasBefore, hasAfter, playableText, sourceEventId }) => {
         if (!bindingSessionId || !isSessionPiBacked(bindingSessionId)) {
           return;
         }
@@ -1772,6 +1799,8 @@ async function main(): Promise<void> {
           anchorEl,
           hasBefore,
           hasAfter,
+          ...(playableText ? { playableText } : {}),
+          ...(sourceEventId ? { sourceEventId } : {}),
         });
       },
     );
@@ -3099,6 +3128,8 @@ async function main(): Promise<void> {
       autoScrollEnabled,
       getAgentDisplayName,
       getInteractionEnabled: () => interactionEnabled,
+      getTextPlaybackAvailable: canPlayNativeVoiceText,
+      playText: playNativeVoiceText,
       isMobileViewport,
       sendInteractionResponse,
       sendQuestionnaireSubmit,
@@ -3448,13 +3479,31 @@ async function main(): Promise<void> {
     anchorEl: HTMLElement;
     hasBefore: boolean;
     hasAfter: boolean;
+    playableText?: string;
+    sourceEventId?: string;
   }): void {
-    const { sessionId, requestId, anchorEl, hasBefore, hasAfter } = options;
+    const { sessionId, requestId, anchorEl, hasBefore, hasAfter, playableText, sourceEventId } =
+      options;
     contextMenuManager.showAnchoredMenu({
       anchorEl,
       menuClassName: 'context-menu request-history-menu',
       closeOnScrollTarget: anchorEl.closest<HTMLElement>('.chat-log'),
       items: [
+        ...(playableText && canPlayNativeVoiceText()
+          ? [
+              {
+                label: 'Play',
+                onClick: () => {
+                  playNativeVoiceText({
+                    sessionId,
+                    text: playableText,
+                    title: getSessionLabel(sessionId),
+                    sourceEventId: sourceEventId ?? `turn:${requestId}`,
+                  });
+                },
+              },
+            ]
+          : []),
         ...(hasBefore
           ? [
               {

--- a/packages/web-client/src/panels/chat/runtime.ts
+++ b/packages/web-client/src/panels/chat/runtime.ts
@@ -1,5 +1,5 @@
 import { ChatScrollManager } from '../../controllers/chatScroll';
-import { ChatRenderer } from '../../controllers/chatRenderer';
+import { ChatRenderer, type ChatTextPlaybackHandler } from '../../controllers/chatRenderer';
 import {
   setToolOutputBlockExpanded,
   setToolOutputBlockNearViewport,
@@ -24,6 +24,8 @@ export interface ChatRuntimeOptions {
   autoScrollEnabled: boolean;
   getAgentDisplayName: (agentId: string) => string;
   getInteractionEnabled?: () => boolean;
+  getTextPlaybackAvailable?: () => boolean;
+  playText?: ChatTextPlaybackHandler;
   isMobileViewport?: () => boolean;
   sendInteractionResponse?: (options: {
     sessionId: string;
@@ -254,6 +256,10 @@ export function createChatRuntime(options: ChatRuntimeOptions): ChatRuntime {
     getAgentDisplayName: options.getAgentDisplayName,
     getExpandToolOutput: () => toolOutputPreferencesClient.getExpandToolOutput(),
     ...(options.getInteractionEnabled ? { getInteractionEnabled: options.getInteractionEnabled } : {}),
+    ...(options.getTextPlaybackAvailable
+      ? { getTextPlaybackAvailable: options.getTextPlaybackAvailable }
+      : {}),
+    ...(options.playText ? { playText: options.playText } : {}),
     getShouldAutoFocusQuestionnaire: () => !(options.isMobileViewport?.() ?? false),
     getShouldRestoreFocusAfterInteraction: () => !(options.isMobileViewport?.() ?? false),
     ...(options.sendInteractionResponse


### PR DESCRIPTION
## Summary
- add a native Android playText bridge/service path for manual text replay through the existing voice queue
- add in-chat Play actions for assistant turns and text/markdown attachments when native voice mode is available
- add Android and web tests for manual text queueing, bridge forwarding, attachment playback, and unavailable playback feedback

## Verification
- npx vitest --run packages/web-client/src/controllers/chatRenderer.test.ts packages/web-client/src/controllers/speechAudioController.test.ts
- npm run build -w @assistant/web-client
- cd packages/mobile-web/android && ./gradlew testDebugUnitTest --tests com.assistant.mobile.voice.AssistantVoiceQueueItemTest --tests com.assistant.mobile.voice.AssistantVoiceRuntimeServiceTest
- npm run build
- deployed to systemd and default Android flavor on all connected devices
