### PR TITLE
Fix time tracker relative range refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 ### Fixed
 
+- Fixed the time tracker entry list refresh so relative Today/Week/Month presets resolve to the current date before listing newly added entries. ([#107](https://github.com/kcosr/assistant/pull/107))
 - Fixed Pi session sync so unreconcilable persisted/live message divergence repairs the canonical JSONL from current messages instead of skipping the write, with diagnostics and failed-rewrite safeguards. ([#104](https://github.com/kcosr/assistant/pull/104))
 - Fixed the Focus list to rank first in list dropdown/browser ordering and to honor add-to-top when creating items from the Focus list. ([#104](https://github.com/kcosr/assistant/pull/104))
 - Fixed chat session picker search so existing sessions match only the displayed label and session id prefix, not hidden agent metadata. ([#101](https://github.com/kcosr/assistant/pull/101))

--- a/packages/plugins/official/time-tracker/web/index.test.ts
+++ b/packages/plugins/official/time-tracker/web/index.test.ts
@@ -62,6 +62,7 @@ describe('time tracker range picker', () => {
   let operationCalls: OperationCall[] = [];
   let mockTasks: MockTask[] = [];
   let mockEntries: MockEntry[] = [];
+  let filterEntryListByRequest = false;
 
   beforeEach(() => {
     panelFactory = null;
@@ -76,6 +77,7 @@ describe('time tracker range picker', () => {
       },
     ];
     mockEntries = [];
+    filterEntryListByRequest = false;
 
     apiFetch.mockReset();
     apiFetch.mockImplementation(async (url: string, options?: RequestInit) => {
@@ -110,7 +112,42 @@ describe('time tracker range picker', () => {
         return json(mockTasks);
       }
       if (operation === 'entry_list') {
-        return json(mockEntries);
+        if (!filterEntryListByRequest) {
+          return json(mockEntries);
+        }
+        const startDate = typeof body['start_date'] === 'string' ? body['start_date'] : null;
+        const endDate = typeof body['end_date'] === 'string' ? body['end_date'] : null;
+        const taskId = typeof body['task_id'] === 'string' ? body['task_id'] : null;
+        const includeReported = body['include_reported'] === true;
+        return json(
+          mockEntries.filter((entry) => {
+            const entryDate = entry.entry_date ?? '';
+            if (startDate && entryDate < startDate) {
+              return false;
+            }
+            if (endDate && entryDate > endDate) {
+              return false;
+            }
+            if (taskId && entry.task_id !== taskId) {
+              return false;
+            }
+            if (!includeReported && entry.reported) {
+              return false;
+            }
+            return true;
+          }),
+        );
+      }
+      if (operation === 'entry_create') {
+        const entry = makeEntry({
+          id: `entry-${mockEntries.length + 1}`,
+          task_id: String(body['task_id']),
+          duration_minutes: Number(body['duration_minutes']),
+          entry_date: String(body['entry_date']),
+          note: typeof body['note'] === 'string' ? body['note'] : '',
+        });
+        mockEntries = [entry, ...mockEntries];
+        return json(entry);
       }
       if (operation === 'timer_status') {
         return json(null);
@@ -363,6 +400,47 @@ describe('time tracker range picker', () => {
     }
   });
 
+  it('refreshes stale today preset dates before listing a newly added entry', async () => {
+    filterEntryListByRequest = true;
+    const today = toDateString(new Date());
+    const yesterdayDate = new Date();
+    yesterdayDate.setDate(yesterdayDate.getDate() - 1);
+    const yesterday = toDateString(yesterdayDate);
+
+    const { container, handle } = await mountPanel({
+      panelState: {
+        selectedTaskId: 'task-1',
+        rangePreset: 'today',
+        rangeStart: yesterday,
+        rangeEnd: yesterday,
+      },
+    });
+
+    try {
+      const addButton = container.querySelector<HTMLButtonElement>('[data-role="entry-add"]');
+      expect(addButton).not.toBeNull();
+      expect(addButton?.disabled).toBe(false);
+
+      addButton?.click();
+      await flushPromises();
+      await flushPromises();
+
+      const entryCreateCall = operationCalls.find((call) => call.operation === 'entry_create');
+      expect(entryCreateCall?.body['entry_date']).toBe(today);
+
+      const latestEntryList = [...operationCalls]
+        .reverse()
+        .find((call) => call.operation === 'entry_list');
+      expect(latestEntryList?.body['start_date']).toBe(today);
+      expect(latestEntryList?.body['end_date']).toBe(today);
+
+      const entryList = container.querySelector<HTMLElement>('[data-role="entry-list"]');
+      expect(entryList?.textContent).toContain('30m');
+    } finally {
+      handle.unmount();
+    }
+  });
+
   it('exports task description before unique note bullets', async () => {
     const rows = await buildExportRows(
       [
@@ -477,7 +555,8 @@ describe('time tracker range picker', () => {
       {
         item: 'QA',
         total_minutes: 60,
-        description: 'Verification pass\n\nNotes:\n• Smoke tested export\n• Checked workbook formatting',
+        description:
+          'Verification pass\n\nNotes:\n• Smoke tested export\n• Checked workbook formatting',
       },
     ]);
   });

--- a/packages/plugins/official/time-tracker/web/index.ts
+++ b/packages/plugins/official/time-tracker/web/index.ts
@@ -417,10 +417,7 @@ async function resolveArtifactsInstanceId(targetId: string): Promise<string> {
   return DEFAULT_INSTANCE_ID;
 }
 
-function buildArtifactsDownloadUrl(options: {
-  instanceId: string;
-  artifactId: string;
-}): string {
+function buildArtifactsDownloadUrl(options: { instanceId: string; artifactId: string }): string {
   const base = getApiBaseUrl().replace(/\/+$/, '');
   return `${base}/api/plugins/artifacts/files/${encodeURIComponent(
     options.instanceId,
@@ -464,6 +461,32 @@ function startOfMonth(date: Date): Date {
 
 function endOfMonth(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth() + 1, 0);
+}
+
+function resolveCurrentDateRange(range: DateRange, now = new Date()): DateRange {
+  if (range.preset === 'today') {
+    const today = toDateString(now);
+    return { start: today, end: today, preset: 'today' };
+  }
+  if (range.preset === 'week') {
+    return {
+      start: toDateString(startOfWeek(now)),
+      end: toDateString(endOfWeek(now)),
+      preset: 'week',
+    };
+  }
+  if (range.preset === 'month') {
+    return {
+      start: toDateString(startOfMonth(now)),
+      end: toDateString(endOfMonth(now)),
+      preset: 'month',
+    };
+  }
+  return range;
+}
+
+function isSameDateRange(a: DateRange, b: DateRange): boolean {
+  return a.start === b.start && a.end === b.end && a.preset === b.preset;
 }
 
 function formatDateLabel(dateString: string, options?: { includeYear?: boolean }): string {
@@ -692,7 +715,10 @@ function setVisible(el: HTMLElement | null, visible: boolean): void {
 }
 
 function normalizeExportNote(note: string): string {
-  return note.trim().replace(/^[-*•–—](?:\s+|$)/, '').trim();
+  return note
+    .trim()
+    .replace(/^[-*•–—](?:\s+|$)/, '')
+    .trim();
 }
 
 function composeExportRowDescription(taskDescription: string, notes: string[]): string {
@@ -877,6 +903,7 @@ if (!registry || typeof registry.registerPanel !== 'function') {
           includeReported = data['includeReported'] as boolean;
         }
       }
+      dateRange = resolveCurrentDateRange(dateRange);
 
       const panelId = host.panelId();
       const contextKey = getPanelContextKey(panelId);
@@ -1123,21 +1150,20 @@ if (!registry || typeof registry.registerPanel !== 'function') {
                 : 'This month';
       }
 
-      function applyPreset(preset: RangePreset): void {
-        const now = new Date();
-        let start = dateRange.start;
-        let end = dateRange.end;
-        if (preset === 'today') {
-          start = toDateString(now);
-          end = start;
-        } else if (preset === 'week') {
-          start = toDateString(startOfWeek(now));
-          end = toDateString(endOfWeek(now));
-        } else if (preset === 'month') {
-          start = toDateString(startOfMonth(now));
-          end = toDateString(endOfMonth(now));
+      function syncRelativeDateRange(): void {
+        const next = resolveCurrentDateRange(dateRange);
+        if (isSameDateRange(dateRange, next)) {
+          return;
         }
-        dateRange = { start, end, preset };
+        dateRange = next;
+        rangeDraftStart = dateRange.start;
+        rangeDraftEnd = dateRange.end;
+        refreshRangeLabel();
+        persistState();
+      }
+
+      function applyPreset(preset: RangePreset): void {
+        dateRange = resolveCurrentDateRange({ ...dateRange, preset });
         refreshRangeLabel();
         persistState();
         void refreshEntries();
@@ -1179,7 +1205,9 @@ if (!registry || typeof registry.registerPanel !== 'function') {
         if (sorted.length === 0) {
           const empty = document.createElement('div');
           empty.className = 'time-tracker-empty';
-          empty.textContent = query ? 'No entries match this filter.' : 'No entries for this period.';
+          empty.textContent = query
+            ? 'No entries match this filter.'
+            : 'No entries for this period.';
           entryList.appendChild(empty);
           rangeTotalValue.textContent = 'Total: 0m';
           return;
@@ -1415,8 +1443,7 @@ if (!registry || typeof registry.registerPanel !== 'function') {
           throw new Error('Failed to export XLSX');
         }
         const mimeType =
-          payload.mimeType ??
-          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+          payload.mimeType ?? 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
         const artifactsInstanceId = await resolveArtifactsInstanceId(selectedInstanceId);
         const artifact = await callArtifactsOperation<ArtifactMetadata>('upload', {
           instance_id: artifactsInstanceId,
@@ -1791,6 +1818,7 @@ if (!registry || typeof registry.registerPanel !== 'function') {
       }
 
       async function refreshEntries(options?: { silent?: boolean }): Promise<void> {
+        syncRelativeDateRange();
         const token = ++entryRefreshToken;
         try {
           const raw = await callInstanceOperation<unknown>('entry_list', {


### PR DESCRIPTION
## Summary
- resolve Today/Week/Month time tracker presets against the current date before entry refreshes
- keep custom date ranges unchanged
- add a regression test proving a stale persisted Today range refreshes to the newly added entry date

## Validation
- npx vitest --run packages/plugins/official/time-tracker/web/index.test.ts
- npx eslint packages/plugins/official/time-tracker/web/index.ts packages/plugins/official/time-tracker/web/index.test.ts
- npx prettier --check packages/plugins/official/time-tracker/web/index.ts packages/plugins/official/time-tracker/web/index.test.ts
