### PR TITLE
Add Android manual auto listen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Changed
 
+- Changed Android native voice Manual mode so Auto Listen can start speech recognition after final assistant messages without playing assistant TTS. ([#109](https://github.com/kcosr/assistant/pull/109))
 - Changed the Voice notification session control to use the shared searchable session picker, replacing the prior native select. ([#100](https://github.com/kcosr/assistant/pull/100))
 - Changed time-tracker XLSX exports to include each task description before unique entry-note bullets in the Description column. ([#99](https://github.com/kcosr/assistant/pull/99))
 - Migrated Pi SDK dependencies from `@mariozechner/*` packages to the `@earendil-works/*` scope at `0.74.0`. ([#98](https://github.com/kcosr/assistant/pull/98))

--- a/docs/design/mobile-voice-tool-mode-android-contract.md
+++ b/docs/design/mobile-voice-tool-mode-android-contract.md
@@ -95,8 +95,9 @@ Queue rules:
 - one item may execute at a time
 - automatic items queue behind current local work when the runtime is already alive
 - manual `Play` and `Speak` actions jump ahead and may interrupt current speech
-- `Manual` mode permits explicit mic starts and manual notification `Speak` actions, but automatic
-  notification playback does not transition into recognition afterward
+- `Manual` mode permits explicit mic starts and manual notification `Speak` actions. When
+  `autoListenEnabled` is on, final assistant replies do not play TTS but may enqueue a listen-only
+  automatic follow-up that starts recognition after the final message arrives.
 - interrupted automatic audio work is discarded rather than requeued
 - `Stop` cancels the current item and flushes the local backlog
 - same-session `session_attention` items coalesce before execution

--- a/docs/design/mobile-voice-tool-mode-web-contract.md
+++ b/docs/design/mobile-voice-tool-mode-web-contract.md
@@ -130,17 +130,18 @@ Existing touchpoints:
 
 ### Auto-listen
 
-`autoListenEnabled` is the source of truth for whether playback automatically transitions
-into recognition.
+`autoListenEnabled` is the source of truth for whether Android-native voice automatically
+transitions into recognition after voice-capable assistant output.
 
 Rules:
 
-- applies only when `Audio Mode` is `Tool` or `Response`
+- applies to `Tool`, `Response`, and Android-native `Manual`
 - when disabled, `voice_ask` and `Response` playback stop after speaking instead of auto-starting
   STT
 - when enabled, `voice_ask` and `Response` playback may transition directly into STT
-- explicit mic starts remain available in `Manual`, `Tool`, and `Response`; `Manual` mode never
-  auto-rearms recognition after notification playback
+- when enabled in Android-native `Manual`, final assistant replies do not play TTS but may start
+  STT automatically after the final message arrives
+- explicit mic starts remain available in `Manual`, `Tool`, and `Response`
 
 ### Adapter URL
 

--- a/packages/mobile-web/README.md
+++ b/packages/mobile-web/README.md
@@ -211,8 +211,9 @@ adb -s <device> exec-out run-as com.assistant.work cat files/voice-runtime.log
   notifications.
 - In `Manual` mode, the microphone can still be started explicitly from the app or notification
   actions, and enabling `Play standalone notifications aloud` still allows standard durable
-  notifications to autoplay through native playback. Session-attention replies still wait for
-  `Response` mode, and automatic notification playback does not re-arm the microphone afterward.
+  notifications to autoplay through native playback. Session-attention replies are not read aloud
+  in `Manual`, but when `Auto Listen` is enabled the native runtime can start recognition
+  automatically after a final assistant reply arrives.
 - Durable session-linked notifications expose `Play` and `Speak` actions both from the Android
   system notification shade and from the in-app Notifications panel cards. Manual actions
   reconstruct fresh local queue items from the stored notification, jump ahead of automatic work,

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceInteractionRules.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceInteractionRules.java
@@ -50,6 +50,32 @@ final class AssistantVoiceInteractionRules {
         return autoListenEnabled && !AssistantVoiceConfig.AUDIO_MODE_MANUAL.equals(audioMode);
     }
 
+    static boolean shouldAutoListenAfterManualAssistantMessage(
+        String audioMode,
+        boolean autoListenEnabled,
+        AssistantVoicePromptEvent prompt,
+        boolean idle
+    ) {
+        return AssistantVoiceConfig.AUDIO_MODE_MANUAL.equals(audioMode)
+            && autoListenEnabled
+            && prompt != null
+            && prompt.isAssistantResponse()
+            && idle;
+    }
+
+    static boolean shouldAutoListenAfterManualAssistantNotification(
+        String audioMode,
+        boolean autoListenEnabled,
+        AssistantVoiceNotificationRecord notification
+    ) {
+        return AssistantVoiceConfig.AUDIO_MODE_MANUAL.equals(audioMode)
+            && autoListenEnabled
+            && notification != null
+            && notification.isUnread()
+            && notification.isSessionAttention()
+            && notification.isSessionLinked();
+    }
+
     static boolean shouldAutoplayNotification(
         String audioMode,
         boolean standaloneNotificationPlaybackEnabled,

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceNotificationRecord.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceNotificationRecord.java
@@ -141,6 +141,26 @@ final class AssistantVoiceNotificationRecord {
         );
     }
 
+    AssistantVoiceQueueItem toManualAutoListenQueueItem(String titleOverride) {
+        if (!isSessionAttention() || !isSessionLinked()) {
+            return null;
+        }
+        return new AssistantVoiceQueueItem(
+            id,
+            kind,
+            source,
+            sourceEventId,
+            sessionId,
+            sessionTitle,
+            resolveSpokenTitle(titleOverride),
+            "",
+            "listen_only",
+            sessionActivitySeq,
+            false,
+            false
+        );
+    }
+
     private static String trim(String value) {
         return value == null ? "" : value.trim();
     }

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceQueueItem.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceQueueItem.java
@@ -59,7 +59,9 @@ final class AssistantVoiceQueueItem {
     }
 
     boolean requiresListenValidation() {
-        return startsListeningAfterPlayback() && !allowListenWithoutValidation && sessionActivitySeq != null;
+        return (startsListeningAfterPlayback() || isListenOnly())
+            && !allowListenWithoutValidation
+            && sessionActivitySeq != null;
     }
 
     boolean isSessionAttention() {
@@ -142,6 +144,37 @@ final class AssistantVoiceQueueItem {
             "speak",
             null,
             true,
+            true
+        );
+    }
+
+    static AssistantVoiceQueueItem fromManualAutoListenPrompt(
+        AssistantVoicePromptEvent prompt,
+        String sessionTitle
+    ) {
+        if (prompt == null || !prompt.isAssistantResponse()) {
+            return null;
+        }
+        String sessionId = trim(prompt.sessionId);
+        if (sessionId.isEmpty()) {
+            return null;
+        }
+        String dedupId = trim(prompt.toolCallId).isEmpty()
+            ? trim(prompt.eventId)
+            : trim(prompt.toolCallId);
+        String normalizedSessionTitle = trim(sessionTitle);
+        return new AssistantVoiceQueueItem(
+            "",
+            "manual_auto_listen",
+            "system",
+            dedupId,
+            sessionId,
+            normalizedSessionTitle,
+            normalizedSessionTitle,
+            "",
+            "listen_only",
+            null,
+            false,
             true
         );
     }

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
@@ -1578,6 +1578,16 @@ public final class AssistantVoiceRuntimeService extends Service {
             Log.d(TAG, "enqueueQueueItem dropped invalid item=" + describeQueueItem(item));
             return;
         }
+        if (shouldDedupManualAutoListenQueueItem(item, activeQueueItem)) {
+            Log.d(TAG, "enqueueQueueItem deduped active manual auto-listen item=" + describeQueueItem(item));
+            return;
+        }
+        for (AssistantVoiceQueueItem queued : queuedVoiceItems) {
+            if (shouldDedupManualAutoListenQueueItem(item, queued)) {
+                Log.d(TAG, "enqueueQueueItem deduped queued manual auto-listen item=" + describeQueueItem(item));
+                return;
+            }
+        }
         String dedupKey = item.dedupKey();
         if (!dedupKey.isEmpty()) {
             if (activeQueueItem != null && dedupKey.equals(activeQueueItem.dedupKey())) {
@@ -2798,14 +2808,31 @@ public final class AssistantVoiceRuntimeService extends Service {
         }
     }
 
-    private static String resolveQueueRecognitionReason(AssistantVoiceQueueItem item) {
+    static String resolveQueueRecognitionReason(AssistantVoiceQueueItem item) {
         if (item != null && item.manual) {
             return "manual_notification_mic";
         }
-        if (item != null && "manual_auto_listen".equals(item.notificationKind)) {
+        if (isManualAutoListenQueueItem(item)) {
             return "manual_auto_listen";
         }
         return "playback_completion";
+    }
+
+    static boolean isManualAutoListenQueueItem(AssistantVoiceQueueItem item) {
+        return item != null
+            && item.isListenOnly()
+            && !item.manual
+            && ("manual_auto_listen".equals(item.notificationKind) || item.isSessionAttention());
+    }
+
+    static boolean shouldDedupManualAutoListenQueueItem(
+        AssistantVoiceQueueItem incoming,
+        AssistantVoiceQueueItem existing
+    ) {
+        return isManualAutoListenQueueItem(incoming)
+            && isManualAutoListenQueueItem(existing)
+            && !incoming.sessionId.isEmpty()
+            && incoming.sessionId.equals(existing.sessionId);
     }
 
     private void validateQueuedRecognitionAndMaybeStart(String requestId) {

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
@@ -1328,19 +1328,41 @@ public final class AssistantVoiceRuntimeService extends Service {
             );
             return;
         }
+        boolean idle = !hasActiveInteraction() && !isManualPreemptStopInFlight();
+        boolean shouldAutoListenAfterManualAssistantMessage =
+            AssistantVoiceInteractionRules.shouldAutoListenAfterManualAssistantMessage(
+                config.audioMode,
+                config.autoListenEnabled,
+                prompt,
+                idle
+            );
         boolean shouldAutoplay = AssistantVoiceInteractionRules.shouldAutoplayEvent(
             config.audioMode,
             prompt,
-            !hasActiveInteraction() && !isManualPreemptStopInFlight()
+            idle
         );
         Log.d(
             TAG,
             "handlePromptEvent decision shouldAutoplay=" + shouldAutoplay
+                + " shouldAutoListenAfterManualAssistantMessage=" + shouldAutoListenAfterManualAssistantMessage
                 + " audioMode=" + safe(config.audioMode)
                 + " autoListenEnabled=" + config.autoListenEnabled
                 + " hasActiveInteraction=" + hasActiveInteraction()
                 + " pendingPreemptStop=" + isManualPreemptStopInFlight()
         );
+        if (shouldAutoListenAfterManualAssistantMessage) {
+            AssistantVoiceQueueItem item =
+                AssistantVoiceQueueItem.fromManualAutoListenPrompt(
+                    prompt,
+                    config.getSessionTitle(prompt.sessionId)
+                );
+            if (item == null) {
+                Log.d(TAG, "handlePromptEvent skipped manual auto-listen prompt with no queue item");
+                return;
+            }
+            enqueueQueueItem(item, false);
+            return;
+        }
         if (!shouldAutoplay) {
             return;
         }
@@ -1511,14 +1533,22 @@ public final class AssistantVoiceRuntimeService extends Service {
     }
 
     private void enqueueAutomaticNotification(AssistantVoiceNotificationRecord notification) {
-        if (!config.isEnabled()
-            || !isRuntimeConnected()
-            || notification == null
-            || !AssistantVoiceInteractionRules.shouldAutoplayNotification(
+        boolean shouldAutoplayNotification =
+            AssistantVoiceInteractionRules.shouldAutoplayNotification(
                 config.audioMode,
                 config.standaloneNotificationPlaybackEnabled,
                 notification
-            )) {
+            );
+        boolean shouldAutoListenAfterManualAssistantNotification =
+            AssistantVoiceInteractionRules.shouldAutoListenAfterManualAssistantNotification(
+                config.audioMode,
+                config.autoListenEnabled,
+                notification
+            );
+        if (!config.isEnabled()
+            || !isRuntimeConnected()
+            || notification == null
+            || (!shouldAutoplayNotification && !shouldAutoListenAfterManualAssistantNotification)) {
             return;
         }
         if (config.ttsPreferredSessionOnly
@@ -1526,14 +1556,17 @@ public final class AssistantVoiceRuntimeService extends Service {
             && !config.preferredVoiceSessionId.equals(notification.sessionId)) {
             return;
         }
-        AssistantVoiceQueueItem item = notification.toAutomaticQueueItem(
-            AssistantVoiceInteractionRules.shouldAutoListenAfterAutomaticNotification(
-                config.audioMode,
-                config.autoListenEnabled
-            ),
-            config.notificationTitlePlaybackEnabled,
-            resolveNotificationSpokenTitle(notification)
-        );
+        String spokenTitle = resolveNotificationSpokenTitle(notification);
+        AssistantVoiceQueueItem item = shouldAutoListenAfterManualAssistantNotification
+            ? notification.toManualAutoListenQueueItem(spokenTitle)
+            : notification.toAutomaticQueueItem(
+                AssistantVoiceInteractionRules.shouldAutoListenAfterAutomaticNotification(
+                    config.audioMode,
+                    config.autoListenEnabled
+                ),
+                config.notificationTitlePlaybackEnabled,
+                spokenTitle
+            );
         if (item == null) {
             return;
         }
@@ -1611,7 +1644,11 @@ public final class AssistantVoiceRuntimeService extends Service {
         Log.d(TAG, "drainVoiceQueueIfPossible starting " + describeQueueItem(next));
         if (next.isListenOnly()) {
             activeQueueItem = next;
-            startRecognition(next.sessionId, "manual_notification_mic");
+            if (next.requiresListenValidation()) {
+                validateQueuedRecognitionAndMaybeStart(next.dedupKey());
+                return;
+            }
+            startRecognition(next.sessionId, resolveQueueRecognitionReason(next));
             return;
         }
         beginQueuedPlayback(next);
@@ -2761,6 +2798,16 @@ public final class AssistantVoiceRuntimeService extends Service {
         }
     }
 
+    private static String resolveQueueRecognitionReason(AssistantVoiceQueueItem item) {
+        if (item != null && item.manual) {
+            return "manual_notification_mic";
+        }
+        if (item != null && "manual_auto_listen".equals(item.notificationKind)) {
+            return "manual_auto_listen";
+        }
+        return "playback_completion";
+    }
+
     private void validateQueuedRecognitionAndMaybeStart(String requestId) {
         AssistantVoiceQueueItem queueItem = activeQueueItem;
         if (queueItem == null) {
@@ -2779,7 +2826,7 @@ public final class AssistantVoiceRuntimeService extends Service {
             AssistantVoiceEventLog.put(details, "requestId", safe(requestId));
             AssistantVoiceEventLog.put(details, "queueItem", describeQueueItem(queueItem));
             recordVoiceEvent("queued_recognition_validation_bypassed", details);
-            startRecognition(queueItem.sessionId, queueItem.manual ? "manual_notification_mic" : "playback_completion");
+            startRecognition(queueItem.sessionId, resolveQueueRecognitionReason(queueItem));
             return;
         }
         Integer expectedSeq = queueItem.sessionActivitySeq;
@@ -2792,7 +2839,9 @@ public final class AssistantVoiceRuntimeService extends Service {
         networkExecutor.execute(() -> {
             Integer currentSeq = fetchSessionActivityRevision(queueItem.sessionId);
             mainHandler.post(() -> {
-                if (!requestId.equals(pendingPlaybackDrainRequestId) && activeQueueItem != queueItem) {
+                boolean playbackDrainStillPending =
+                    !trim(requestId).isEmpty() && requestId.equals(pendingPlaybackDrainRequestId);
+                if (!playbackDrainStillPending && activeQueueItem != queueItem) {
                     Log.d(TAG, "validateQueuedRecognitionAndMaybeStart stale requestId=" + requestId);
                     return;
                 }
@@ -2816,10 +2865,7 @@ public final class AssistantVoiceRuntimeService extends Service {
                     return;
                 }
                 recordVoiceEvent("queued_recognition_validation_passed", resultDetails);
-                startRecognition(
-                    queueItem.sessionId,
-                    queueItem.manual ? "manual_notification_mic" : "playback_completion"
-                );
+                startRecognition(queueItem.sessionId, resolveQueueRecognitionReason(queueItem));
             });
         });
     }

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceSessionSocketProtocol.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceSessionSocketProtocol.java
@@ -96,6 +96,14 @@ final class AssistantVoiceSessionSocketProtocol {
                 + "\"messagePhases\":[\"final_answer\"]"
                 + "}";
         }
+        if (AssistantVoiceConfig.AUDIO_MODE_MANUAL.equals(normalizedAudioMode)) {
+            return "{"
+                + "\"serverMessageTypes\":[\"transcript_event\"],"
+                + "\"chatEventTypes\":[\"tool_call\",\"assistant_done\"],"
+                + "\"toolNames\":[\"voice_speak\",\"voice_ask\"],"
+                + "\"messagePhases\":[\"final_answer\"]"
+                + "}";
+        }
         return "{"
             + "\"serverMessageTypes\":[\"transcript_event\"],"
             + "\"chatEventTypes\":[\"tool_call\"],"

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceInteractionRulesTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceInteractionRulesTest.java
@@ -186,6 +186,127 @@ public final class AssistantVoiceInteractionRulesTest {
     }
 
     @Test
+    public void manualModeAutoListensOnlyAfterAssistantResponsesWhenEnabledAndIdle() {
+        AssistantVoicePromptEvent assistantResponse = new AssistantVoicePromptEvent(
+            "event-1",
+            "session-1",
+            "response-1",
+            "assistant_response",
+            "Answer"
+        );
+        AssistantVoicePromptEvent toolPrompt = new AssistantVoicePromptEvent(
+            "event-2",
+            "session-1",
+            "call-1",
+            "voice_ask",
+            "Question?"
+        );
+
+        assertTrue(AssistantVoiceInteractionRules.shouldAutoListenAfterManualAssistantMessage(
+            AssistantVoiceConfig.AUDIO_MODE_MANUAL,
+            true,
+            assistantResponse,
+            true
+        ));
+        assertFalse(AssistantVoiceInteractionRules.shouldAutoListenAfterManualAssistantMessage(
+            AssistantVoiceConfig.AUDIO_MODE_MANUAL,
+            false,
+            assistantResponse,
+            true
+        ));
+        assertFalse(AssistantVoiceInteractionRules.shouldAutoListenAfterManualAssistantMessage(
+            AssistantVoiceConfig.AUDIO_MODE_MANUAL,
+            true,
+            assistantResponse,
+            false
+        ));
+        assertFalse(AssistantVoiceInteractionRules.shouldAutoListenAfterManualAssistantMessage(
+            AssistantVoiceConfig.AUDIO_MODE_TOOL,
+            true,
+            assistantResponse,
+            true
+        ));
+        assertFalse(AssistantVoiceInteractionRules.shouldAutoListenAfterManualAssistantMessage(
+            AssistantVoiceConfig.AUDIO_MODE_MANUAL,
+            true,
+            toolPrompt,
+            true
+        ));
+    }
+
+    @Test
+    public void manualModeAutoListensForUnreadSessionAttentionNotificationsWhenEnabled() {
+        AssistantVoiceNotificationRecord responseNotification = new AssistantVoiceNotificationRecord(
+            "notif-response",
+            "session_attention",
+            "system",
+            "Latest reply",
+            "Answer",
+            "",
+            "session-1",
+            "Session 1",
+            "speak_then_listen",
+            "",
+            "event-1",
+            4
+        );
+        AssistantVoiceNotificationRecord readResponseNotification = new AssistantVoiceNotificationRecord(
+            "notif-read",
+            "session_attention",
+            "system",
+            "Latest reply",
+            "Answer",
+            "2026-04-06T12:00:00.000Z",
+            "session-1",
+            "Session 1",
+            "speak_then_listen",
+            "",
+            "event-2",
+            5
+        );
+        AssistantVoiceNotificationRecord sessionlessNotification = new AssistantVoiceNotificationRecord(
+            "notif-sessionless",
+            "session_attention",
+            "system",
+            "Latest reply",
+            "Answer",
+            "",
+            "",
+            "",
+            "speak_then_listen",
+            "",
+            "event-3",
+            null
+        );
+
+        assertTrue(AssistantVoiceInteractionRules.shouldAutoListenAfterManualAssistantNotification(
+            AssistantVoiceConfig.AUDIO_MODE_MANUAL,
+            true,
+            responseNotification
+        ));
+        assertFalse(AssistantVoiceInteractionRules.shouldAutoListenAfterManualAssistantNotification(
+            AssistantVoiceConfig.AUDIO_MODE_MANUAL,
+            false,
+            responseNotification
+        ));
+        assertFalse(AssistantVoiceInteractionRules.shouldAutoListenAfterManualAssistantNotification(
+            AssistantVoiceConfig.AUDIO_MODE_TOOL,
+            true,
+            responseNotification
+        ));
+        assertFalse(AssistantVoiceInteractionRules.shouldAutoListenAfterManualAssistantNotification(
+            AssistantVoiceConfig.AUDIO_MODE_MANUAL,
+            true,
+            readResponseNotification
+        ));
+        assertFalse(AssistantVoiceInteractionRules.shouldAutoListenAfterManualAssistantNotification(
+            AssistantVoiceConfig.AUDIO_MODE_MANUAL,
+            true,
+            sessionlessNotification
+        ));
+    }
+
+    @Test
     public void autoplaysOnlyUnreadNotificationsThatMatchTheCurrentAudioMode() {
         AssistantVoiceNotificationRecord responseNotification = new AssistantVoiceNotificationRecord(
             "notif-response",

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceQueueItemTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceQueueItemTest.java
@@ -118,6 +118,41 @@ public final class AssistantVoiceQueueItemTest {
     }
 
     @Test
+    public void fromManualAutoListenPromptBuildsListenOnlyQueueItemWithoutSpeech() {
+        AssistantVoicePromptEvent prompt = new AssistantVoicePromptEvent(
+            "event-7",
+            "session-7",
+            "response-7",
+            "assistant_response",
+            "Answer"
+        );
+
+        AssistantVoiceQueueItem item = AssistantVoiceQueueItem.fromManualAutoListenPrompt(
+            prompt,
+            "Session 7"
+        );
+
+        assertNotNull(item);
+        assertEquals("manual_auto_listen", item.notificationKind);
+        assertEquals("system", item.source);
+        assertEquals("response-7", item.dedupKey());
+        assertEquals("session-7", item.sessionId);
+        assertEquals("", item.spokenText);
+        assertEquals("listen_only", item.executionMode);
+        assertTrue(item.isListenOnly());
+        assertTrue(item.requiresSession());
+        assertTrue(!item.requiresListenValidation());
+    }
+
+    @Test
+    public void fromManualAutoListenPromptIgnoresNonAssistantPrompts() {
+        assertNull(AssistantVoiceQueueItem.fromManualAutoListenPrompt(
+            new AssistantVoicePromptEvent("event-8", "session-8", "call-8", "voice_ask", "Question?"),
+            "Session 8"
+        ));
+    }
+
+    @Test
     public void manualNotificationMicSkipsPlaybackAndStartsListeningImmediately() {
         AssistantVoiceNotificationRecord notification = new AssistantVoiceNotificationRecord(
             "notif-1",
@@ -140,6 +175,38 @@ public final class AssistantVoiceQueueItemTest {
         assertEquals("listen_only", item.executionMode);
         assertEquals("", item.spokenText);
         assertTrue(item.isListenOnly());
+        assertTrue(!item.requiresListenValidation());
+    }
+
+    @Test
+    public void manualAutoListenNotificationSkipsPlaybackAndRequiresValidationWhenSequenced() {
+        AssistantVoiceNotificationRecord notification = new AssistantVoiceNotificationRecord(
+            "notif-auto",
+            "session_attention",
+            "system",
+            "Latest assistant reply",
+            "Reply body",
+            "",
+            "session-auto",
+            "Session Auto",
+            "speak_then_listen",
+            "Reply body",
+            "response-auto",
+            Integer.valueOf(9)
+        );
+
+        AssistantVoiceQueueItem item = notification.toManualAutoListenQueueItem("Session Auto");
+
+        assertNotNull(item);
+        assertEquals("session_attention", item.notificationKind);
+        assertEquals("system", item.source);
+        assertEquals("response-auto", item.dedupKey());
+        assertEquals("session-auto", item.sessionId);
+        assertEquals("", item.spokenText);
+        assertEquals("listen_only", item.executionMode);
+        assertTrue(item.isListenOnly());
+        assertTrue(item.requiresSession());
+        assertTrue(item.requiresListenValidation());
     }
 
     @Test

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRuntimeServiceTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRuntimeServiceTest.java
@@ -35,6 +35,100 @@ import static org.junit.Assert.assertFalse;
 public final class AssistantVoiceRuntimeServiceTest {
     @Test
     @Config(sdk = Build.VERSION_CODES.N)
+    public void manualAutoListenQueueItemsDedupAcrossPromptAndNotificationSources() {
+        AssistantVoiceQueueItem promptItem = AssistantVoiceQueueItem.fromManualAutoListenPrompt(
+            new AssistantVoicePromptEvent(
+                "event-prompt",
+                "session-1",
+                "response-prompt",
+                "assistant_response",
+                "Answer"
+            ),
+            "Session 1"
+        );
+        AssistantVoiceQueueItem notificationItem = new AssistantVoiceNotificationRecord(
+            "notif-1",
+            "session_attention",
+            "system",
+            "Latest assistant reply",
+            "Answer",
+            "",
+            "session-1",
+            "Session 1",
+            "speak_then_listen",
+            "Answer",
+            "different-source-event",
+            Integer.valueOf(7)
+        ).toManualAutoListenQueueItem("Session 1");
+        AssistantVoiceQueueItem otherSessionItem = AssistantVoiceQueueItem.fromManualAutoListenPrompt(
+            new AssistantVoicePromptEvent(
+                "event-other",
+                "session-2",
+                "response-other",
+                "assistant_response",
+                "Answer"
+            ),
+            "Session 2"
+        );
+        AssistantVoiceQueueItem manualMicItem = new AssistantVoiceNotificationRecord(
+            "notif-2",
+            "session_attention",
+            "system",
+            "Latest assistant reply",
+            "Answer",
+            "",
+            "session-1",
+            "Session 1",
+            "speak_then_listen",
+            "Answer",
+            "response-2",
+            Integer.valueOf(8)
+        ).toManualMicQueueItem();
+
+        assertTrue(AssistantVoiceRuntimeService.shouldDedupManualAutoListenQueueItem(
+            notificationItem,
+            promptItem
+        ));
+        assertTrue(AssistantVoiceRuntimeService.shouldDedupManualAutoListenQueueItem(
+            promptItem,
+            notificationItem
+        ));
+        assertFalse(AssistantVoiceRuntimeService.shouldDedupManualAutoListenQueueItem(
+            notificationItem,
+            otherSessionItem
+        ));
+        assertFalse(AssistantVoiceRuntimeService.shouldDedupManualAutoListenQueueItem(
+            notificationItem,
+            manualMicItem
+        ));
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.N)
+    public void notificationManualAutoListenUsesManualAutoListenRecognitionReason() {
+        AssistantVoiceQueueItem notificationItem = new AssistantVoiceNotificationRecord(
+            "notif-1",
+            "session_attention",
+            "system",
+            "Latest assistant reply",
+            "Answer",
+            "",
+            "session-1",
+            "Session 1",
+            "speak_then_listen",
+            "Answer",
+            "response-1",
+            Integer.valueOf(7)
+        ).toManualAutoListenQueueItem("Session 1");
+
+        assertEquals(
+            "manual_auto_listen",
+            AssistantVoiceRuntimeService.resolveQueueRecognitionReason(notificationItem)
+        );
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.N)
     public void playTextIntentCarriesManualPlaybackPayload() {
         Context context = RuntimeEnvironment.getApplication();
 

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceSessionSocketProtocolTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceSessionSocketProtocolTest.java
@@ -37,6 +37,21 @@ public final class AssistantVoiceSessionSocketProtocolTest {
     }
 
     @Test
+    public void buildManualSubscribeMessageIncludesVoiceToolsAndFinalResponses() {
+        String payload = AssistantVoiceSessionSocketProtocol.buildSubscribeMessage(
+            "session-123",
+            AssistantVoiceConfig.AUDIO_MODE_MANUAL
+        );
+
+        assertTrue(payload.contains("\"type\":\"subscribe\""));
+        assertTrue(payload.contains("\"sessionId\":\"session-123\""));
+        assertTrue(payload.contains("\"serverMessageTypes\":[\"transcript_event\"]"));
+        assertTrue(payload.contains("\"chatEventTypes\":[\"tool_call\",\"assistant_done\"]"));
+        assertTrue(payload.contains("\"toolNames\":[\"voice_speak\",\"voice_ask\"]"));
+        assertTrue(payload.contains("\"messagePhases\":[\"final_answer\"]"));
+    }
+
+    @Test
     public void buildUnsubscribeMessageIncludesSessionId() {
         String payload = AssistantVoiceSessionSocketProtocol.buildUnsubscribeMessage("session-123");
 


### PR DESCRIPTION
## Summary
- support Auto Listen in Android Manual native voice mode after final assistant messages
- preserve Manual mode behavior that skips assistant TTS playback
- deduplicate manual auto-listen triggers while preserving existing Tool and Response behavior

## Validation
- PASS: npm run build
- PASS: npm run android:test -w @assistant/mobile-web
- PASS: npm run android:build -w @assistant/mobile-web
- PASS: manual Android feature verification by user
- NOTE: root npm test currently fails on this branch and on main due existing broad-suite Vitest worker OOM; on host pc, main also reproduces existing bangCommand timeout failures under /bin/sh -> dash
