### PR TITLE
Add virtual pinned list view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Added a virtual Pinned list view for list items tagged `pinned`, including first-class list picker placement, source-item actions, tag-chip rendering, and pin/unpin menu icon states. ([#111](https://github.com/kcosr/assistant/pull/111))
 - Added an Electron desktop package with native backend proxying, WebSocket forwarding, variant-aware backend defaults, and packaged-app asset routing. ([#108](https://github.com/kcosr/assistant/pull/108))
 - Added native Android voice replay for assistant turns and text/markdown attachments, using the existing local voice queue with front-of-queue, non-interrupting playback. ([#106](https://github.com/kcosr/assistant/pull/106))
 - Added one-shot Pi SDK session wake-ups to the scheduled-sessions plugin, including durable wake-up storage, current-session create/update/cancel-by-id tools, current-session tool listing, multiple wake-ups per session with an active wake-up cap, busy-session queue delivery, and panel visibility/cancel controls. ([#105](https://github.com/kcosr/assistant/pull/105))

--- a/packages/plugins/official/lists/README.md
+++ b/packages/plugins/official/lists/README.md
@@ -6,6 +6,7 @@ List management with a dedicated lists panel, list item CRUD, tags, and browser 
 
 - [Overview](#overview)
 - [Focus View](#focus-view)
+- [Pinned View](#pinned-view)
 - [AQL Search](#aql-search)
 - [Source files](#source-files)
 - [Web UI Architecture](#web-ui-architecture)
@@ -43,12 +44,13 @@ operations.
 - Cmd/Ctrl+C/X/V support copy/cut/paste of selected list items between lists; external paste
   uses the same plain-text item block.
 - The lists dropdown includes a quick-add (+) action to add an item to a list without switching views.
-- The lists dropdown includes a virtual Focus view for ordering and working through items from
-  multiple source lists.
+- The lists dropdown includes virtual Focus and Pinned views for working through items from multiple
+  source lists.
 - Browser mode supports arrow-key grid navigation with Enter to open a list; Escape returns to the
   browser view from list mode.
 - Press **p** in browser mode to toggle pinned lists, or in list view to toggle pinned list items.
-  Pinned entries show a pin icon and appear in the command palette via `/pinned`.
+  Pinned items show a distinct pinned chip in the tag area and appear in the command palette via
+  `/pinned`.
 - Favorite lists from the add/edit dialog; favorites show a heart icon and appear in the command
   palette via `/favorites`.
 - Column headers stick while scrolling list items.
@@ -78,6 +80,20 @@ or deleting the source item still uses the source list item.
 - Dragging and keyboard reordering use the normal list UI. Copying Focus items to a real list copies
   from each item's source list.
 - Focus updates use `focus-get`, `focus-items`, `focus-add`, `focus-update`, and `focus-remove`.
+
+## Pinned View
+
+Pinned is a virtual list with the fixed id `__pinned__`. It is derived from source items tagged
+`pinned`; it does not store an independent item order.
+
+- Removing an item from Pinned removes the `pinned` tag from the source item and does not delete the
+  source item.
+- Editing, completing, touching, moving, copying, or source-deleting a Pinned row still operates on
+  the underlying source item.
+- Adding an item while Pinned is open opens a source-list dropdown, then adds the new item to that
+  list with the `pinned` tag.
+- Pinned read operations use `pinned-get` and `pinned-items`. Pinning and unpinning use the normal
+  item tag operations.
 
 ## AQL Search
 
@@ -200,8 +216,8 @@ The server broadcasts panel updates to keep all lists panels in sync:
     - `itemId` (optional)
     - `refresh` (optional)
 
-The lists panel uses these updates to refresh list metadata, invalidate previews, or
-apply incremental item updates.
+The lists panel uses these updates to refresh list metadata, invalidate previews, apply incremental
+item updates, or refresh virtual views when source item tags/focus membership change.
 
 ## Panel Context
 

--- a/packages/plugins/official/lists/manifest.json
+++ b/packages/plugins/official/lists/manifest.json
@@ -119,6 +119,34 @@
       "capabilities": ["lists.read"]
     },
     {
+      "id": "pinned-get",
+      "summary": "Get the virtual Pinned list.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "instance_id": {
+            "type": "string",
+            "description": "Instance id (defaults to \"default\")."
+          }
+        }
+      },
+      "capabilities": ["lists.read"]
+    },
+    {
+      "id": "pinned-items",
+      "summary": "List items in the virtual Pinned list.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "instance_id": {
+            "type": "string",
+            "description": "Instance id (defaults to \"default\")."
+          }
+        }
+      },
+      "capabilities": ["lists.read"]
+    },
+    {
       "id": "focus-add",
       "summary": "Add an existing item to Focus.",
       "inputSchema": {

--- a/packages/plugins/official/lists/server/index.test.ts
+++ b/packages/plugins/official/lists/server/index.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { ToolContext } from '../../../../agent-server/src/tools';
 import manifestJson from '../manifest.json';
 import { createPlugin } from './index';
-import type { FocusListItem, ListDefinition, ListItem } from './types';
+import type { FocusListItem, ListDefinition, ListItem, PinnedListItem } from './types';
 
 function createTempDataDir(): string {
   return path.join(os.tmpdir(), `lists-plugin-test-${Date.now()}-${Math.random().toString(16)}`);
@@ -528,6 +528,28 @@ describe('lists plugin operations', () => {
       panelId: string;
     };
     expect(showResult).toEqual({ ok: true, panelId: 'lists-1' });
+
+    await ops['item-tags-add']({ listId: 'home', id: homeItem.id, tags: ['pinned'] }, ctx);
+    const pinnedList = (await ops['pinned-get']({}, ctx)) as ListDefinition;
+    expect(pinnedList).toMatchObject({
+      id: '__pinned__',
+      name: 'Pinned',
+    });
+    const pinnedItems = (await ops['pinned-items']({}, ctx)) as PinnedListItem[];
+    expect(pinnedItems).toHaveLength(1);
+    expect(pinnedItems[0]).toMatchObject({
+      id: homeItem.id,
+      listId: 'home',
+      sourceListId: 'home',
+      sourceListName: 'Home',
+      tags: expect.arrayContaining(['pinned']),
+    });
+
+    const pinnedShowResult = (await ops.show({ id: '__pinned__', panelId: 'lists-1' }, ctx)) as {
+      ok: true;
+      panelId: string;
+    };
+    expect(pinnedShowResult).toEqual({ ok: true, panelId: 'lists-1' });
     expect(broadcastToAll).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'panel_event',

--- a/packages/plugins/official/lists/server/index.ts
+++ b/packages/plugins/official/lists/server/index.ts
@@ -25,6 +25,7 @@ type PluginFactoryArgs = { manifest: CombinedPluginManifest };
 
 const LIST_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const FOCUS_LIST_ID = '__focus__';
+const PINNED_LIST_ID = '__pinned__';
 
 function asObject(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -535,6 +536,16 @@ export function createPlugin(_options: PluginFactoryArgs): PluginModule {
         const { store: listsStore } = await resolveStore(parsed);
         return listsStore.listFocusItems();
       },
+      'pinned-get': async (args): Promise<unknown> => {
+        const parsed = asObject(args);
+        const { store: listsStore } = await resolveStore(parsed);
+        return listsStore.getPinnedList();
+      },
+      'pinned-items': async (args): Promise<unknown> => {
+        const parsed = asObject(args);
+        const { store: listsStore } = await resolveStore(parsed);
+        return listsStore.listPinnedItems();
+      },
       'focus-add': async (args, ctx): Promise<unknown> => {
         const parsed = asObject(args);
         const { instanceId, store: listsStore } = await resolveStore(parsed);
@@ -578,7 +589,7 @@ export function createPlugin(_options: PluginFactoryArgs): PluginModule {
         const { instanceId, store: listsStore } = await resolveStore(parsed);
         const id = requireNonEmptyString(parsed['id'], 'id');
         const panelId = requireNonEmptyString(parsed['panelId'], 'panelId');
-        if (id !== FOCUS_LIST_ID) {
+        if (id !== FOCUS_LIST_ID && id !== PINNED_LIST_ID) {
           const list = await listsStore.getList(id);
           if (!list) {
             throw new ToolError('list_not_found', `List not found: ${id}`);

--- a/packages/plugins/official/lists/server/store.test.ts
+++ b/packages/plugins/official/lists/server/store.test.ts
@@ -442,6 +442,44 @@ describe('ListsStore (plugin)', () => {
     await expect(store.removeFocusItem('missing-item')).resolves.toBeUndefined();
   });
 
+  it('derives the virtual pinned list from pinned item tags', async () => {
+    const filePath = createTempFilePath();
+    const store = createStore(filePath);
+
+    vi.setSystemTime(new Date('2024-05-01T00:00:00.000Z'));
+    await store.createList({ id: 'work', name: 'Work' });
+    await store.createList({ id: 'home', name: 'Home' });
+
+    const workItem = await store.addItem({
+      listId: 'work',
+      title: 'Ship feature',
+      tags: ['pinned', 'urgent'],
+    });
+    const homeItem = await store.addItem({
+      listId: 'home',
+      title: 'Pay bills',
+      tags: ['PINNED'],
+    });
+    await store.addItem({ listId: 'home', title: 'Clean kitchen' });
+
+    const pinnedList = await store.getPinnedList();
+    expect(pinnedList).toMatchObject({
+      id: '__pinned__',
+      name: 'Pinned',
+      tags: [],
+      defaultTags: [],
+      savedQueries: [],
+    });
+
+    const pinnedItems = await store.listPinnedItems();
+    expect(pinnedItems.map((item) => item.id)).toEqual([workItem.id, homeItem.id]);
+    expect(pinnedItems.map((item) => item.position)).toEqual([0, 1]);
+    expect(pinnedItems.map((item) => item.sourceListName)).toEqual(['Work', 'Home']);
+
+    await store.updateItem({ id: workItem.id, tags: ['urgent'] });
+    expect((await store.listPinnedItems()).map((item) => item.id)).toEqual([homeItem.id]);
+  });
+
   it('touches items without changing updatedAt', async () => {
     const filePath = createTempFilePath();
     const store = createStore(filePath);

--- a/packages/plugins/official/lists/server/store.ts
+++ b/packages/plugins/official/lists/server/store.ts
@@ -12,10 +12,13 @@ import type {
   ListItem,
   ListsData,
   ListSavedQuery,
+  PinnedListItem,
 } from './types';
 import { repositionItem, reflowPositions } from './positions';
 
 const LIST_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const PINNED_LIST_ID = '__pinned__';
+const PINNED_TAG = 'pinned';
 
 export type ItemSortOrder = 'position' | 'newest' | 'oldest';
 type TagMatchMode = 'all' | 'any';
@@ -43,6 +46,10 @@ export class ListsStore {
       ...(filterTags ? { filterTags } : {}),
       ...(tagMatch ? { tagMatch } : {}),
     });
+  }
+
+  private hasPinnedTag(tags: string[] | undefined): boolean {
+    return Array.isArray(tags) && tags.some((tag) => tag.trim().toLowerCase() === PINNED_TAG);
   }
 
   private async ensureLoaded(): Promise<void> {
@@ -963,6 +970,64 @@ export class ListsStore {
     this.data.focusEntries = nextEntries;
     this.assignFocusPositions();
     await this.save();
+  }
+
+  async getPinnedList(): Promise<ListDefinition> {
+    await this.ensureLoaded();
+    const pinnedItems = this.data.items.filter((item) => this.hasPinnedTag(item.tags));
+    const now = new Date().toISOString();
+    const updatedAt =
+      pinnedItems.reduce((latest, item) => {
+        const latestMs = Date.parse(latest);
+        const itemMs = Date.parse(item.updatedAt);
+        return Number.isFinite(itemMs) && (!Number.isFinite(latestMs) || itemMs > latestMs)
+          ? item.updatedAt
+          : latest;
+      }, '') || now;
+    const createdAt =
+      pinnedItems.reduce((earliest, item) => {
+        const earliestMs = Date.parse(earliest);
+        const itemMs = Date.parse(item.addedAt);
+        return Number.isFinite(itemMs) && (!Number.isFinite(earliestMs) || itemMs < earliestMs)
+          ? item.addedAt
+          : earliest;
+      }, '') || now;
+    return {
+      id: PINNED_LIST_ID,
+      name: 'Pinned',
+      description: 'Pinned items from multiple lists.',
+      tags: [],
+      defaultTags: [],
+      savedQueries: [],
+      createdAt,
+      updatedAt,
+    };
+  }
+
+  async listPinnedItems(): Promise<PinnedListItem[]> {
+    await this.ensureLoaded();
+    const listById = new Map(this.data.lists.map((list) => [list.id, list]));
+    const result: PinnedListItem[] = [];
+
+    for (const item of this.data.items) {
+      if (!this.hasPinnedTag(item.tags)) {
+        continue;
+      }
+      const list = listById.get(item.listId);
+      if (!list) {
+        continue;
+      }
+      result.push({
+        ...item,
+        tags: [...(item.tags ?? [])],
+        ...(item.customFields ? { customFields: { ...item.customFields } } : {}),
+        position: result.length,
+        sourceListId: item.listId,
+        sourceListName: list.name,
+      });
+    }
+
+    return result;
   }
 
   // Query operations

--- a/packages/plugins/official/lists/server/types.ts
+++ b/packages/plugins/official/lists/server/types.ts
@@ -57,6 +57,11 @@ export interface FocusListItem extends ListItem {
   focusEntryId: string;
 }
 
+export interface PinnedListItem extends ListItem {
+  sourceListId: string;
+  sourceListName: string;
+}
+
 export interface ListsData {
   lists: ListDefinition[];
   items: ListItem[];

--- a/packages/plugins/official/lists/web/index.ts
+++ b/packages/plugins/official/lists/web/index.ts
@@ -265,9 +265,11 @@ const USER_UPDATE_TIMEOUT_MS = 5000;
 const DEFAULT_INSTANCE_ID = 'default';
 const LISTS_BROWSER_SORT_MODE_KEY = 'aiAssistantListsBrowserSortMode';
 const FOCUS_LIST_ID = '__focus__';
+const PINNED_LIST_ID = '__pinned__';
 const FOCUS_DEFAULT_LIST_STORAGE_KEY = 'aiAssistantFocusDefaultListId';
 
 type ViewMode = 'browser' | 'list';
+type ListViewKind = 'list' | 'focus' | 'pinned';
 
 type Instance = {
   id: string;
@@ -286,7 +288,7 @@ type ListSummary = {
   updatedAt?: string;
   instanceId: string;
   instanceLabel?: string;
-  viewKind?: 'list' | 'focus';
+  viewKind?: ListViewKind;
 };
 
 type NoteSummary = {
@@ -367,8 +369,29 @@ function buildFocusSummary(instanceId: string, instanceLabel?: string): ListSumm
   };
 }
 
+function buildPinnedSummary(instanceId: string, instanceLabel?: string): ListSummary {
+  return {
+    id: PINNED_LIST_ID,
+    name: 'Pinned',
+    description: 'Pinned items from multiple lists.',
+    tags: [],
+    defaultTags: [],
+    instanceId,
+    ...(instanceLabel ? { instanceLabel } : {}),
+    viewKind: 'pinned',
+  };
+}
+
 function isFocusListId(listId: string | null | undefined): boolean {
   return listId === FOCUS_LIST_ID;
+}
+
+function isPinnedListId(listId: string | null | undefined): boolean {
+  return listId === PINNED_LIST_ID;
+}
+
+function isVirtualListId(listId: string | null | undefined): boolean {
+  return isFocusListId(listId) || isPinnedListId(listId);
 }
 
 function parseInstance(value: unknown): Instance | null {
@@ -595,14 +618,21 @@ function renderListTags(tags: string[] | undefined): HTMLElement | null {
   wrapper.className = 'collection-tags';
   for (const rawTag of tags) {
     const tag = rawTag.trim();
-    if (!tag || isPinnedTag(tag)) {
+    if (!tag) {
       continue;
     }
     const pill = document.createElement('span');
-    pill.className = 'collection-tag';
-    pill.textContent = rawTag;
+    if (isPinnedTag(tag)) {
+      pill.className = 'collection-tag collection-tag-pinned';
+      pill.innerHTML = `${ICONS.pin}<span>Pinned</span>`;
+      pill.title = 'Pinned';
+      pill.setAttribute('aria-label', 'Pinned');
+    } else {
+      pill.className = 'collection-tag';
+      pill.textContent = rawTag;
+      applyTagColorToElement(pill, tag);
+    }
     pill.dataset['tag'] = normalizeTag(tag);
-    applyTagColorToElement(pill, tag);
     wrapper.appendChild(pill);
   }
   return wrapper.firstChild ? wrapper : null;
@@ -670,11 +700,13 @@ async function fetchListPreview(
 ): Promise<CollectionPreviewCacheEntry | null> {
   const rawItems = isFocusListId(listId)
     ? await callInstanceOperation<unknown>('focus-items', {})
-    : await callInstanceOperation<unknown>('items-list', {
-        listId,
-        limit: 50,
-        sort: 'position',
-      });
+    : isPinnedListId(listId)
+      ? await callInstanceOperation<unknown>('pinned-items', {})
+      : await callInstanceOperation<unknown>('items-list', {
+          listId,
+          limit: 50,
+          sort: 'position',
+        });
   const items = buildListPreviewItems(parseListItems(rawItems));
   if (items.length === 0) {
     return null;
@@ -1299,7 +1331,9 @@ if (!registry || typeof registry.registerPanel !== 'function') {
             updatedAt: list.updatedAt,
             instanceId: list.instanceId,
             instanceLabel: list.instanceLabel ?? getInstanceLabel(list.instanceId),
-            ...(list.viewKind === 'focus' ? { specialKind: 'focus' as const } : {}),
+            ...(list.viewKind === 'focus' || list.viewKind === 'pinned'
+              ? { specialKind: list.viewKind }
+              : {}),
           }));
 
       const emitGlobalTags = (): void => {
@@ -1363,11 +1397,11 @@ if (!registry || typeof registry.registerPanel !== 'function') {
           ? { type: 'list', id: activeListId, instanceId: activeListInstanceId }
           : null;
 
-      const decorateFocusCollectionItem = (
+      const decorateVirtualCollectionItem = (
         itemEl: HTMLElement,
         item: CollectionItemSummary,
       ): void => {
-        if (item.specialKind !== 'focus') {
+        if (item.specialKind !== 'focus' && item.specialKind !== 'pinned') {
           return;
         }
         const labelEl = itemEl.querySelector<HTMLElement>('.collection-search-dropdown-item-label');
@@ -1375,11 +1409,16 @@ if (!registry || typeof registry.registerPanel !== 'function') {
           return;
         }
         const icon = document.createElement('span');
-        icon.className = 'collection-focus-icon';
-        icon.innerHTML = ICONS.eye;
+        icon.className =
+          item.specialKind === 'focus' ? 'collection-focus-icon' : 'collection-pinned-icon';
+        icon.innerHTML = item.specialKind === 'focus' ? ICONS.eye : ICONS.pin;
         icon.setAttribute('aria-hidden', 'true');
         labelEl.insertAdjacentElement('beforebegin', icon);
-        itemEl.classList.add('collection-search-dropdown-item--focus');
+        itemEl.classList.add(
+          item.specialKind === 'focus'
+            ? 'collection-search-dropdown-item--focus'
+            : 'collection-search-dropdown-item--pinned',
+        );
       };
 
       const openReference = (reference: ListItemReference): void => {
@@ -1718,7 +1757,10 @@ if (!registry || typeof registry.registerPanel !== 'function') {
         if (!dropdownTriggerText) {
           return;
         }
-        dropdownTriggerText.classList.remove('collection-search-dropdown-trigger-text--focus');
+        dropdownTriggerText.classList.remove(
+          'collection-search-dropdown-trigger-text--focus',
+          'collection-search-dropdown-trigger-text--pinned',
+        );
         if (!reference) {
           dropdownTriggerText.textContent = 'Select a list...';
           chromeController?.scheduleLayoutCheck();
@@ -1736,18 +1778,23 @@ if (!registry || typeof registry.registerPanel !== 'function') {
         } else {
           dropdownTriggerText.textContent = list?.name ?? 'Select a list...';
         }
-        if (list?.viewKind === 'focus') {
-          const label = dropdownTriggerText.textContent ?? 'Focus';
+        if (list?.viewKind === 'focus' || list?.viewKind === 'pinned') {
+          const label = dropdownTriggerText.textContent ?? list.name;
           dropdownTriggerText.textContent = '';
           const icon = document.createElement('span');
-          icon.className = 'collection-focus-icon';
-          icon.innerHTML = ICONS.eye;
+          icon.className =
+            list.viewKind === 'focus' ? 'collection-focus-icon' : 'collection-pinned-icon';
+          icon.innerHTML = list.viewKind === 'focus' ? ICONS.eye : ICONS.pin;
           icon.setAttribute('aria-hidden', 'true');
           const labelEl = document.createElement('span');
           labelEl.textContent = label;
           dropdownTriggerText.appendChild(icon);
           dropdownTriggerText.appendChild(labelEl);
-          dropdownTriggerText.classList.add('collection-search-dropdown-trigger-text--focus');
+          dropdownTriggerText.classList.add(
+            list.viewKind === 'focus'
+              ? 'collection-search-dropdown-trigger-text--focus'
+              : 'collection-search-dropdown-trigger-text--pinned',
+          );
         }
         chromeController?.scheduleLayoutCheck();
       };
@@ -2133,7 +2180,9 @@ if (!registry || typeof registry.registerPanel !== 'function') {
               }
             })();
           return sortListSummariesForMoveTargets(
-            availableLists.filter((list) => list.instanceId === instanceId && !isFocusListId(list.id)),
+            availableLists.filter(
+              (list) => list.instanceId === instanceId && !isVirtualListId(list.id),
+            ),
             sortMode,
           )
             .map((list) => ({
@@ -2147,7 +2196,7 @@ if (!registry || typeof registry.registerPanel !== 'function') {
         resolveAddItemTarget: async () => {
           const instanceId = activeListInstanceId ?? activeInstanceId;
           const candidates = availableLists.filter(
-            (list) => list.instanceId === instanceId && !isFocusListId(list.id),
+            (list) => list.instanceId === instanceId && !isVirtualListId(list.id),
           );
           if (candidates.length === 0) {
             services.setStatus('Create a list before adding focus items');
@@ -2361,8 +2410,8 @@ if (!registry || typeof registry.registerPanel !== 'function') {
             const targetInstanceId = instanceId ?? activeListInstanceId ?? activeInstanceId;
             const raw = await callInstanceOperation<unknown>(
               targetInstanceId,
-              isFocusListId(listId) ? 'focus-get' : 'get',
-              isFocusListId(listId) ? {} : { id: listId },
+              isFocusListId(listId) ? 'focus-get' : isPinnedListId(listId) ? 'pinned-get' : 'get',
+              isVirtualListId(listId) ? {} : { id: listId },
             );
             const list = parseListSummary(raw, targetInstanceId);
             if (!list) {
@@ -2390,8 +2439,8 @@ if (!registry || typeof registry.registerPanel !== 'function') {
             return list?.id ?? null;
           },
           updateList: async (listId, payload) => {
-            if (isFocusListId(listId)) {
-              services.setStatus('Focus metadata is managed by the app');
+            if (isVirtualListId(listId)) {
+              services.setStatus('Virtual list metadata is managed by the app');
               return false;
             }
             const sourceInstanceId = payload.sourceInstanceId ?? activeListInstanceId ?? activeInstanceId;
@@ -2416,8 +2465,8 @@ if (!registry || typeof registry.registerPanel !== 'function') {
             return true;
           },
           deleteList: async (listId) => {
-            if (isFocusListId(listId)) {
-              services.setStatus('Focus cannot be deleted');
+            if (isVirtualListId(listId)) {
+              services.setStatus('Virtual lists cannot be deleted');
               return false;
             }
             const targetInstanceId = activeListInstanceId ?? activeInstanceId;
@@ -2503,7 +2552,7 @@ if (!registry || typeof registry.registerPanel !== 'function') {
           const instanceId = item.instanceId ?? activeInstanceId;
           void selectList(item.id, instanceId, { focus: false });
         },
-        renderItemContent: decorateFocusCollectionItem,
+        renderItemContent: decorateVirtualCollectionItem,
         renderItemActions: (actionsEl, item) => {
           if (item.type !== 'list') {
             return;
@@ -3310,7 +3359,11 @@ if (!registry || typeof registry.registerPanel !== 'function') {
                 ...list,
                 instanceLabel,
               }));
-              return [buildFocusSummary(instanceId, instanceLabel), ...lists];
+              return [
+                buildFocusSummary(instanceId, instanceLabel),
+                buildPinnedSummary(instanceId, instanceLabel),
+                ...lists,
+              ];
             }),
           );
           if (currentToken !== refreshToken) {
@@ -3372,10 +3425,11 @@ if (!registry || typeof registry.registerPanel !== 'function') {
             : null;
         try {
           const focusView = isFocusListId(listId);
+          const pinnedView = isPinnedListId(listId);
           const rawList = await callInstanceOperation<unknown>(
             instanceId,
-            focusView ? 'focus-get' : 'get',
-            focusView ? {} : { id: listId },
+            focusView ? 'focus-get' : pinnedView ? 'pinned-get' : 'get',
+            focusView || pinnedView ? {} : { id: listId },
           );
           const list = parseListSummary(rawList, instanceId);
           if (!list) {
@@ -3383,16 +3437,18 @@ if (!registry || typeof registry.registerPanel !== 'function') {
           }
           const rawItems = await callInstanceOperation<unknown>(
             instanceId,
-            focusView ? 'focus-items' : 'items-list',
+            focusView ? 'focus-items' : pinnedView ? 'pinned-items' : 'items-list',
             focusView
               ? {}
-              : {
-                  listId,
-                  limit: 0,
-                  sort: 'position',
-                },
+              : pinnedView
+                ? {}
+                : {
+                    listId,
+                    limit: 0,
+                    sort: 'position',
+                  },
           );
-          const rawSavedQueries = focusView
+          const rawSavedQueries = focusView || pinnedView
             ? []
             : await callInstanceOperation<unknown>(instanceId, 'aql-query-list', { listId });
           if (currentToken !== loadToken) {
@@ -3441,7 +3497,7 @@ if (!registry || typeof registry.registerPanel !== 'function') {
             customFields: list.customFields,
             savedQueries,
             items,
-            viewKind: focusView ? 'focus' : 'list',
+            viewKind: focusView ? 'focus' : pinnedView ? 'pinned' : 'list',
           };
           activeListId = list.id;
           activeListInstanceId = instanceId;
@@ -3630,7 +3686,7 @@ if (!registry || typeof registry.registerPanel !== 'function') {
 
         if (action === 'focus_updated') {
           if (
-            activeListId === FOCUS_LIST_ID &&
+            isVirtualListId(activeListId) &&
             activeListInstanceId === instanceId &&
             mode === 'list'
           ) {

--- a/packages/plugins/official/lists/web/styles.css
+++ b/packages/plugins/official/lists/web/styles.css
@@ -500,12 +500,15 @@
   white-space: nowrap;
 }
 
-.collection-search-dropdown-item--focus {
+.collection-search-dropdown-item--focus,
+.collection-search-dropdown-item--pinned {
   color: var(--color-accent-primary);
 }
 
 .collection-focus-icon,
+.collection-pinned-icon,
 .collection-browser-item-focus,
+.collection-browser-item-pin,
 .collection-search-dropdown-trigger-text--focus .icon {
   display: inline-flex;
   align-items: center;
@@ -1916,6 +1919,22 @@
   cursor: default;
 }
 
+.collection-tag-pinned,
+.collection-browser-item-tag-pinned {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--color-accent-primary);
+  background-color: color-mix(in srgb, var(--color-accent-primary) 12%, transparent);
+  border-color: color-mix(in srgb, var(--color-accent-primary) 38%, transparent);
+}
+
+.collection-tag-pinned .icon,
+.collection-browser-item-tag-pinned .icon {
+  width: 12px;
+  height: 12px;
+}
+
 table.collection-list-table {
   width: 100%;
   border-collapse: separate !important;
@@ -2385,16 +2404,6 @@ body.list-row-dragging .list-item-row * {
   gap: var(--spacing-xs);
   min-width: 0;
   width: 100%;
-}
-
-.lists-panel .list-item-pin {
-  display: inline-flex;
-  color: var(--color-text-muted);
-}
-
-.lists-panel .list-item-pin .icon {
-  width: 14px;
-  height: 14px;
 }
 
 .lists-panel .list-item-title-main span,

--- a/packages/plugins/official/lists/web/styles.css
+++ b/packages/plugins/official/lists/web/styles.css
@@ -2826,6 +2826,14 @@ button.list-item-menu-checkbox {
   color: var(--color-accent-primary);
 }
 
+.list-item-menu-item.pin-toggle {
+  color: var(--color-text-muted);
+}
+
+.list-item-menu-item.pin-toggle.active {
+  color: #f59e0b;
+}
+
 .input-mic-button {
   display: inline-flex;
   align-items: center;

--- a/packages/plugins/official/notes/web/styles.css
+++ b/packages/plugins/official/notes/web/styles.css
@@ -1727,6 +1727,20 @@
   color: var(--tag-fg, var(--color-text-secondary));
 }
 
+.collection-browser-item-tag-pinned {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--color-accent-primary);
+  background-color: color-mix(in srgb, var(--color-accent-primary) 12%, transparent);
+  border-color: color-mix(in srgb, var(--color-accent-primary) 38%, transparent);
+}
+
+.collection-browser-item-tag-pinned .icon {
+  width: 12px;
+  height: 12px;
+}
+
 .collection-list-table {
   width: 100%;
   border-collapse: collapse;

--- a/packages/web-client/src/controllers/collectionBrowserController.test.ts
+++ b/packages/web-client/src/controllers/collectionBrowserController.test.ts
@@ -285,11 +285,12 @@ describe('CollectionBrowserController list CRUD UI', () => {
     });
   });
 
-  it('keeps the Focus list at the top of browser list results', () => {
+  it('keeps virtual Focus and Pinned lists at the top of browser list results', () => {
     const { controller, containerEl } = makeController({
       getAvailableItems: () => [
         { type: 'list', id: 'agent-pack', name: 'Agent Pack' },
         { type: 'list', id: '__focus__', name: 'Focus', specialKind: 'focus' },
+        { type: 'list', id: '__pinned__', name: 'Pinned', specialKind: 'pinned' },
         { type: 'list', id: 'today', name: 'Today' },
       ],
     });
@@ -302,7 +303,7 @@ describe('CollectionBrowserController list CRUD UI', () => {
       ),
     ).map((el) => el.dataset['collectionId']);
 
-    expect(ids).toEqual(['__focus__', 'agent-pack', 'today']);
+    expect(ids).toEqual(['__focus__', '__pinned__', 'agent-pack', 'today']);
   });
 
   it('sorts items by last updated and persists the choice', () => {

--- a/packages/web-client/src/controllers/collectionBrowserController.ts
+++ b/packages/web-client/src/controllers/collectionBrowserController.ts
@@ -9,7 +9,7 @@ import { CollectionDropdownFilterController } from './collectionDropdownFilterCo
 import { handleCollectionSearchKeyDown } from '../utils/collectionSearchKeyboard';
 import { applyMarkdownToElement } from '../utils/markdown';
 import { applyTagColorToElement, normalizeTag } from '../utils/tagColors';
-import { hasPinnedTag, isPinnedTag } from '../utils/pinnedTag';
+import { isPinnedTag } from '../utils/pinnedTag';
 import type { DialogManager } from './dialogManager';
 import {
   ListMetadataDialog,
@@ -540,35 +540,8 @@ export class CollectionBrowserController {
     }
   }
 
-  private decorateItemPinned(itemEl: HTMLElement, item: CollectionItemSummary): void {
-    if (!hasPinnedTag(item.tags)) {
-      return;
-    }
-    const labelEl = itemEl.querySelector<HTMLElement>('.collection-search-dropdown-item-label');
-    if (!labelEl) {
-      return;
-    }
-    let titleRow: HTMLElement | null = null;
-    if (
-      labelEl.parentElement &&
-      labelEl.parentElement.classList.contains('collection-browser-item-title')
-    ) {
-      titleRow = labelEl.parentElement as HTMLElement;
-    } else {
-      titleRow = document.createElement('div');
-      titleRow.className = 'collection-browser-item-title';
-      labelEl.insertAdjacentElement('beforebegin', titleRow);
-      titleRow.appendChild(labelEl);
-    }
-    const pin = document.createElement('span');
-    pin.className = 'collection-browser-item-pin';
-    pin.innerHTML = this.options.icons.pin;
-    pin.setAttribute('aria-hidden', 'true');
-    titleRow.insertBefore(pin, labelEl);
-  }
-
   private decorateItemSpecialKind(itemEl: HTMLElement, item: CollectionItemSummary): void {
-    if (item.specialKind !== 'focus') {
+    if (item.specialKind !== 'focus' && item.specialKind !== 'pinned') {
       return;
     }
     const labelEl = itemEl.querySelector<HTMLElement>('.collection-search-dropdown-item-label');
@@ -587,11 +560,15 @@ export class CollectionBrowserController {
       labelEl.insertAdjacentElement('beforebegin', titleRow);
       titleRow.appendChild(labelEl);
     }
-    const focus = document.createElement('span');
-    focus.className = 'collection-browser-item-focus';
-    focus.innerHTML = this.options.icons.focus;
-    focus.setAttribute('aria-hidden', 'true');
-    titleRow.insertBefore(focus, labelEl);
+    const marker = document.createElement('span');
+    marker.className =
+      item.specialKind === 'focus'
+        ? 'collection-browser-item-focus'
+        : 'collection-browser-item-pin';
+    marker.innerHTML =
+      item.specialKind === 'focus' ? this.options.icons.focus : this.options.icons.pin;
+    marker.setAttribute('aria-hidden', 'true');
+    titleRow.insertBefore(marker, labelEl);
   }
 
   private decorateItemFavorite(itemEl: HTMLElement, item: CollectionItemSummary): void {
@@ -656,6 +633,9 @@ export class CollectionBrowserController {
 
   private decorateListItem(itemEl: HTMLElement, item: CollectionItemSummary): void {
     if (item.type.toLowerCase().trim() !== 'list') {
+      return;
+    }
+    if (item.specialKind === 'focus' || item.specialKind === 'pinned') {
       return;
     }
     if (this.options.showListEditActions === false) {
@@ -922,8 +902,8 @@ export class CollectionBrowserController {
       if (idxA !== idxB) {
         return idxA - idxB;
       }
-      const specialRankA = a.specialKind === 'focus' ? 0 : 1;
-      const specialRankB = b.specialKind === 'focus' ? 0 : 1;
+      const specialRankA = a.specialKind === 'focus' ? 0 : a.specialKind === 'pinned' ? 1 : 2;
+      const specialRankB = b.specialKind === 'focus' ? 0 : b.specialKind === 'pinned' ? 1 : 2;
       if (specialRankA !== specialRankB) {
         return specialRankA - specialRankB;
       }
@@ -945,7 +925,6 @@ export class CollectionBrowserController {
       renderItemContent: (itemEl, item) => {
         this.decorateItemFavorite(itemEl, item);
         this.decorateItemSpecialKind(itemEl, item);
-        this.decorateItemPinned(itemEl, item);
         this.decorateItemInstanceBadge(itemEl, item);
         this.decorateListItem(itemEl, item);
         this.decorateItemPreview(itemEl, item);
@@ -988,7 +967,6 @@ export class CollectionBrowserController {
       ? item.tags
           .filter((tag): tag is string => typeof tag === 'string' && tag.trim().length > 0)
           .map((tag) => tag.trim())
-          .filter((tag) => !isPinnedTag(tag))
       : [];
 
     if (tags.length === 0) {
@@ -1000,10 +978,17 @@ export class CollectionBrowserController {
 
     for (const tag of tags) {
       const tagEl = document.createElement('span');
-      tagEl.className = 'collection-browser-item-tag';
-      tagEl.textContent = tag;
+      if (isPinnedTag(tag)) {
+        tagEl.className = 'collection-browser-item-tag collection-browser-item-tag-pinned';
+        tagEl.innerHTML = `${this.options.icons.pin}<span>Pinned</span>`;
+        tagEl.title = 'Pinned';
+        tagEl.setAttribute('aria-label', 'Pinned');
+      } else {
+        tagEl.className = 'collection-browser-item-tag';
+        tagEl.textContent = tag;
+        applyTagColorToElement(tagEl, tag);
+      }
       tagEl.dataset['tag'] = normalizeTag(tag);
-      applyTagColorToElement(tagEl, tag);
       tagsEl.appendChild(tagEl);
     }
 

--- a/packages/web-client/src/controllers/collectionDropdown.test.ts
+++ b/packages/web-client/src/controllers/collectionDropdown.test.ts
@@ -44,12 +44,13 @@ function makeController(
 }
 
 describe('CollectionDropdownController', () => {
-  it('keeps the Focus list at the top of list dropdown results', () => {
+  it('keeps virtual Focus and Pinned lists at the top of list dropdown results', () => {
     const { controller, list } = makeController();
 
     controller.populate([
       { type: 'list', id: 'agent-pack', name: 'Agent Pack' },
       { type: 'list', id: '__focus__', name: 'Focus', specialKind: 'focus' },
+      { type: 'list', id: '__pinned__', name: 'Pinned', specialKind: 'pinned' },
       { type: 'list', id: 'today', name: 'Today' },
     ]);
 
@@ -57,6 +58,6 @@ describe('CollectionDropdownController', () => {
       list.querySelectorAll<HTMLElement>('.collection-search-dropdown-item'),
     ).map((el) => el.dataset['collectionId']);
 
-    expect(ids).toEqual(['__focus__', 'agent-pack', 'today']);
+    expect(ids).toEqual(['__focus__', '__pinned__', 'agent-pack', 'today']);
   });
 });

--- a/packages/web-client/src/controllers/collectionDropdown.ts
+++ b/packages/web-client/src/controllers/collectionDropdown.ts
@@ -229,8 +229,8 @@ export class CollectionDropdownController {
       if (idxA !== idxB) {
         return idxA - idxB;
       }
-      const specialRankA = a.specialKind === 'focus' ? 0 : 1;
-      const specialRankB = b.specialKind === 'focus' ? 0 : 1;
+      const specialRankA = a.specialKind === 'focus' ? 0 : a.specialKind === 'pinned' ? 1 : 2;
+      const specialRankB = b.specialKind === 'focus' ? 0 : b.specialKind === 'pinned' ? 1 : 2;
       if (specialRankA !== specialRankB) {
         return specialRankA - specialRankB;
       }

--- a/packages/web-client/src/controllers/collectionTypes.ts
+++ b/packages/web-client/src/controllers/collectionTypes.ts
@@ -13,5 +13,5 @@ export type CollectionItemSummary = {
   updatedAt?: string;
   instanceId?: string;
   instanceLabel?: string;
-  specialKind?: 'focus';
+  specialKind?: 'focus' | 'pinned';
 };

--- a/packages/web-client/src/controllers/listItemMenuController.test.ts
+++ b/packages/web-client/src/controllers/listItemMenuController.test.ts
@@ -41,6 +41,7 @@ describe('ListItemMenuController', () => {
         move: '<svg></svg>',
         x: '<svg></svg>',
         eye: '<svg></svg>',
+        pin: '<svg></svg>',
         clock: '<svg></svg>',
         clockOff: '<svg></svg>',
         moveTop: '<svg></svg>',
@@ -106,6 +107,7 @@ describe('ListItemMenuController', () => {
         move: '<svg></svg>',
         x: '<svg></svg>',
         eye: '<svg></svg>',
+        pin: '<svg></svg>',
         clock: '<svg></svg>',
         clockOff: '<svg></svg>',
         moveTop: '<svg></svg>',
@@ -185,6 +187,7 @@ describe('ListItemMenuController', () => {
         move: '<svg></svg>',
         x: '<svg></svg>',
         eye: '<svg></svg>',
+        pin: '<svg></svg>',
         clock: '<svg></svg>',
         clockOff: '<svg></svg>',
         moveTop: '<svg></svg>',
@@ -263,6 +266,7 @@ describe('ListItemMenuController', () => {
         move: '<svg></svg>',
         x: '<svg></svg>',
         eye: '<svg></svg>',
+        pin: '<svg></svg>',
         clock: '<svg></svg>',
         clockOff: '<svg></svg>',
         moveTop: '<svg></svg>',
@@ -298,5 +302,106 @@ describe('ListItemMenuController', () => {
 
     addButton!.click();
     expect(onToggleItemFocus).toHaveBeenCalledWith('source-list', 'item-123', false);
+  });
+
+  it('uses pin toggle actions for pinned state without treating unpin as delete', () => {
+    const contextMenuManager = new ContextMenuManager({
+      isSessionPinned: () => false,
+      pinSession: vi.fn(),
+      clearHistory: vi.fn(),
+      deleteSession: vi.fn(),
+      renameSession: vi.fn(),
+      editSession: vi.fn(),
+    });
+    const onToggleItemPinned = vi.fn();
+    const onDeleteItem = vi.fn();
+    const onDeleteUnderlyingItem = vi.fn();
+
+    const controller = new ListItemMenuController({
+      contextMenuManager,
+      icons: {
+        edit: '<svg class="edit"></svg>',
+        trash: '<svg class="trash"></svg>',
+        copy: '<svg class="copy"></svg>',
+        duplicate: '<svg class="duplicate"></svg>',
+        move: '<svg class="move"></svg>',
+        x: '<svg class="x"></svg>',
+        eye: '<svg class="eye"></svg>',
+        pin: '<svg class="pin"></svg>',
+        clock: '<svg class="clock"></svg>',
+        clockOff: '<svg class="clock-off"></svg>',
+        moveTop: '<svg class="move-top"></svg>',
+        moveBottom: '<svg class="move-bottom"></svg>',
+      },
+      recentUserItemUpdates: new Set<string>(),
+      userUpdateTimeoutMs: 1000,
+      getMoveTargetLists: () => [],
+      updateListItem: vi.fn(),
+      onEditItem: vi.fn(),
+      onDeleteItem,
+      onDeleteUnderlyingItem,
+      onToggleItemPinned,
+      onMoveItemToList: vi.fn(),
+      onCopyItemToList: vi.fn(),
+      onTouchItem: vi.fn(),
+      onClearTouchItem: vi.fn(),
+    });
+
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    const row = document.createElement('tr');
+
+    controller.open(
+      trigger,
+      'source-list',
+      { id: 'item-1', title: 'Unpinned task', tags: ['work'] },
+      'item-1',
+      row,
+    );
+    const pinButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('.list-item-menu-item'),
+    ).find((btn) => btn.getAttribute('aria-label') === 'Pin item');
+    expect(pinButton).toBeDefined();
+    expect(pinButton?.innerHTML).toContain('pin');
+    expect(pinButton?.classList.contains('pin-toggle')).toBe(true);
+    expect(pinButton?.classList.contains('active')).toBe(false);
+
+    pinButton!.click();
+    expect(onToggleItemPinned).toHaveBeenCalledWith('source-list', 'item-1', false);
+
+    controller.open(
+      trigger,
+      '__pinned__',
+      {
+        id: 'item-2',
+        title: 'Pinned task',
+        tags: ['pinned', 'work'],
+        sourceListId: 'source-list',
+        sourceListName: 'Source List',
+      },
+      'item-2',
+      row,
+    );
+    const unpinButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('.list-item-menu-item'),
+    ).find((btn) => btn.getAttribute('aria-label') === 'Unpin item');
+    const removeFromPinnedTrashButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('.list-item-menu-item'),
+    ).find((btn) => btn.getAttribute('aria-label') === 'Delete item');
+    const deleteSourceButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('.list-item-menu-item'),
+    ).find((btn) => btn.getAttribute('aria-label') === 'Delete source item');
+
+    expect(unpinButton).toBeDefined();
+    expect(unpinButton?.innerHTML).toContain('pin');
+    expect(unpinButton?.classList.contains('pin-toggle')).toBe(true);
+    expect(unpinButton?.classList.contains('active')).toBe(true);
+    expect(removeFromPinnedTrashButton).toBeUndefined();
+    expect(deleteSourceButton).toBeDefined();
+
+    unpinButton!.click();
+    expect(onToggleItemPinned).toHaveBeenCalledWith('__pinned__', 'item-2', true);
+    expect(onDeleteItem).not.toHaveBeenCalled();
+    expect(onDeleteUnderlyingItem).not.toHaveBeenCalled();
   });
 });

--- a/packages/web-client/src/controllers/listItemMenuController.ts
+++ b/packages/web-client/src/controllers/listItemMenuController.ts
@@ -191,7 +191,9 @@ export class ListItemMenuController {
       this.options.onCopyItemToList(listId, itemId);
     });
 
-    const isFocusItem = typeof item.sourceListId === 'string' && item.sourceListId.trim().length > 0;
+    const hasSourceItem =
+      typeof item.sourceListId === 'string' && item.sourceListId.trim().length > 0;
+    const isFocusItem = listId === '__focus__' && hasSourceItem;
     if (this.options.onToggleItemFocus) {
       const isFocused = isFocusItem || item.focused === true;
       addMenuButton(
@@ -215,7 +217,7 @@ export class ListItemMenuController {
       );
     }
 
-    if (isFocusItem && this.options.onDeleteUnderlyingItem) {
+    if (hasSourceItem && this.options.onDeleteUnderlyingItem) {
       addMenuButton(
         this.options.icons.trash,
         'Delete source item',

--- a/packages/web-client/src/controllers/listItemMenuController.ts
+++ b/packages/web-client/src/controllers/listItemMenuController.ts
@@ -1,5 +1,9 @@
 import type { ContextMenuManager } from './contextMenu';
 import type { ListMoveTarget, ListPanelItem } from './listPanelController';
+import { hasPinnedTag } from '../utils/pinnedTag';
+
+const FOCUS_LIST_ID = '__focus__';
+const PINNED_LIST_ID = '__pinned__';
 
 export interface ListItemMenuControllerOptions {
   contextMenuManager: ContextMenuManager;
@@ -11,6 +15,7 @@ export interface ListItemMenuControllerOptions {
     duplicate: string;
     x: string;
     eye: string;
+    pin: string;
     clock: string;
     clockOff: string;
     moveTop: string;
@@ -32,6 +37,7 @@ export interface ListItemMenuControllerOptions {
   onDeleteItem: (listId: string, itemId: string, title: string) => void;
   onDeleteUnderlyingItem?: (listId: string, itemId: string, title: string) => void;
   onToggleItemFocus?: (listId: string, itemId: string, focused: boolean) => void;
+  onToggleItemPinned?: (listId: string, itemId: string, pinned: boolean) => void;
   onMoveItemToList: (listId: string, itemId: string) => void;
   onCopyItemToList: (listId: string, itemId: string) => void;
   onTouchItem: (listId: string, itemId: string) => void;
@@ -193,7 +199,8 @@ export class ListItemMenuController {
 
     const hasSourceItem =
       typeof item.sourceListId === 'string' && item.sourceListId.trim().length > 0;
-    const isFocusItem = listId === '__focus__' && hasSourceItem;
+    const isFocusItem = listId === FOCUS_LIST_ID && hasSourceItem;
+    const isPinnedViewItem = listId === PINNED_LIST_ID && hasSourceItem;
     if (this.options.onToggleItemFocus) {
       const isFocused = isFocusItem || item.focused === true;
       addMenuButton(
@@ -206,7 +213,19 @@ export class ListItemMenuController {
       );
     }
 
-    if (!isFocusItem) {
+    if (this.options.onToggleItemPinned) {
+      const isPinned = isPinnedViewItem || hasPinnedTag(item.tags);
+      addMenuButton(
+        this.options.icons.pin,
+        isPinned ? 'Unpin item' : 'Pin item',
+        () => {
+          this.options.onToggleItemPinned?.(listId, itemId, isPinned);
+        },
+        isPinned ? 'pin-toggle active' : 'pin-toggle',
+      );
+    }
+
+    if (!isFocusItem && !isPinnedViewItem) {
       addMenuButton(
         this.options.icons.trash,
         'Delete item',

--- a/packages/web-client/src/controllers/listPanelController.test.ts
+++ b/packages/web-client/src/controllers/listPanelController.test.ts
@@ -1012,6 +1012,90 @@ describe('ListPanelController focus view', () => {
     });
   });
 
+  it('routes pinned view edits to source items and removal to pinned tag removal', async () => {
+    const callOperation = vi.fn(
+      async () => ({} as unknown),
+    ) as NonNullable<ListPanelControllerOptions['callOperation']>;
+    const controller = buildController({ callOperation });
+    controller.render('__pinned__', {
+      id: '__pinned__',
+      name: 'Pinned',
+      viewKind: 'pinned',
+      items: [
+        {
+          id: 'item-1',
+          title: 'Pinned task',
+          tags: ['pinned', 'urgent'],
+          sourceListId: 'work',
+          sourceListName: 'Work',
+        },
+      ],
+    });
+
+    const internal = controller as unknown as {
+      updateListItem: (
+        listId: string,
+        itemId: string,
+        updates: Record<string, unknown>,
+      ) => Promise<boolean>;
+      deleteListItem: (listId: string, itemId: string) => Promise<boolean>;
+    };
+
+    await expect(
+      internal.updateListItem('__pinned__', 'item-1', { completed: true }),
+    ).resolves.toBe(true);
+    expect(callOperation).toHaveBeenLastCalledWith('item-update', {
+      listId: 'work',
+      id: 'item-1',
+      completed: true,
+    });
+
+    await expect(internal.deleteListItem('__pinned__', 'item-1')).resolves.toBe(true);
+    expect(callOperation).toHaveBeenLastCalledWith('item-tags-remove', {
+      listId: 'work',
+      id: 'item-1',
+      tags: ['pinned'],
+    });
+    expect(callOperation).not.toHaveBeenCalledWith(
+      'item-remove',
+      expect.objectContaining({ id: 'item-1' }),
+    );
+  });
+
+  it('does not treat pinned view source-backed rows as focused', async () => {
+    const callOperation = vi.fn(
+      async () => ({} as unknown),
+    ) as NonNullable<ListPanelControllerOptions['callOperation']>;
+    const controller = buildController({ callOperation });
+    controller.render('__pinned__', {
+      id: '__pinned__',
+      name: 'Pinned',
+      viewKind: 'pinned',
+      items: [
+        {
+          id: 'item-1',
+          title: 'Pinned task',
+          tags: ['pinned'],
+          sourceListId: 'work',
+          sourceListName: 'Work',
+        },
+      ],
+    });
+
+    const internal = controller as unknown as {
+      updateListItem: (
+        listId: string,
+        itemId: string,
+        updates: Record<string, unknown>,
+      ) => Promise<boolean>;
+    };
+
+    await expect(
+      internal.updateListItem('__pinned__', 'item-1', { focused: true }),
+    ).resolves.toBe(true);
+    expect(callOperation).toHaveBeenLastCalledWith('focus-add', { itemId: 'item-1' });
+  });
+
   it('does not remove focus when editing a non-focused source item', async () => {
     const callOperation = vi.fn(
       async () => ({} as unknown),

--- a/packages/web-client/src/controllers/listPanelController.ts
+++ b/packages/web-client/src/controllers/listPanelController.ts
@@ -281,6 +281,7 @@ export class ListPanelController {
         trash: options.icons.trash,
         x: options.icons.x,
         eye: options.icons.eye,
+        pin: options.icons.pin,
         clock: options.icons.clock,
         clockOff: options.icons.clockOff,
         moveTop: options.icons.moveTop,
@@ -305,6 +306,9 @@ export class ListPanelController {
       },
       onToggleItemFocus: (_listId, itemId, focused) => {
         void this.toggleItemFocus(itemId, focused);
+      },
+      onToggleItemPinned: (listId, itemId, pinned) => {
+        void this.toggleItemPinned(listId, itemId, pinned);
       },
       onMoveItemToList: (listId, itemId) => {
         void this.showMoveItemToListDialog(listId, itemId);
@@ -1499,10 +1503,71 @@ export class ListPanelController {
     }
   }
 
+  private async toggleItemPinned(
+    listId: string,
+    itemId: string,
+    currentlyPinned: boolean,
+  ): Promise<boolean> {
+    if (!this.options.callOperation) {
+      this.options.setStatus('Lists tool is unavailable');
+      return false;
+    }
+    const sourceListId =
+      this.currentData?.viewKind === 'pinned' || isPinnedListId(listId)
+        ? this.getSourceListIdForItem(itemId)
+        : listId;
+    if (!sourceListId || isVirtualListId(sourceListId)) {
+      this.options.setStatus('Source list is unavailable');
+      return false;
+    }
+
+    try {
+      await this.runOperation(currentlyPinned ? 'item-tags-remove' : 'item-tags-add', {
+        listId: sourceListId,
+        id: itemId,
+        tags: [PINNED_TAG],
+      });
+      this.markItemPinned(itemId, !currentlyPinned);
+      this.options.setStatus(currentlyPinned ? 'Removed from Pinned' : 'Added to Pinned');
+      this.rerenderCurrent();
+      return true;
+    } catch {
+      this.options.setStatus(
+        currentlyPinned ? 'Failed to remove from Pinned' : 'Failed to add to Pinned',
+      );
+      return false;
+    }
+  }
+
   private markItemFocused(itemId: string, focused: boolean): void {
     const item = this.currentData?.items?.find((entry) => entry.id === itemId);
     if (item) {
       item.focused = focused;
+    }
+  }
+
+  private markItemPinned(itemId: string, pinned: boolean): void {
+    const currentData = this.currentData;
+    if (!currentData) {
+      return;
+    }
+    const item = currentData.items?.find((entry) => entry.id === itemId);
+    if (!item) {
+      return;
+    }
+    if (!pinned && (currentData.viewKind === 'pinned' || isPinnedListId(this.currentListId))) {
+      currentData.items = currentData.items?.filter((entry) => entry.id !== itemId) ?? [];
+      syncArrayContents(
+        this.currentSortedItems,
+        this.currentSortedItems.filter((entry) => entry.id !== itemId),
+      );
+      return;
+    }
+    const tags = Array.isArray(item.tags) ? item.tags : [];
+    if (pinned) {
+      item.tags = hasPinnedTag(tags) ? tags : [...tags, PINNED_TAG];
+    } else {
+      item.tags = withoutPinnedTag(tags);
     }
   }
 

--- a/packages/web-client/src/controllers/listPanelController.ts
+++ b/packages/web-client/src/controllers/listPanelController.ts
@@ -71,7 +71,7 @@ export interface ListPanelData {
     updatedAt?: string;
   }>;
   items?: ListPanelItem[];
-  viewKind?: 'list' | 'focus';
+  viewKind?: 'list' | 'focus' | 'pinned';
 }
 
 export interface ListPanelControllerOptions {
@@ -213,9 +213,18 @@ type ListColumnState = {
 };
 
 const FOCUS_LIST_ID = '__focus__';
+const PINNED_LIST_ID = '__pinned__';
 
 function isFocusListId(listId: string | null | undefined): boolean {
   return listId === FOCUS_LIST_ID;
+}
+
+function isPinnedListId(listId: string | null | undefined): boolean {
+  return listId === PINNED_LIST_ID;
+}
+
+function isVirtualListId(listId: string | null | undefined): boolean {
+  return isFocusListId(listId) || isPinnedListId(listId);
 }
 
 export class ListPanelController {
@@ -472,6 +481,10 @@ export class ListPanelController {
       void this.openFocusAddItemDialog(options?.openOptions);
       return;
     }
+    if (isPinnedListId(listId)) {
+      void this.openPinnedAddItemDialog(options?.openOptions);
+      return;
+    }
     if (options?.instanceId) {
       this.addDialogInstanceOverrides.set(listId, options.instanceId);
     } else {
@@ -495,6 +508,29 @@ export class ListPanelController {
       ...(openOptions ?? {}),
       ...(target.openOptions ?? {}),
       focused: true,
+      showFocusToggle: true,
+    };
+    this.openAddItemDialog(target.listId, {
+      ...(target.instanceId ? { instanceId: target.instanceId } : {}),
+      openOptions: targetOpenOptions,
+    });
+  }
+
+  private async openPinnedAddItemDialog(
+    openOptions?: ListItemEditorDialogOpenOptions,
+  ): Promise<void> {
+    if (!this.options.resolveAddItemTarget) {
+      this.options.setStatus('Choose a source list before adding pinned items');
+      return;
+    }
+    const target = await this.options.resolveAddItemTarget();
+    if (!target) {
+      return;
+    }
+    const targetOpenOptions: ListItemEditorDialogOpenOptions = {
+      ...(openOptions ?? {}),
+      ...(target.openOptions ?? {}),
+      defaultTags: [PINNED_TAG],
       showFocusToggle: true,
     };
     this.openAddItemDialog(target.listId, {
@@ -767,6 +803,7 @@ export class ListPanelController {
     // Get custom fields early for the header
     const customFields = Array.isArray(data.customFields) ? data.customFields : [];
     const isFocusView = data.viewKind === 'focus' || isFocusListId(listId);
+    const isVirtualView = isFocusView || data.viewKind === 'pinned' || isPinnedListId(listId);
 
     // Check if sorted by position (default or explicit)
     const aqlPrimarySort = this.currentAqlQuery?.orderBy?.[0] ?? null;
@@ -822,8 +859,8 @@ export class ListPanelController {
         this.options.setRightControls(newControls.rightControls);
       },
       onEditMetadata: () => {
-        if (isFocusView) {
-          this.options.setStatus('Focus metadata is managed by the app');
+        if (isVirtualView) {
+          this.options.setStatus(`${data.name} metadata is managed by the app`);
           return;
         }
         this.options.openListMetadataDialog(listId, data);
@@ -1328,6 +1365,13 @@ export class ListPanelController {
           instanceId ? { instanceId } : undefined,
         );
       }
+      if (this.currentData?.viewKind === 'pinned' && created?.id) {
+        await this.runOperation(
+          'item-tags-add',
+          { listId, id: created.id, tags: [PINNED_TAG] },
+          instanceId ? { instanceId } : undefined,
+        );
+      }
       if (instanceId) {
         this.addDialogInstanceOverrides.delete(listId);
       }
@@ -1377,6 +1421,37 @@ export class ListPanelController {
             id: itemId,
             ...sourceUpdates,
           });
+        }
+        if (targetListId && targetListId !== sourceListId) {
+          await this.runOperation('item-move', { id: itemId, targetListId });
+        }
+        return true;
+      }
+      if (this.currentData?.viewKind === 'pinned' || isPinnedListId(listId)) {
+        const sourceUpdates = { ...updates };
+        delete sourceUpdates['position'];
+        delete sourceUpdates['targetListId'];
+        const focused = sourceUpdates['focused'];
+        delete sourceUpdates['focused'];
+        const sourceListId = this.getSourceListIdForItem(itemId);
+        if (!sourceListId) {
+          return false;
+        }
+        if (updates['position'] !== undefined && Object.keys(sourceUpdates).length === 0) {
+          this.options.setStatus('Pinned is tag-derived and cannot be reordered');
+          return false;
+        }
+        if (Object.keys(sourceUpdates).length > 0) {
+          await this.runOperation('item-update', {
+            listId: sourceListId,
+            id: itemId,
+            ...sourceUpdates,
+          });
+        }
+        if (focused === true && !this.isItemFocused(itemId, listId)) {
+          await this.runOperation('focus-add', { itemId });
+        } else if (focused === false && this.isItemFocused(itemId, listId)) {
+          await this.runOperation('focus-remove', { itemId });
         }
         if (targetListId && targetListId !== sourceListId) {
           await this.runOperation('item-move', { id: itemId, targetListId });
@@ -1436,7 +1511,7 @@ export class ListPanelController {
       return true;
     }
     const item = this.currentData?.items?.find((entry) => entry.id === itemId);
-    return item?.focused === true || !!item?.sourceListId;
+    return item?.focused === true;
   }
 
   private getSourceListIdForItem(itemId: string): string | null {
@@ -1454,7 +1529,9 @@ export class ListPanelController {
     }
     try {
       const operationListId =
-        this.currentData?.viewKind === 'focus' || isFocusListId(listId)
+        this.currentData?.viewKind === 'focus' ||
+        this.currentData?.viewKind === 'pinned' ||
+        isVirtualListId(listId)
           ? this.getSourceListIdForItem(itemId)
           : listId;
       if (!operationListId) {
@@ -1480,7 +1557,9 @@ export class ListPanelController {
     }
     try {
       const operationListId =
-        this.currentData?.viewKind === 'focus' || isFocusListId(listId)
+        this.currentData?.viewKind === 'focus' ||
+        this.currentData?.viewKind === 'pinned' ||
+        isVirtualListId(listId)
           ? this.getSourceListIdForItem(itemId)
           : listId;
       if (!operationListId) {
@@ -1512,6 +1591,18 @@ export class ListPanelController {
     try {
       if (this.currentData?.viewKind === 'focus' || isFocusListId(listId)) {
         await this.runOperation('focus-remove', { itemId });
+        return true;
+      }
+      if (this.currentData?.viewKind === 'pinned' || isPinnedListId(listId)) {
+        const sourceListId = this.getSourceListIdForItem(itemId);
+        if (!sourceListId) {
+          return false;
+        }
+        await this.runOperation('item-tags-remove', {
+          listId: sourceListId,
+          id: itemId,
+          tags: [PINNED_TAG],
+        });
         return true;
       }
       await this.runOperation('item-remove', { listId, id: itemId });
@@ -1624,7 +1715,8 @@ export class ListPanelController {
       openOptions.initialCustomFieldValues = item.customFields as Record<string, unknown>;
     }
     if (mode === 'edit' && item) {
-      openOptions.focused = item.focused === true || !!item.sourceListId;
+      openOptions.focused =
+        item.focused === true || this.currentData?.viewKind === 'focus' || isFocusListId(listId);
     } else if (mode === 'add' && openOptionsOverride?.focused !== undefined) {
       openOptions.focused = openOptionsOverride.focused;
     }
@@ -1634,13 +1726,16 @@ export class ListPanelController {
 
   private showListItemDeleteConfirmation(listId: string, itemId: string, title: string): void {
     const isFocusItem = this.currentData?.viewKind === 'focus' || isFocusListId(listId);
+    const isPinnedItem = this.currentData?.viewKind === 'pinned' || isPinnedListId(listId);
     this.options.dialogManager.showConfirmDialog({
-      title: isFocusItem ? 'Remove From Focus' : 'Delete Item',
+      title: isFocusItem ? 'Remove From Focus' : isPinnedItem ? 'Remove From Pinned' : 'Delete Item',
       message: isFocusItem
         ? `Remove "${title}" from Focus? The source item will stay in its list.`
-        : `Delete "${title}" from this list?`,
-      confirmText: isFocusItem ? 'Remove' : 'Delete',
-      confirmClassName: isFocusItem ? 'primary' : 'danger',
+        : isPinnedItem
+          ? `Remove "${title}" from Pinned? The source item will stay in its list.`
+          : `Delete "${title}" from this list?`,
+      confirmText: isFocusItem || isPinnedItem ? 'Remove' : 'Delete',
+      confirmClassName: isFocusItem || isPinnedItem ? 'primary' : 'danger',
       keydownStopsPropagation: true,
       onConfirm: () => {
         void (async () => {
@@ -1662,7 +1757,7 @@ export class ListPanelController {
   ): void {
     this.options.dialogManager.showConfirmDialog({
       title: 'Delete Source Item',
-      message: `Delete "${title}" from its source list? This also removes it from Focus.`,
+      message: `Delete "${title}" from its source list? This also removes it from virtual views.`,
       confirmText: 'Delete',
       confirmClassName: 'danger',
       keydownStopsPropagation: true,
@@ -1687,13 +1782,20 @@ export class ListPanelController {
 
     const count = selectedIds.length;
     const isFocusList = this.currentData?.viewKind === 'focus' || isFocusListId(listId);
+    const isPinnedList = this.currentData?.viewKind === 'pinned' || isPinnedListId(listId);
     this.options.dialogManager.showConfirmDialog({
-      title: isFocusList ? 'Delete Source Items' : 'Delete Selected Items',
+      title: isPinnedList
+        ? 'Remove From Pinned'
+        : isFocusList
+          ? 'Delete Source Items'
+          : 'Delete Selected Items',
       message: isFocusList
         ? `Delete ${count} selected source item${count === 1 ? '' : 's'}? This also removes them from Focus.`
-        : `Delete ${count} selected item${count === 1 ? '' : 's'} from this list? This cannot be undone.`,
-      confirmText: 'Delete',
-      confirmClassName: 'danger',
+        : isPinnedList
+          ? `Remove ${count} selected item${count === 1 ? '' : 's'} from Pinned? The source items will stay in their lists.`
+          : `Delete ${count} selected item${count === 1 ? '' : 's'} from this list? This cannot be undone.`,
+      confirmText: isPinnedList ? 'Remove' : 'Delete',
+      confirmClassName: isPinnedList ? 'primary' : 'danger',
       keydownStopsPropagation: true,
       onConfirm: () => {
         this.clearListSelection();
@@ -1894,6 +1996,9 @@ export class ListPanelController {
     if (isFocusListId(targetListId)) {
       return this.addItemsToFocus(itemIds, options?.targetPosition ?? null);
     }
+    if (isPinnedListId(targetListId)) {
+      return this.addItemsToPinned(itemIds);
+    }
     try {
       const basePosition =
         typeof options?.targetPosition === 'number' && Number.isFinite(options.targetPosition)
@@ -1945,7 +2050,7 @@ export class ListPanelController {
       return;
     }
     const trimmedTargetId = targetListId.trim();
-    if (!trimmedTargetId || (!isFocusListId(trimmedTargetId) && trimmedTargetId === sourceListId)) {
+    if (!trimmedTargetId || (!isVirtualListId(trimmedTargetId) && trimmedTargetId === sourceListId)) {
       return;
     }
     await this.bulkMoveItems(itemIds, trimmedTargetId, {
@@ -2038,8 +2143,12 @@ export class ListPanelController {
       await this.addItemsToFocus(itemIds, null);
       return;
     }
+    if (isPinnedListId(trimmedTargetId)) {
+      await this.addItemsToPinned(itemIds);
+      return;
+    }
     try {
-      if (this.currentData?.viewKind === 'focus' || isFocusListId(sourceListId)) {
+      if (this.currentData?.viewKind === 'focus' || isVirtualListId(sourceListId)) {
         await this.copyFocusItemsToList(itemIds, trimmedTargetId);
         return;
       }
@@ -2122,6 +2231,64 @@ export class ListPanelController {
       return okCount === itemIds.length;
     }
     this.options.setStatus('Failed to remove items from Focus');
+    return false;
+  }
+
+  private async addItemsToPinned(itemIds: string[]): Promise<boolean> {
+    if (!this.options.callOperation || itemIds.length === 0) {
+      return false;
+    }
+    let okCount = 0;
+    for (const itemId of itemIds) {
+      const sourceListId = this.getSourceListIdForItem(itemId) ?? this.currentListId;
+      if (!itemId || !sourceListId || isVirtualListId(sourceListId)) {
+        continue;
+      }
+      try {
+        await this.runOperation('item-tags-add', {
+          listId: sourceListId,
+          id: itemId,
+          tags: [PINNED_TAG],
+        });
+        okCount += 1;
+      } catch {
+        // Continue pinning the remaining selection.
+      }
+    }
+    if (okCount > 0) {
+      this.options.setStatus(`Pinned ${okCount} item${okCount === 1 ? '' : 's'}`);
+      return okCount === itemIds.length;
+    }
+    this.options.setStatus('Failed to pin items');
+    return false;
+  }
+
+  private async removeItemsFromPinned(itemIds: string[]): Promise<boolean> {
+    if (!this.options.callOperation || itemIds.length === 0) {
+      return false;
+    }
+    let okCount = 0;
+    for (const itemId of itemIds) {
+      const sourceListId = this.getSourceListIdForItem(itemId);
+      if (!itemId || !sourceListId) {
+        continue;
+      }
+      try {
+        await this.runOperation('item-tags-remove', {
+          listId: sourceListId,
+          id: itemId,
+          tags: [PINNED_TAG],
+        });
+        okCount += 1;
+      } catch {
+        // Continue removing the remaining selection.
+      }
+    }
+    if (okCount > 0) {
+      this.options.setStatus(`Removed ${okCount} item${okCount === 1 ? '' : 's'} from Pinned`);
+      return okCount === itemIds.length;
+    }
+    this.options.setStatus('Failed to remove items from Pinned');
     return false;
   }
 
@@ -2489,6 +2656,11 @@ export class ListPanelController {
     }
 
     try {
+      if (this.currentData.viewKind === 'pinned' || isPinnedListId(listId)) {
+        return shouldPin
+          ? await this.addItemsToPinned(itemIds)
+          : await this.removeItemsFromPinned(itemIds);
+      }
       await this.runOperation('items-bulk-update-tags', {
         listId,
         items: itemIds.map((id) => ({

--- a/packages/web-client/src/controllers/listPanelTableController.test.ts
+++ b/packages/web-client/src/controllers/listPanelTableController.test.ts
@@ -116,6 +116,41 @@ describe('ListPanelTableController double-click edit', () => {
     );
   });
 
+  it('renders pinned state through the tags area instead of a title prefix', () => {
+    const renderTags = vi.fn((tags: string[] | undefined) => {
+      if (!tags?.includes('pinned')) {
+        return null;
+      }
+      const wrapper = document.createElement('div');
+      wrapper.className = 'collection-tags';
+      const chip = document.createElement('span');
+      chip.className = 'collection-tag collection-tag-pinned';
+      chip.textContent = 'Pinned';
+      wrapper.appendChild(chip);
+      return wrapper;
+    });
+    const controller = new ListPanelTableController({
+      icons: { moreVertical: '', pin: '' },
+      renderTags,
+      recentUserItemUpdates,
+      userUpdateTimeoutMs: 1000,
+      getSelectedItemCount: () => 0,
+      showListItemMenu: vi.fn(),
+      updateListItem: vi.fn(async () => true),
+    });
+
+    const { table } = controller.renderTable({
+      ...baseRenderOptions,
+      sortedItems: [{ id: 'item1', title: 'Item 1', tags: ['pinned'] }],
+      showTagsColumn: true,
+    });
+
+    expect(table.querySelector('.list-item-pin')).toBeNull();
+    expect(table.querySelector('.list-item-title-main .collection-tag-pinned')).toBeNull();
+    expect(table.querySelector('td[data-column-key="tags"] .collection-tag-pinned')).not.toBeNull();
+    expect(renderTags).toHaveBeenCalledWith(['pinned']);
+  });
+
   it('does not call onEditItem when double-clicking the menu trigger', () => {
     const onEditItem = vi.fn();
     const controller = new ListPanelTableController({

--- a/packages/web-client/src/controllers/listPanelTableController.ts
+++ b/packages/web-client/src/controllers/listPanelTableController.ts
@@ -1,5 +1,4 @@
 import { applyMarkdownToElement } from '../utils/markdown';
-import { hasPinnedTag } from '../utils/pinnedTag';
 import type { ListCustomFieldDefinition } from './listCustomFields';
 import type { ListPanelItem } from './listPanelController';
 import type { ColumnVisibility } from '../utils/listColumnPreferences';
@@ -1986,7 +1985,7 @@ export class ListPanelTableController {
 
     const menuTrigger = document.createElement('button');
     menuTrigger.type = 'button';
-    const isFocusedItem = item.focused === true || !!item.sourceListId;
+    const isFocusedItem = item.focused === true || (listId === '__focus__' && !!item.sourceListId);
     menuTrigger.className = isFocusedItem
       ? 'list-item-menu-trigger list-item-menu-trigger-focused'
       : 'list-item-menu-trigger';
@@ -2387,14 +2386,6 @@ export class ListPanelTableController {
 
       const titleMain = document.createElement('div');
       titleMain.className = 'list-item-title-main';
-
-      if (hasPinnedTag(item.tags)) {
-        const pin = document.createElement('span');
-        pin.className = 'list-item-pin';
-        pin.innerHTML = this.options.icons.pin;
-        pin.setAttribute('aria-hidden', 'true');
-        titleMain.appendChild(pin);
-      }
 
       if (!showUrlColumn && item.url) {
         const link = document.createElement('a');


### PR DESCRIPTION
## Summary
- add a virtual Pinned list derived from items tagged `pinned` across lists
- render pinned state as a tag chip and expose Pinned beside Focus in list pickers
- make Pinned item actions operate on source items, with unpin removing the `pinned` tag
- use pin iconography for pin/unpin menu actions instead of trash

## Validation
- `npm test -- packages/plugins/official/lists/server/store.test.ts packages/plugins/official/lists/server/index.test.ts packages/web-client/src/controllers/listPanelController.test.ts packages/web-client/src/controllers/listPanelTableController.test.ts packages/web-client/src/controllers/collectionBrowserController.test.ts packages/web-client/src/controllers/collectionDropdown.test.ts`
- `npm test -- packages/plugins/official/lists/web/index.test.ts`
- `npm test -- packages/web-client/src/controllers/listItemMenuController.test.ts packages/web-client/src/controllers/listPanelController.test.ts packages/web-client/src/controllers/listPanelTableController.test.ts`
- `npm run build -w @assistant/web-client`
- `npm run build:plugins`
- `npm run build`

## Deploy
- deployed to the systemd dev environment and confirmed `assistant.service` active/listening
