### PR TITLE
Add Android Realtime duplex voice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Added
 
+- Added Android native voice foundations for exclusive Thread vs Realtime ownership: generation-fenced controller helpers, shared audio router (focus/mode/SCO), Thread queue stop/clear/pause-admission hooks, and a `voiceRuntimeMode` preference (Thread queue vs Realtime) in web settings. Realtime WebRTC media remains a follow-up.
+- Wait for the agent-voice-adapter client identity before starting direct TTS playback from the Android voice queue, and drain the queue once the identity arrives.
 - Added a virtual Pinned list view for list items tagged `pinned`, including first-class list picker placement, source-item actions, tag-chip rendering, and pin/unpin menu icon states. ([#111](https://github.com/kcosr/assistant/pull/111))
 - Added an Electron desktop package with native backend proxying, WebSocket forwarding, variant-aware backend defaults, and packaged-app asset routing. ([#108](https://github.com/kcosr/assistant/pull/108))
 - Added native Android voice replay for assistant turns and text/markdown attachments, using the existing local voice queue with front-of-queue, non-interrupting playback. ([#106](https://github.com/kcosr/assistant/pull/106))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### Added
 
-- Added Android native voice foundations for exclusive Thread vs Realtime ownership: generation-fenced controller helpers, shared audio router (focus/mode/SCO), Thread queue stop/clear/pause-admission hooks, and a `voiceRuntimeMode` preference (Thread queue vs Realtime) in web settings. Realtime WebRTC media remains a follow-up.
+- Added Android Realtime voice end-to-end: server `/api/voice/*` (conversation/session, OpenAI SDP negotiate, sideband lists tools, events), Android WebRTC Realtime client with exclusive-owner preemption, wake lock, start/stop/mute plugin APIs, and web settings controls. Uses server-side `OPENAI_API_KEY` only.
+- Added Android native voice foundations for exclusive Thread vs Realtime ownership: generation-fenced controller helpers, shared audio router (focus/mode/SCO), Thread queue stop/clear/pause-admission hooks, and a `voiceRuntimeMode` preference.
 - Wait for the agent-voice-adapter client identity before starting direct TTS playback from the Android voice queue, and drain the queue once the identity arrives.
 - Added a virtual Pinned list view for list items tagged `pinned`, including first-class list picker placement, source-item actions, tag-chip rendering, and pin/unpin menu icon states. ([#111](https://github.com/kcosr/assistant/pull/111))
 - Added an Electron desktop package with native backend proxying, WebSocket forwarding, variant-aware backend defaults, and packaged-app asset routing. ([#108](https://github.com/kcosr/assistant/pull/108))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@
 
 ### Added
 
-- Added Android Realtime voice end-to-end: server `/api/voice/*` (conversation/session, OpenAI SDP negotiate, sideband lists tools, events), Android WebRTC Realtime client with exclusive-owner preemption, wake lock, start/stop/mute plugin APIs, and web settings controls. Uses server-side `OPENAI_API_KEY` only.
-- Added Android native voice foundations for exclusive Thread vs Realtime ownership: generation-fenced controller helpers, shared audio router (focus/mode/SCO), Thread queue stop/clear/pause-admission hooks, and a `voiceRuntimeMode` preference.
-- Wait for the agent-voice-adapter client identity before starting direct TTS playback from the Android voice queue, and drain the queue once the identity arrives.
+- Added Android Realtime voice end-to-end: server `/api/voice/*` (conversation/session, OpenAI SDP negotiate, sideband lists tools, events), Android WebRTC Realtime client with exclusive-owner preemption, wake lock, start/stop/mute plugin APIs, config tool allowlist/denylist globs, `realtime_end_session` hangup, headset media-button start/stop, and web settings/FAB controls. Uses server-side `OPENAI_API_KEY` only. ([#113](https://github.com/kcosr/assistant/pull/113))
+- Added Android native voice foundations for exclusive Thread vs Realtime ownership: generation-fenced controller helpers, shared audio router (focus/mode/SCO), Thread queue stop/clear/pause-admission hooks, and a `voiceRuntimeMode` preference. ([#113](https://github.com/kcosr/assistant/pull/113))
+- Wait for the agent-voice-adapter client identity before starting direct TTS playback from the Android voice queue, and drain the queue once the identity arrives. ([#113](https://github.com/kcosr/assistant/pull/113))
 - Added a virtual Pinned list view for list items tagged `pinned`, including first-class list picker placement, source-item actions, tag-chip rendering, and pin/unpin menu icon states. ([#111](https://github.com/kcosr/assistant/pull/111))
 - Added an Electron desktop package with native backend proxying, WebSocket forwarding, variant-aware backend defaults, and packaged-app asset routing. ([#108](https://github.com/kcosr/assistant/pull/108))
 - Added native Android voice replay for assistant turns and text/markdown attachments, using the existing local voice queue with front-of-queue, non-interrupting playback. ([#106](https://github.com/kcosr/assistant/pull/106))
@@ -46,6 +46,7 @@
 
 ### Fixed
 
+- Fixed Android Realtime ownership and lease lifecycle: Thread path no longer stomps Realtime runtime state, Realtime callbacks are generation-fenced, WebRTC release completes dispose/server close, server reaps live sessions after missed heartbeats, hangup uses a success close token, and the Realtime wake lock is not capped at one hour. ([#113](https://github.com/kcosr/assistant/pull/113))
 - Fixed the Lists header pinned tag chip to show only the pin icon while preserving accessible labeling. ([#112](https://github.com/kcosr/assistant/pull/112))
 - Fixed Electron desktop HTML links and time-tracker XLSX export clicks so they open in the system browser/download path instead of being captured inside the Electron webview. ([#108](https://github.com/kcosr/assistant/pull/108))
 - Fixed the time tracker entry list refresh so relative Today/Week/Month presets resolve to the current date before listing newly added entries. ([#107](https://github.com/kcosr/assistant/pull/107))

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -72,6 +72,20 @@ reads the provider environment variables directly. For a complete list, see the
 
 OpenAI TTS requires `OPENAI_API_KEY`.
 
+### Realtime voice (Android)
+
+Realtime duplex voice reuses the same server-side OpenAI credential as TTS/chat:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `OPENAI_API_KEY` | - | **Required** for Realtime. Held only on the agent-server host; never sent to Android/web clients. |
+| `OPENAI_REALTIME_MODEL` | `gpt-realtime` | Pinned Realtime model id (avoid floating `latest`). |
+| `OPENAI_REALTIME_VOICE` | `TTS_VOICE` / `alloy` | OpenAI Realtime output voice. |
+
+**Storage plan:** set `OPENAI_API_KEY` in the agent-server environment (systemd unit, shell profile, or secrets manager that injects env). Do not put the raw key in client apps, Capacitor assets, or committed `config.json`. Optional `${OPENAI_API_KEY}` substitution in `config.json` is fine for other agent fields; Realtime reads the env via `loadEnvConfig()` the same way OpenAI TTS does.
+
+Capability probe: `GET /api/voice/capabilities` reports `agentRealtime.status` as `ready` or `not-configured`.
+
 ### ElevenLabs TTS
 
 Used when `TTS_BACKEND=elevenlabs`.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -79,8 +79,8 @@ Realtime duplex voice reuses the same server-side OpenAI credential as TTS/chat:
 | Variable | Default | Description |
 | --- | --- | --- |
 | `OPENAI_API_KEY` | - | **Required** for Realtime. Held only on the agent-server host; never sent to Android/web clients. |
-| `OPENAI_REALTIME_MODEL` | `gpt-realtime` | Pinned Realtime model id (avoid floating `latest`). |
-| `OPENAI_REALTIME_VOICE` | `TTS_VOICE` / `alloy` | OpenAI Realtime output voice. |
+| `OPENAI_REALTIME_MODEL` | `gpt-realtime-2.1` | Pinned Realtime model id (matches T3). |
+| `OPENAI_REALTIME_VOICE` | `marin` | OpenAI Realtime output voice (matches T3 default; female). |
 
 **Storage plan:** set `OPENAI_API_KEY` in the agent-server environment (systemd unit, shell profile, or secrets manager that injects env). Do not put the raw key in client apps, Capacitor assets, or committed `config.json`. Optional `${OPENAI_API_KEY}` substitution in `config.json` is fine for other agent fields; Realtime reads the env via `loadEnvConfig()` the same way OpenAI TTS does.
 

--- a/packages/agent-server/data/config.example.json
+++ b/packages/agent-server/data/config.example.json
@@ -11,16 +11,24 @@
       "displayName": "Lists Manager",
       "description": "Manages your personal lists - reading, shopping, movies, and more.",
       "systemPrompt": "You are a lists manager. Help the user create and manage personal lists for any purpose - reading lists, shopping lists, movie watchlists, recipe collections, and more.\n\nYou can:\n- Create new lists with names, descriptions, and tags\n- Add items to lists (with optional URLs and notes)\n- Search across lists or within a specific list\n- Move items between lists\n- Update or delete lists and items\n\nWhen the user asks you to save a URL to a list, use the url_fetch_fetch tool with mode \"metadata\" to retrieve the page title before adding the item. If the fetch fails or returns no title, derive a title from the URL or ask the user what they'd like to call it.\n\nWhen displaying multiple items (from a list or search results), format them as a markdown table with minimal relevant columns (e.g., title and URL, or title and notes). Keep it concise.",
-      "toolAllowlist": ["lists_*", "url_fetch_fetch"]
+      "toolAllowlist": [
+        "lists_*",
+        "url_fetch_fetch"
+      ]
     },
     {
       "agentId": "notes",
       "displayName": "Notes",
       "description": "Manages your personal notes - capture thoughts, meeting notes, and documents.",
       "systemPrompt": "You are a notes assistant. Help the user capture and organize their thoughts, meeting notes, ideas, and documents.\n\nYou can:\n- Create new notes with titles, content, and tags\n- Read and search existing notes\n- Append to existing notes\n- Update or delete notes\n\nBefore making changes to existing notes, use notes_preview_write to show the user a diff of what will change. Ask for confirmation before proceeding with the write.\n\nWhen the user asks you to save a URL in a note, use the url_fetch_fetch tool with mode \"metadata\" to retrieve the page title and description. Include this information in the note.\n\nWhen listing notes, format them as a markdown table showing title, tags, and last updated date.",
-      "toolAllowlist": ["notes_*", "url_fetch_fetch"],
+      "toolAllowlist": [
+        "notes_*",
+        "url_fetch_fetch"
+      ],
       "toolExposure": "skills",
-      "skillAllowlist": ["notes"]
+      "skillAllowlist": [
+        "notes"
+      ]
     },
     {
       "agentId": "general",
@@ -29,13 +37,19 @@
       "systemPrompt": "You are a helpful assistant.",
       "sessionWorkingDir": {
         "mode": "prompt",
-        "roots": ["/path/to/workspaces"]
+        "roots": [
+          "/path/to/workspaces"
+        ]
       },
-      "toolAllowlist": ["*"],
+      "toolAllowlist": [
+        "*"
+      ],
       "skills": [
         {
           "root": "./dist/skills",
-          "available": ["*"],
+          "available": [
+            "*"
+          ],
           "inline": []
         }
       ]
@@ -46,11 +60,23 @@
       "description": "Claude Code CLI agent.",
       "chat": {
         "provider": "claude-cli",
-        "models": ["opus", "sonnet", "haiku"],
-        "thinking": ["none", "low", "medium", "high", "xhigh"],
+        "models": [
+          "opus",
+          "sonnet",
+          "haiku"
+        ],
+        "thinking": [
+          "none",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ],
         "config": {
           "workdir": "/path/to/workspace",
-          "extraArgs": ["--dangerously-skip-permissions"],
+          "extraArgs": [
+            "--dangerously-skip-permissions"
+          ],
           "wrapper": {
             "path": "/home/kevin/devtools/container/run.sh",
             "env": {
@@ -68,7 +94,10 @@
       "description": "OpenAI Codex CLI agent.",
       "chat": {
         "provider": "codex-cli",
-        "models": ["gpt-5.2-codex", "gpt-5.2"],
+        "models": [
+          "gpt-5.2-codex",
+          "gpt-5.2"
+        ],
         "thinking": [
           "off",
           "low",
@@ -177,17 +206,39 @@
     }
   ],
   "profiles": [
-    { "id": "default", "label": "Global" },
-    { "id": "work", "label": "Work" },
-    { "id": "oss", "label": "Open Source" },
-    { "id": "personal", "label": "Personal" }
+    {
+      "id": "default",
+      "label": "Global"
+    },
+    {
+      "id": "work",
+      "label": "Work"
+    },
+    {
+      "id": "oss",
+      "label": "Open Source"
+    },
+    {
+      "id": "personal",
+      "label": "Personal"
+    }
   ],
   "plugins": {
-    "hello": { "enabled": false },
-    "chat": { "enabled": true },
-    "ws-echo": { "enabled": false },
-    "terminal": { "enabled": false },
-    "files": { "enabled": false },
+    "hello": {
+      "enabled": false
+    },
+    "chat": {
+      "enabled": true
+    },
+    "ws-echo": {
+      "enabled": false
+    },
+    "terminal": {
+      "enabled": false
+    },
+    "files": {
+      "enabled": false
+    },
     "diff": {
       "enabled": false,
       "workspaceRoot": "/var/lib/assistant/coding-workspaces",
@@ -200,17 +251,37 @@
         }
       ]
     },
-    "lists": { "enabled": true },
-    "notes": { "enabled": true },
-    "search": { "enabled": true },
+    "lists": {
+      "enabled": true
+    },
+    "notes": {
+      "enabled": true
+    },
+    "search": {
+      "enabled": true
+    },
     "time-tracker": {
       "enabled": false,
-      "instances": ["work", { "id": "personal", "label": "Personal" }]
+      "instances": [
+        "work",
+        {
+          "id": "personal",
+          "label": "Personal"
+        }
+      ]
     },
-    "scheduled-sessions": { "enabled": true },
-    "agents": { "enabled": true },
-    "sessions": { "enabled": true },
-    "url-fetch": { "enabled": true },
+    "scheduled-sessions": {
+      "enabled": true
+    },
+    "agents": {
+      "enabled": true
+    },
+    "sessions": {
+      "enabled": true
+    },
+    "url-fetch": {
+      "enabled": true
+    },
     "links": {
       "enabled": true,
       "spotify": {
@@ -218,5 +289,12 @@
       }
     }
   },
-  "mcpServers": []
+  "mcpServers": [],
+  "voice": {
+    "realtime": {
+      "toolAllowlist": [
+        "lists_*"
+      ]
+    }
+  }
 }

--- a/packages/agent-server/src/config.test.ts
+++ b/packages/agent-server/src/config.test.ts
@@ -74,6 +74,8 @@ describe('loadConfig', () => {
     expect(agent.skillDenylist).toEqual(['lists-private']);
     expect(agent.capabilityAllowlist).toEqual(['lists.*']);
     expect(agent.capabilityDenylist).toEqual(['lists.write']);
+    // voice section is optional; omit => undefined (realtime tools default to none at runtime)
+    expect(config.voice).toBeUndefined();
 
     const listsPlugin = config.plugins['lists'];
     const notesPlugin = config.plugins['notes'];
@@ -1077,6 +1079,34 @@ describe('loadConfig', () => {
         },
       },
     });
+  });
+
+  it('loads voice.realtime tool allowlist and denylist', async () => {
+    const filePath = createTempFile('config-voice-realtime');
+    const configJson = {
+      agents: [],
+      voice: {
+        realtime: {
+          toolAllowlist: ['lists_*'],
+          toolDenylist: ['lists_show', 'lists_aql_*'],
+          instructions: ' Be brief. ',
+        },
+      },
+    };
+
+    await fs.writeFile(filePath, JSON.stringify(configJson), 'utf8');
+
+    const config = loadConfig(filePath);
+    expect(config.voice?.realtime?.toolAllowlist).toEqual(['lists_*']);
+    expect(config.voice?.realtime?.toolDenylist).toEqual(['lists_show', 'lists_aql_*']);
+    expect(config.voice?.realtime?.instructions).toBe('Be brief.');
+  });
+
+  it('treats missing voice section as undefined (no realtime tools by default)', async () => {
+    const filePath = createTempFile('config-voice-missing');
+    await fs.writeFile(filePath, JSON.stringify({ agents: [] }), 'utf8');
+    const config = loadConfig(filePath);
+    expect(config.voice).toBeUndefined();
   });
 
   it('substitutes env vars in MCP server command and args', async () => {

--- a/packages/agent-server/src/config.ts
+++ b/packages/agent-server/src/config.ts
@@ -800,6 +800,38 @@ export const AttachmentsConfigSchema = z.object({
 
 export type AttachmentsConfig = z.infer<typeof AttachmentsConfigSchema>;
 
+/**
+ * Realtime voice agent tool exposure. Unlike text agents, missing/empty
+ * toolAllowlist means no tools (explicit opt-in only).
+ */
+export const VoiceRealtimeConfigSchema = z.object({
+  toolAllowlist: GlobPatternListSchema,
+  toolDenylist: GlobPatternListSchema,
+  /**
+   * Optional instructions override. When omitted, the server uses a default
+   * concise realtime prompt plus recent conversation context.
+   */
+  instructions: z.string().optional().nullable().transform((value) => {
+    if (typeof value !== 'string') {
+      return undefined;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }),
+});
+
+export type VoiceRealtimeConfig = z.infer<typeof VoiceRealtimeConfigSchema>;
+
+export const VoiceConfigSchema = z
+  .object({
+    realtime: VoiceRealtimeConfigSchema.optional().nullable().transform((value) => value ?? undefined),
+  })
+  .optional()
+  .nullable()
+  .transform((value) => value ?? undefined);
+
+export type VoiceConfig = z.infer<typeof VoiceConfigSchema>;
+
 export const AppConfigSchema = z
   .object({
     agents: z
@@ -817,6 +849,7 @@ export const AppConfigSchema = z
       .transform((value) => value ?? []),
     sessions: SessionsConfigSchema.optional(),
     attachments: AttachmentsConfigSchema.default({}),
+    voice: VoiceConfigSchema,
   })
   .superRefine((value, ctx) => {
     const profileIds = new Set<string>();

--- a/packages/agent-server/src/http/routes/voice.ts
+++ b/packages/agent-server/src/http/routes/voice.ts
@@ -1,0 +1,172 @@
+import type { HttpRouteHandler } from '../types';
+import type { VoiceService } from '../../voice/service';
+
+export function createVoiceRouteHandler(getVoiceService: () => VoiceService | null): HttpRouteHandler {
+  return async (context, req, _res, url, segments, helpers) => {
+    if (segments.length < 2 || segments[0] !== 'api' || segments[1] !== 'voice') {
+      return false;
+    }
+
+    const voice = getVoiceService();
+    if (!voice) {
+      helpers.sendJson(503, { error: 'Voice service unavailable' });
+      return true;
+    }
+
+    // GET /api/voice/capabilities
+    if (segments.length === 3 && segments[2] === 'capabilities' && req.method === 'GET') {
+      helpers.sendJson(200, voice.capabilities());
+      return true;
+    }
+
+    // POST /api/voice/conversations
+    if (segments.length === 3 && segments[2] === 'conversations' && req.method === 'POST') {
+      const body = (await helpers.readJsonBody()) ?? {};
+      const conversation = await voice.createConversation({
+        conversationId:
+          typeof body['conversationId'] === 'string' ? body['conversationId'] : null,
+        listsInstanceId:
+          typeof body['listsInstanceId'] === 'string' ? body['listsInstanceId'] : undefined,
+      });
+      helpers.sendJson(200, {
+        conversationId: conversation.id,
+        title: conversation.title,
+        listsInstanceId: conversation.listsInstanceId,
+      });
+      return true;
+    }
+
+    // GET /api/voice/conversations/:id
+    if (segments.length === 4 && segments[2] === 'conversations' && req.method === 'GET') {
+      const id = decodeURIComponent(segments[3] ?? '');
+      const conversation = await voice.getConversation(id);
+      if (!conversation) {
+        helpers.sendJson(404, { error: 'Conversation not found' });
+        return true;
+      }
+      helpers.sendJson(200, {
+        conversationId: conversation.id,
+        title: conversation.title,
+        listsInstanceId: conversation.listsInstanceId,
+        journal: conversation.journal.slice(-50),
+        activeSessionId: conversation.activeSessionId,
+      });
+      return true;
+    }
+
+    // POST /api/voice/sessions
+    if (segments.length === 3 && segments[2] === 'sessions' && req.method === 'POST') {
+      try {
+        const body = (await helpers.readJsonBody()) ?? {};
+        const result = await voice.createSession({
+          conversationId:
+            typeof body['conversationId'] === 'string' ? body['conversationId'] : null,
+          listsInstanceId:
+            typeof body['listsInstanceId'] === 'string' ? body['listsInstanceId'] : undefined,
+        });
+        helpers.sendJson(200, {
+          conversationId: result.conversationId,
+          sessionId: result.session.id,
+          state: result.session.state,
+          listsInstanceId: result.session.listsInstanceId,
+        });
+      } catch (error) {
+        helpers.sendJson(400, {
+          error: error instanceof Error ? error.message : 'Failed to create voice session',
+        });
+      }
+      return true;
+    }
+
+    // Session-scoped routes: /api/voice/sessions/:id/...
+    if (segments.length >= 4 && segments[2] === 'sessions') {
+      const sessionId = decodeURIComponent(segments[3] ?? '');
+      if (!sessionId) {
+        helpers.sendJson(400, { error: 'sessionId is required' });
+        return true;
+      }
+
+      // GET /api/voice/sessions/:id
+      if (segments.length === 4 && req.method === 'GET') {
+        const session = await voice.getSession(sessionId);
+        if (!session) {
+          helpers.sendJson(404, { error: 'Session not found' });
+          return true;
+        }
+        helpers.sendJson(200, {
+          sessionId: session.id,
+          conversationId: session.conversationId,
+          state: session.state,
+          muted: session.muted,
+          lastError: session.lastError,
+          sequence: session.sequence,
+        });
+        return true;
+      }
+
+      // POST /api/voice/sessions/:id/offer
+      if (segments.length === 5 && segments[4] === 'offer' && req.method === 'POST') {
+        try {
+          const body = (await helpers.readJsonBody()) ?? {};
+          const offerSdp = typeof body['sdp'] === 'string' ? body['sdp'] : '';
+          if (!offerSdp.trim()) {
+            helpers.sendJson(400, { error: 'sdp is required' });
+            return true;
+          }
+          const result = await voice.negotiateOffer({ sessionId, offerSdp });
+          helpers.sendJson(200, {
+            sdp: result.answerSdp,
+            providerCallId: result.providerCallId,
+          });
+        } catch (error) {
+          helpers.sendJson(400, {
+            error: error instanceof Error ? error.message : 'Offer negotiation failed',
+          });
+        }
+        return true;
+      }
+
+      // POST /api/voice/sessions/:id/heartbeat
+      if (segments.length === 5 && segments[4] === 'heartbeat' && req.method === 'POST') {
+        const session = await voice.heartbeat(sessionId);
+        if (!session) {
+          helpers.sendJson(404, { error: 'Session not found' });
+          return true;
+        }
+        helpers.sendJson(200, { ok: true, state: session.state, sequence: session.sequence });
+        return true;
+      }
+
+      // POST /api/voice/sessions/:id/mute
+      if (segments.length === 5 && segments[4] === 'mute' && req.method === 'POST') {
+        const body = (await helpers.readJsonBody()) ?? {};
+        const muted = body['muted'] === true;
+        const session = await voice.setMuted(sessionId, muted);
+        if (!session) {
+          helpers.sendJson(404, { error: 'Session not found' });
+          return true;
+        }
+        helpers.sendJson(200, { muted: session.muted });
+        return true;
+      }
+
+      // GET /api/voice/sessions/:id/events?after=N
+      if (segments.length === 5 && segments[4] === 'events' && req.method === 'GET') {
+        const after = Number(url.searchParams.get('after') ?? '0');
+        const events = await voice.events(sessionId, Number.isFinite(after) ? after : 0);
+        helpers.sendJson(200, { events });
+        return true;
+      }
+
+      // POST /api/voice/sessions/:id/close
+      if (segments.length === 5 && segments[4] === 'close' && req.method === 'POST') {
+        await voice.closeSession(sessionId, 'client_stop');
+        helpers.sendJson(200, { ok: true });
+        return true;
+      }
+    }
+
+    helpers.sendJson(404, { error: 'Not found' });
+    return true;
+  };
+}

--- a/packages/agent-server/src/http/routes/voice.ts
+++ b/packages/agent-server/src/http/routes/voice.ts
@@ -23,10 +23,12 @@ export function createVoiceRouteHandler(getVoiceService: () => VoiceService | nu
     if (segments.length === 3 && segments[2] === 'conversations' && req.method === 'POST') {
       const body = (await helpers.readJsonBody()) ?? {};
       const conversation = await voice.createConversation({
-        conversationId:
-          typeof body['conversationId'] === 'string' ? body['conversationId'] : null,
-        listsInstanceId:
-          typeof body['listsInstanceId'] === 'string' ? body['listsInstanceId'] : undefined,
+        ...(typeof body['conversationId'] === 'string'
+          ? { conversationId: body['conversationId'] }
+          : {}),
+        ...(typeof body['listsInstanceId'] === 'string'
+          ? { listsInstanceId: body['listsInstanceId'] }
+          : {}),
       });
       helpers.sendJson(200, {
         conversationId: conversation.id,
@@ -59,10 +61,12 @@ export function createVoiceRouteHandler(getVoiceService: () => VoiceService | nu
       try {
         const body = (await helpers.readJsonBody()) ?? {};
         const result = await voice.createSession({
-          conversationId:
-            typeof body['conversationId'] === 'string' ? body['conversationId'] : null,
-          listsInstanceId:
-            typeof body['listsInstanceId'] === 'string' ? body['listsInstanceId'] : undefined,
+          ...(typeof body['conversationId'] === 'string'
+            ? { conversationId: body['conversationId'] }
+            : {}),
+          ...(typeof body['listsInstanceId'] === 'string'
+            ? { listsInstanceId: body['listsInstanceId'] }
+            : {}),
         });
         helpers.sendJson(200, {
           conversationId: result.conversationId,

--- a/packages/agent-server/src/http/server.ts
+++ b/packages/agent-server/src/http/server.ts
@@ -21,6 +21,8 @@ import { handlePreferencesRoutes } from './routes/preferences';
 import { handlePanelRoutes } from './routes/panels';
 import { handleStaticRoutes } from './routes/static';
 import { handleSearchRoutes } from './routes/search';
+import { createVoiceRouteHandler } from './routes/voice';
+import type { VoiceService } from '../voice/service';
 import type { HttpContext, HttpHelpers, HttpRouteHandler } from './types';
 
 const WEB_CLIENT_PUBLIC_DIR = path.resolve(__dirname, '../../../../../web-client/public');
@@ -37,6 +39,7 @@ export function createHttpServer(options: {
   eventStore: EventStore;
   scheduledSessionService?: ScheduledSessionService;
   historyProvider?: HistoryProviderRegistry;
+  voiceService?: VoiceService;
 }): http.Server {
   const {
     config,
@@ -49,6 +52,7 @@ export function createHttpServer(options: {
     eventStore,
     scheduledSessionService,
     historyProvider,
+    voiceService,
   } = options;
 
   const pluginToolHost = pluginRegistry ? new PluginToolHost(pluginRegistry) : undefined;
@@ -181,6 +185,7 @@ export function createHttpServer(options: {
         handleExternalRoutes,
         handlePanelRoutes,
         handleSearchRoutes,
+        createVoiceRouteHandler(() => voiceService ?? null),
         ...pluginRoutes,
         handlePluginRoutes,
         handlePreferencesRoutes,

--- a/packages/agent-server/src/index.ts
+++ b/packages/agent-server/src/index.ts
@@ -31,6 +31,7 @@ import {
 } from './history/historyProvider';
 import { PiSessionWriter } from './history/piSessionWriter';
 import { AttachmentStore } from './attachments/store';
+import { VoiceService } from './voice/service';
 
 export {
   buildSystemPrompt,
@@ -168,6 +169,28 @@ export async function startServer(
     await scheduledSessionService.initialize();
   }
 
+  const voiceService = new VoiceService(
+    {
+      envConfig: config,
+      toolHost,
+      createToolContext: (sessionId) => ({
+        sessionId,
+        signal: new AbortController().signal,
+        eventStore: chatEventStore,
+        sessionHub,
+        sessionIndex,
+        agentRegistry: registry,
+        envConfig: config,
+        baseToolHost: toolHost,
+        ...(historyProvider ? { historyProvider } : {}),
+        ...(scheduledSessionService ? { scheduledSessionService } : {}),
+        ...(searchService ? { searchService } : {}),
+      }),
+    },
+    config.dataDir,
+  );
+  await voiceService.init();
+
   const httpServer = createHttpServer({
     config,
     sessionIndex,
@@ -179,6 +202,7 @@ export async function startServer(
     ...(scheduledSessionService ? { scheduledSessionService } : {}),
     historyProvider,
     ...(pluginRegistry ? { pluginRegistry } : {}),
+    voiceService,
   });
 
   const wss = new WebSocketServer({

--- a/packages/agent-server/src/index.ts
+++ b/packages/agent-server/src/index.ts
@@ -169,6 +169,7 @@ export async function startServer(
     await scheduledSessionService.initialize();
   }
 
+  const voiceRealtime = appConfig?.voice?.realtime;
   const voiceService = new VoiceService(
     {
       envConfig: config,
@@ -186,6 +187,10 @@ export async function startServer(
         ...(scheduledSessionService ? { scheduledSessionService } : {}),
         ...(searchService ? { searchService } : {}),
       }),
+      // Explicit opt-in: missing voice.realtime.toolAllowlist => no realtime tools.
+      ...(voiceRealtime?.toolAllowlist ? { toolAllowlist: voiceRealtime.toolAllowlist } : {}),
+      ...(voiceRealtime?.toolDenylist ? { toolDenylist: voiceRealtime.toolDenylist } : {}),
+      ...(voiceRealtime?.instructions ? { instructions: voiceRealtime.instructions } : {}),
     },
     config.dataDir,
   );

--- a/packages/agent-server/src/index.ts
+++ b/packages/agent-server/src/index.ts
@@ -273,6 +273,7 @@ export async function startServer(
       gitVersioningService.shutdown();
     }
     scheduledSessionService?.shutdown();
+    voiceService.shutdown();
   };
 
   process.once('SIGINT', shutdownHandler);

--- a/packages/agent-server/src/voice/listsTools.test.ts
+++ b/packages/agent-server/src/voice/listsTools.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Tool } from '../tools';
+
+import {
+  buildRealtimeInstructions,
+  filterToolsForVoiceRealtime,
+  isToolAllowedForVoiceRealtime,
+  toRealtimeFunctionTools,
+} from './listsTools';
+
+const sampleTools: Tool[] = [
+  { name: 'lists_list', description: 'List lists', parameters: { type: 'object' } },
+  { name: 'lists_item_move', description: 'Move item', parameters: { type: 'object' } },
+  { name: 'notes_list', description: 'List notes', parameters: { type: 'object' } },
+  { name: 'bash', description: 'Shell', parameters: { type: 'object' } },
+];
+
+describe('filterToolsForVoiceRealtime', () => {
+  it('defaults to no tools when allowlist is missing', () => {
+    expect(filterToolsForVoiceRealtime(sampleTools, undefined, undefined)).toEqual([]);
+  });
+
+  it('defaults to no tools when allowlist is empty', () => {
+    expect(filterToolsForVoiceRealtime(sampleTools, [], undefined)).toEqual([]);
+  });
+
+  it('matches globs and applies denylist', () => {
+    const filtered = filterToolsForVoiceRealtime(sampleTools, ['lists_*'], ['lists_item_move']);
+    expect(filtered.map((t) => t.name)).toEqual(['lists_list']);
+  });
+
+  it('supports exact names and star', () => {
+    expect(filterToolsForVoiceRealtime(sampleTools, ['bash'], undefined).map((t) => t.name)).toEqual([
+      'bash',
+    ]);
+    expect(filterToolsForVoiceRealtime(sampleTools, ['*'], ['bash', 'notes_*']).map((t) => t.name)).toEqual([
+      'lists_list',
+      'lists_item_move',
+    ]);
+  });
+});
+
+describe('isToolAllowedForVoiceRealtime', () => {
+  it('denies when allowlist omitted', () => {
+    expect(isToolAllowedForVoiceRealtime('lists_list', undefined, undefined)).toBe(false);
+  });
+
+  it('allows matching names and honors denylist', () => {
+    expect(isToolAllowedForVoiceRealtime('lists_item_move', ['lists_*'], undefined)).toBe(true);
+    expect(isToolAllowedForVoiceRealtime('lists_item_move', ['lists_*'], ['lists_item_move'])).toBe(
+      false,
+    );
+    expect(isToolAllowedForVoiceRealtime('notes_list', ['lists_*'], undefined)).toBe(false);
+  });
+});
+
+describe('toRealtimeFunctionTools', () => {
+  it('maps host tools into realtime function shape', () => {
+    const tools = toRealtimeFunctionTools([sampleTools[0]!]);
+    expect(tools).toEqual([
+      {
+        type: 'function',
+        name: 'lists_list',
+        description: 'List lists',
+        parameters: { type: 'object' },
+      },
+    ]);
+  });
+});
+
+describe('buildRealtimeInstructions', () => {
+  it('uses override when provided', () => {
+    const text = buildRealtimeInstructions('ctx', 'Custom voice agent.');
+    expect(text).toContain('Custom voice agent.');
+    expect(text).toContain('Recent conversation context:\nctx');
+  });
+
+  it('uses default prompt when override omitted', () => {
+    const text = buildRealtimeInstructions('');
+    expect(text).toContain('Assistant realtime voice agent');
+    expect(text).toContain('No prior conversation context.');
+  });
+});

--- a/packages/agent-server/src/voice/listsTools.test.ts
+++ b/packages/agent-server/src/voice/listsTools.test.ts
@@ -3,8 +3,12 @@ import { describe, expect, it } from 'vitest';
 import type { Tool } from '../tools';
 
 import {
+  REALTIME_END_SESSION_TOOL_NAME,
+  buildRealtimeEndSessionTool,
   buildRealtimeInstructions,
+  buildRealtimeToolsFromHost,
   filterToolsForVoiceRealtime,
+  isRealtimeEndSessionTool,
   isToolAllowedForVoiceRealtime,
   toRealtimeFunctionTools,
 } from './listsTools';
@@ -46,12 +50,45 @@ describe('isToolAllowedForVoiceRealtime', () => {
     expect(isToolAllowedForVoiceRealtime('lists_list', undefined, undefined)).toBe(false);
   });
 
+  it('always allows the built-in end-session tool', () => {
+    expect(isRealtimeEndSessionTool(REALTIME_END_SESSION_TOOL_NAME)).toBe(true);
+    expect(isToolAllowedForVoiceRealtime(REALTIME_END_SESSION_TOOL_NAME, undefined, undefined)).toBe(
+      true,
+    );
+    expect(isToolAllowedForVoiceRealtime(REALTIME_END_SESSION_TOOL_NAME, [], ['*'])).toBe(true);
+  });
+
   it('allows matching names and honors denylist', () => {
     expect(isToolAllowedForVoiceRealtime('lists_item_move', ['lists_*'], undefined)).toBe(true);
     expect(isToolAllowedForVoiceRealtime('lists_item_move', ['lists_*'], ['lists_item_move'])).toBe(
       false,
     );
     expect(isToolAllowedForVoiceRealtime('notes_list', ['lists_*'], undefined)).toBe(false);
+  });
+});
+
+describe('buildRealtimeToolsFromHost', () => {
+  it('always appends realtime_end_session even with empty allowlist', async () => {
+    const tools = await buildRealtimeToolsFromHost({
+      listTools: async () => sampleTools,
+      toolAllowlist: undefined,
+      toolDenylist: undefined,
+    });
+    expect(tools.map((t) => t.name)).toEqual([REALTIME_END_SESSION_TOOL_NAME]);
+    expect(tools[0]).toEqual(buildRealtimeEndSessionTool());
+  });
+
+  it('appends end session after filtered host tools', async () => {
+    const tools = await buildRealtimeToolsFromHost({
+      listTools: async () => sampleTools,
+      toolAllowlist: ['lists_*'],
+      toolDenylist: undefined,
+    });
+    expect(tools.map((t) => t.name)).toEqual([
+      'lists_list',
+      'lists_item_move',
+      REALTIME_END_SESSION_TOOL_NAME,
+    ]);
   });
 });
 

--- a/packages/agent-server/src/voice/listsTools.ts
+++ b/packages/agent-server/src/voice/listsTools.ts
@@ -1,0 +1,218 @@
+import type { RealtimeFunctionTool } from './types';
+
+/** Canonical lists plugin ops exposed to Realtime (title-lookup friendly). */
+export const REALTIME_LISTS_TOOL_NAMES = [
+  'lists_list',
+  'lists_get',
+  'lists_items_list',
+  'lists_items_search',
+  'lists_item_get',
+  'lists_item_add',
+  'lists_item_update',
+  'lists_item_remove',
+  'lists_item_tags_add',
+  'lists_item_tags_remove',
+] as const;
+
+export type RealtimeListsToolName = (typeof REALTIME_LISTS_TOOL_NAMES)[number];
+
+const TOOL_TO_PLUGIN_OP: Record<RealtimeListsToolName, string> = {
+  lists_list: 'lists_list',
+  lists_get: 'lists_get',
+  lists_items_list: 'lists_items_list',
+  lists_items_search: 'lists_items_search',
+  lists_item_get: 'lists_item_get',
+  lists_item_add: 'lists_item_add',
+  lists_item_update: 'lists_item_update',
+  lists_item_remove: 'lists_item_remove',
+  lists_item_tags_add: 'lists_item_tags_add',
+  lists_item_tags_remove: 'lists_item_tags_remove',
+};
+
+export function isRealtimeListsTool(name: string): name is RealtimeListsToolName {
+  return (REALTIME_LISTS_TOOL_NAMES as readonly string[]).includes(name);
+}
+
+export function pluginToolNameForRealtime(name: RealtimeListsToolName): string {
+  return TOOL_TO_PLUGIN_OP[name];
+}
+
+export function buildRealtimeListsTools(): RealtimeFunctionTool[] {
+  const instance = {
+    type: 'string',
+    description: 'Lists plugin instance id (default "default").',
+  };
+  return [
+    {
+      type: 'function',
+      name: 'lists_list',
+      description: 'List all lists, optionally filtered by tags.',
+      parameters: {
+        type: 'object',
+        properties: {
+          instance_id: instance,
+          tags: { type: 'array', items: { type: 'string' } },
+        },
+        additionalProperties: false,
+      },
+    },
+    {
+      type: 'function',
+      name: 'lists_get',
+      description: 'Get a list by id.',
+      parameters: {
+        type: 'object',
+        properties: {
+          instance_id: instance,
+          id: { type: 'string', description: 'List id.' },
+        },
+        required: ['id'],
+        additionalProperties: false,
+      },
+    },
+    {
+      type: 'function',
+      name: 'lists_items_list',
+      description: 'List items in a list.',
+      parameters: {
+        type: 'object',
+        properties: {
+          instance_id: instance,
+          listId: { type: 'string' },
+        },
+        required: ['listId'],
+        additionalProperties: false,
+      },
+    },
+    {
+      type: 'function',
+      name: 'lists_items_search',
+      description: 'Search list items by query and optional list/tags filters.',
+      parameters: {
+        type: 'object',
+        properties: {
+          instance_id: instance,
+          query: { type: 'string' },
+          listId: { type: 'string' },
+          tags: { type: 'array', items: { type: 'string' } },
+        },
+        additionalProperties: false,
+      },
+    },
+    {
+      type: 'function',
+      name: 'lists_item_get',
+      description: 'Get one list item by id.',
+      parameters: {
+        type: 'object',
+        properties: {
+          instance_id: instance,
+          listId: { type: 'string' },
+          id: { type: 'string' },
+        },
+        required: ['listId', 'id'],
+        additionalProperties: false,
+      },
+    },
+    {
+      type: 'function',
+      name: 'lists_item_add',
+      description: 'Add an item to a list. Prefer list title lookup when id is unknown.',
+      parameters: {
+        type: 'object',
+        properties: {
+          instance_id: instance,
+          listId: { type: 'string' },
+          listTitle: { type: 'string', description: 'Optional list title lookup if listId unknown.' },
+          title: { type: 'string' },
+          notes: { type: 'string' },
+          tags: { type: 'array', items: { type: 'string' } },
+        },
+        required: ['title'],
+        additionalProperties: false,
+      },
+    },
+    {
+      type: 'function',
+      name: 'lists_item_update',
+      description:
+        'Update a list item. Prefer lookupTitle when the item id is unknown from conversation.',
+      parameters: {
+        type: 'object',
+        properties: {
+          instance_id: instance,
+          listId: { type: 'string' },
+          id: { type: 'string' },
+          lookupTitle: { type: 'string' },
+          title: { type: 'string' },
+          notes: { type: 'string' },
+          completed: { type: 'boolean' },
+          tags: { type: 'array', items: { type: 'string' } },
+        },
+        additionalProperties: false,
+      },
+    },
+    {
+      type: 'function',
+      name: 'lists_item_remove',
+      description: 'Remove a list item by id or title.',
+      parameters: {
+        type: 'object',
+        properties: {
+          instance_id: instance,
+          listId: { type: 'string' },
+          id: { type: 'string' },
+          title: { type: 'string' },
+        },
+        additionalProperties: false,
+      },
+    },
+    {
+      type: 'function',
+      name: 'lists_item_tags_add',
+      description: 'Add tags to a list item.',
+      parameters: {
+        type: 'object',
+        properties: {
+          instance_id: instance,
+          listId: { type: 'string' },
+          id: { type: 'string' },
+          lookupTitle: { type: 'string' },
+          tags: { type: 'array', items: { type: 'string' } },
+        },
+        required: ['tags'],
+        additionalProperties: false,
+      },
+    },
+    {
+      type: 'function',
+      name: 'lists_item_tags_remove',
+      description: 'Remove tags from a list item.',
+      parameters: {
+        type: 'object',
+        properties: {
+          instance_id: instance,
+          listId: { type: 'string' },
+          id: { type: 'string' },
+          lookupTitle: { type: 'string' },
+          tags: { type: 'array', items: { type: 'string' } },
+        },
+        required: ['tags'],
+        additionalProperties: false,
+      },
+    },
+  ];
+}
+
+export function buildRealtimeInstructions(contextBlock: string): string {
+  return [
+    'You are the Assistant realtime voice agent.',
+    'Speak concisely. Prefer short confirmations after list mutations.',
+    'You may only use the provided lists tools. Never invent tool names.',
+    'Prefer title lookup fields when the user refers to items by name.',
+    'Do not claim you can control Thread voice, notifications, or coding agents.',
+    contextBlock.trim().length > 0
+      ? `Recent conversation context:\n${contextBlock.trim()}`
+      : 'No prior conversation context.',
+  ].join('\n');
+}

--- a/packages/agent-server/src/voice/listsTools.ts
+++ b/packages/agent-server/src/voice/listsTools.ts
@@ -1,218 +1,106 @@
+import type { Tool } from '../tools';
+import { matchesGlobPattern } from '../tools/scoping';
+
 import type { RealtimeFunctionTool } from './types';
 
-/** Canonical lists plugin ops exposed to Realtime (title-lookup friendly). */
-export const REALTIME_LISTS_TOOL_NAMES = [
-  'lists_list',
-  'lists_get',
-  'lists_items_list',
-  'lists_items_search',
-  'lists_item_get',
-  'lists_item_add',
-  'lists_item_update',
-  'lists_item_remove',
-  'lists_item_tags_add',
-  'lists_item_tags_remove',
-] as const;
+/**
+ * Explicit opt-in filter for realtime voice tools.
+ *
+ * Unlike text agents ({@link filterToolsForAgent}), a missing or empty allowlist
+ * yields no tools — never the full registry.
+ */
+export function filterToolsForVoiceRealtime<T extends { name: string }>(
+  tools: readonly T[],
+  allowlist: string[] | undefined,
+  denylist: string[] | undefined,
+): T[] {
+  if (!allowlist || allowlist.length === 0) {
+    return [];
+  }
 
-export type RealtimeListsToolName = (typeof REALTIME_LISTS_TOOL_NAMES)[number];
+  let filtered = tools.filter((tool) =>
+    allowlist.some((pattern) => matchesGlobPattern(tool.name, pattern)),
+  );
 
-const TOOL_TO_PLUGIN_OP: Record<RealtimeListsToolName, string> = {
-  lists_list: 'lists_list',
-  lists_get: 'lists_get',
-  lists_items_list: 'lists_items_list',
-  lists_items_search: 'lists_items_search',
-  lists_item_get: 'lists_item_get',
-  lists_item_add: 'lists_item_add',
-  lists_item_update: 'lists_item_update',
-  lists_item_remove: 'lists_item_remove',
-  lists_item_tags_add: 'lists_item_tags_add',
-  lists_item_tags_remove: 'lists_item_tags_remove',
-};
+  if (denylist && denylist.length > 0) {
+    filtered = filtered.filter(
+      (tool) => !denylist.some((pattern) => matchesGlobPattern(tool.name, pattern)),
+    );
+  }
 
-export function isRealtimeListsTool(name: string): name is RealtimeListsToolName {
-  return (REALTIME_LISTS_TOOL_NAMES as readonly string[]).includes(name);
+  return filtered;
 }
 
-export function pluginToolNameForRealtime(name: RealtimeListsToolName): string {
-  return TOOL_TO_PLUGIN_OP[name];
+export function isToolAllowedForVoiceRealtime(
+  name: string,
+  allowlist: string[] | undefined,
+  denylist: string[] | undefined,
+): boolean {
+  if (!allowlist || allowlist.length === 0) {
+    return false;
+  }
+  const allowed = allowlist.some((pattern) => matchesGlobPattern(name, pattern));
+  if (!allowed) {
+    return false;
+  }
+  if (denylist && denylist.length > 0) {
+    if (denylist.some((pattern) => matchesGlobPattern(name, pattern))) {
+      return false;
+    }
+  }
+  return true;
 }
 
-export function buildRealtimeListsTools(): RealtimeFunctionTool[] {
-  const instance = {
-    type: 'string',
-    description: 'Lists plugin instance id (default "default").',
+function normalizeParameters(parameters: unknown): Record<string, unknown> {
+  if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
+    return parameters as Record<string, unknown>;
+  }
+  return {
+    type: 'object',
+    properties: {},
+    additionalProperties: false,
   };
-  return [
-    {
-      type: 'function',
-      name: 'lists_list',
-      description: 'List all lists, optionally filtered by tags.',
-      parameters: {
-        type: 'object',
-        properties: {
-          instance_id: instance,
-          tags: { type: 'array', items: { type: 'string' } },
-        },
-        additionalProperties: false,
-      },
-    },
-    {
-      type: 'function',
-      name: 'lists_get',
-      description: 'Get a list by id.',
-      parameters: {
-        type: 'object',
-        properties: {
-          instance_id: instance,
-          id: { type: 'string', description: 'List id.' },
-        },
-        required: ['id'],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: 'function',
-      name: 'lists_items_list',
-      description: 'List items in a list.',
-      parameters: {
-        type: 'object',
-        properties: {
-          instance_id: instance,
-          listId: { type: 'string' },
-        },
-        required: ['listId'],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: 'function',
-      name: 'lists_items_search',
-      description: 'Search list items by query and optional list/tags filters.',
-      parameters: {
-        type: 'object',
-        properties: {
-          instance_id: instance,
-          query: { type: 'string' },
-          listId: { type: 'string' },
-          tags: { type: 'array', items: { type: 'string' } },
-        },
-        additionalProperties: false,
-      },
-    },
-    {
-      type: 'function',
-      name: 'lists_item_get',
-      description: 'Get one list item by id.',
-      parameters: {
-        type: 'object',
-        properties: {
-          instance_id: instance,
-          listId: { type: 'string' },
-          id: { type: 'string' },
-        },
-        required: ['listId', 'id'],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: 'function',
-      name: 'lists_item_add',
-      description: 'Add an item to a list. Prefer list title lookup when id is unknown.',
-      parameters: {
-        type: 'object',
-        properties: {
-          instance_id: instance,
-          listId: { type: 'string' },
-          listTitle: { type: 'string', description: 'Optional list title lookup if listId unknown.' },
-          title: { type: 'string' },
-          notes: { type: 'string' },
-          tags: { type: 'array', items: { type: 'string' } },
-        },
-        required: ['title'],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: 'function',
-      name: 'lists_item_update',
-      description:
-        'Update a list item. Prefer lookupTitle when the item id is unknown from conversation.',
-      parameters: {
-        type: 'object',
-        properties: {
-          instance_id: instance,
-          listId: { type: 'string' },
-          id: { type: 'string' },
-          lookupTitle: { type: 'string' },
-          title: { type: 'string' },
-          notes: { type: 'string' },
-          completed: { type: 'boolean' },
-          tags: { type: 'array', items: { type: 'string' } },
-        },
-        additionalProperties: false,
-      },
-    },
-    {
-      type: 'function',
-      name: 'lists_item_remove',
-      description: 'Remove a list item by id or title.',
-      parameters: {
-        type: 'object',
-        properties: {
-          instance_id: instance,
-          listId: { type: 'string' },
-          id: { type: 'string' },
-          title: { type: 'string' },
-        },
-        additionalProperties: false,
-      },
-    },
-    {
-      type: 'function',
-      name: 'lists_item_tags_add',
-      description: 'Add tags to a list item.',
-      parameters: {
-        type: 'object',
-        properties: {
-          instance_id: instance,
-          listId: { type: 'string' },
-          id: { type: 'string' },
-          lookupTitle: { type: 'string' },
-          tags: { type: 'array', items: { type: 'string' } },
-        },
-        required: ['tags'],
-        additionalProperties: false,
-      },
-    },
-    {
-      type: 'function',
-      name: 'lists_item_tags_remove',
-      description: 'Remove tags from a list item.',
-      parameters: {
-        type: 'object',
-        properties: {
-          instance_id: instance,
-          listId: { type: 'string' },
-          id: { type: 'string' },
-          lookupTitle: { type: 'string' },
-          tags: { type: 'array', items: { type: 'string' } },
-        },
-        required: ['tags'],
-        additionalProperties: false,
-      },
-    },
-  ];
 }
 
-export function buildRealtimeInstructions(contextBlock: string): string {
-  return [
-    'You are the Assistant realtime voice agent.',
-    'Speak concisely. Prefer short confirmations after list mutations.',
-    'You may only use the provided lists tools. Never invent tool names.',
-    'Prefer title lookup fields when the user refers to items by name.',
-    'Do not claim you can control Thread voice, notifications, or coding agents.',
+/** Map host tool descriptors into OpenAI Realtime function tool shape. */
+export function toRealtimeFunctionTools(tools: readonly Tool[]): RealtimeFunctionTool[] {
+  return tools.map((tool) => ({
+    type: 'function',
+    name: tool.name,
+    description: tool.description?.trim() || tool.name,
+    parameters: normalizeParameters(tool.parameters),
+  }));
+}
+
+export async function buildRealtimeToolsFromHost(options: {
+  listTools: () => Promise<Tool[]>;
+  toolAllowlist: string[] | undefined;
+  toolDenylist: string[] | undefined;
+}): Promise<RealtimeFunctionTool[]> {
+  const all = await options.listTools();
+  const filtered = filterToolsForVoiceRealtime(all, options.toolAllowlist, options.toolDenylist);
+  return toRealtimeFunctionTools(filtered);
+}
+
+export function buildRealtimeInstructions(
+  contextBlock: string,
+  instructionsOverride?: string,
+): string {
+  const base =
+    typeof instructionsOverride === 'string' && instructionsOverride.trim().length > 0
+      ? instructionsOverride.trim()
+      : [
+          'You are the Assistant realtime voice agent.',
+          'Speak concisely. Prefer short confirmations after mutations.',
+          'You may only use the provided tools. Never invent tool names.',
+          'Prefer title or name lookup fields when the user refers to items by name.',
+          'Do not claim you can control Thread voice, notifications, or coding agents unless those tools are provided.',
+        ].join('\n');
+
+  const context =
     contextBlock.trim().length > 0
       ? `Recent conversation context:\n${contextBlock.trim()}`
-      : 'No prior conversation context.',
-  ].join('\n');
+      : 'No prior conversation context.';
+
+  return `${base}\n${context}`;
 }

--- a/packages/agent-server/src/voice/listsTools.ts
+++ b/packages/agent-server/src/voice/listsTools.ts
@@ -3,6 +3,32 @@ import { matchesGlobPattern } from '../tools/scoping';
 
 import type { RealtimeFunctionTool } from './types';
 
+/** Built-in Realtime-only hangup tool (not a plugin op; always available on Realtime sessions). */
+export const REALTIME_END_SESSION_TOOL_NAME = 'realtime_end_session';
+
+export function isRealtimeEndSessionTool(name: string): boolean {
+  return name === REALTIME_END_SESSION_TOOL_NAME;
+}
+
+export function buildRealtimeEndSessionTool(): RealtimeFunctionTool {
+  return {
+    type: 'function',
+    name: REALTIME_END_SESSION_TOOL_NAME,
+    description:
+      'End the current realtime voice call immediately. Use when the user wants to hang up, stop, or end the conversation. Prefer a brief spoken goodbye first when natural, then call this tool.',
+    parameters: {
+      type: 'object',
+      properties: {
+        reason: {
+          type: 'string',
+          description: 'Optional short reason (for example user_request or done).',
+        },
+      },
+      additionalProperties: false,
+    },
+  };
+}
+
 /**
  * Explicit opt-in filter for realtime voice tools.
  *
@@ -36,6 +62,10 @@ export function isToolAllowedForVoiceRealtime(
   allowlist: string[] | undefined,
   denylist: string[] | undefined,
 ): boolean {
+  // Built-in hangup is always available on Realtime sessions.
+  if (isRealtimeEndSessionTool(name)) {
+    return true;
+  }
   if (!allowlist || allowlist.length === 0) {
     return false;
   }
@@ -79,7 +109,9 @@ export async function buildRealtimeToolsFromHost(options: {
 }): Promise<RealtimeFunctionTool[]> {
   const all = await options.listTools();
   const filtered = filterToolsForVoiceRealtime(all, options.toolAllowlist, options.toolDenylist);
-  return toRealtimeFunctionTools(filtered);
+  const hostTools = toRealtimeFunctionTools(filtered);
+  // Always expose hangup, independent of plugin allowlist (including empty allowlist).
+  return [...hostTools, buildRealtimeEndSessionTool()];
 }
 
 export function buildRealtimeInstructions(
@@ -94,6 +126,7 @@ export function buildRealtimeInstructions(
           'Speak concisely. Prefer short confirmations after mutations.',
           'You may only use the provided tools. Never invent tool names.',
           'Prefer title or name lookup fields when the user refers to items by name.',
+          'When the user wants to hang up, stop, or end the call, call realtime_end_session. A short goodbye first is fine; the call ends when that tool runs.',
           'Do not claim you can control Thread voice, notifications, or coding agents unless those tools are provided.',
         ].join('\n');
 

--- a/packages/agent-server/src/voice/openaiRealtime.ts
+++ b/packages/agent-server/src/voice/openaiRealtime.ts
@@ -1,0 +1,154 @@
+import WebSocket from 'ws';
+
+import type { RealtimeSessionConfig } from './types';
+
+const OPENAI_API_ORIGIN = 'https://api.openai.com';
+
+export interface NegotiateRealtimeResult {
+  answerSdp: string;
+  providerCallId: string;
+}
+
+export async function negotiateOpenAiRealtimeCall(options: {
+  apiKey: string;
+  offerSdp: string;
+  session: RealtimeSessionConfig;
+}): Promise<NegotiateRealtimeResult> {
+  const form = new FormData();
+  form.set('sdp', options.offerSdp);
+  form.set(
+    'session',
+    JSON.stringify({
+      type: 'realtime',
+      model: options.session.model,
+      instructions: options.session.instructions,
+      audio: {
+        output: {
+          voice: options.session.voice,
+        },
+      },
+      tools: options.session.tools,
+      tool_choice: 'auto',
+    }),
+  );
+
+  const response = await fetch(`${OPENAI_API_ORIGIN}/v1/realtime/calls`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${options.apiKey}`,
+      Accept: 'application/sdp',
+    },
+    body: form,
+  });
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '');
+    throw new Error(
+      `OpenAI realtime negotiate failed (${response.status}): ${detail.slice(0, 500)}`,
+    );
+  }
+
+  const location = response.headers.get('location') ?? '';
+  const providerCallId = location.split('/').filter(Boolean).at(-1) ?? '';
+  if (!providerCallId.startsWith('rtc_')) {
+    throw new Error('OpenAI realtime response omitted a valid call id');
+  }
+
+  const answerSdp = await response.text();
+  if (!answerSdp.trim()) {
+    throw new Error('OpenAI realtime returned an empty SDP answer');
+  }
+
+  return { answerSdp, providerCallId };
+}
+
+export type SidebandEventHandler = (event: Record<string, unknown>) => void | Promise<void>;
+
+export class OpenAiRealtimeSideband {
+  private socket: WebSocket | null = null;
+  private closed = false;
+
+  constructor(
+    private readonly apiKey: string,
+    private readonly providerCallId: string,
+    private readonly onEvent: SidebandEventHandler,
+    private readonly onClose: (reason: string) => void,
+  ) {}
+
+  connect(): void {
+    const url = `wss://api.openai.com/v1/realtime?call_id=${encodeURIComponent(this.providerCallId)}`;
+    this.socket = new WebSocket(url, {
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+    });
+
+    this.socket.on('open', () => {
+      // no-op; session was configured at negotiate time
+    });
+
+    this.socket.on('message', (data) => {
+      void this.handleMessage(data);
+    });
+
+    this.socket.on('close', () => {
+      if (!this.closed) {
+        this.closed = true;
+        this.onClose('sideband_closed');
+      }
+    });
+
+    this.socket.on('error', () => {
+      if (!this.closed) {
+        this.closed = true;
+        this.onClose('sideband_error');
+      }
+    });
+  }
+
+  send(event: Record<string, unknown>): void {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    this.socket.send(JSON.stringify(event));
+  }
+
+  close(): void {
+    this.closed = true;
+    try {
+      this.socket?.close();
+    } catch {
+      // ignore
+    }
+    this.socket = null;
+  }
+
+  private async handleMessage(data: WebSocket.RawData): Promise<void> {
+    try {
+      const text = typeof data === 'string' ? data : data.toString('utf8');
+      const event = JSON.parse(text) as Record<string, unknown>;
+      await this.onEvent(event);
+    } catch {
+      // ignore malformed frames
+    }
+  }
+}
+
+export async function hangupOpenAiRealtimeCall(options: {
+  apiKey: string;
+  providerCallId: string;
+}): Promise<void> {
+  try {
+    await fetch(
+      `${OPENAI_API_ORIGIN}/v1/realtime/calls/${encodeURIComponent(options.providerCallId)}/hangup`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${options.apiKey}`,
+        },
+      },
+    );
+  } catch {
+    // best-effort
+  }
+}

--- a/packages/agent-server/src/voice/service.test.ts
+++ b/packages/agent-server/src/voice/service.test.ts
@@ -48,10 +48,10 @@ function makeToolContext(sessionId: string): ToolContext {
   return {
     sessionId,
     signal: new AbortController().signal,
-    eventStore: {} as ToolContext['eventStore'],
-    sessionHub: {} as ToolContext['sessionHub'],
-    sessionIndex: {} as ToolContext['sessionIndex'],
-    agentRegistry: {} as ToolContext['agentRegistry'],
+    eventStore: {} as NonNullable<ToolContext['eventStore']>,
+    sessionHub: {} as NonNullable<ToolContext['sessionHub']>,
+    sessionIndex: {} as NonNullable<ToolContext['sessionIndex']>,
+    agentRegistry: {} as NonNullable<ToolContext['agentRegistry']>,
     envConfig: makeEnv(),
     baseToolHost: makeToolHost(),
   };
@@ -75,7 +75,7 @@ describe('VoiceService', () => {
     tempDirs.push(dataDir);
     const service = new VoiceService(
       {
-        envConfig: makeEnv({ dataDir, apiKey: undefined }),
+        envConfig: makeEnv({ dataDir }),
         toolHost: makeToolHost(),
         createToolContext: makeToolContext,
       },

--- a/packages/agent-server/src/voice/service.test.ts
+++ b/packages/agent-server/src/voice/service.test.ts
@@ -1,0 +1,109 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { EnvConfig } from '../envConfig';
+import type { ToolContext, ToolHost } from '../tools';
+import { VoiceService } from './service';
+
+const tempDirs: string[] = [];
+
+function makeEnv(partial: Partial<EnvConfig> = {}): EnvConfig {
+  return {
+    port: 3000,
+    toolsEnabled: true,
+    dataDir: partial.dataDir ?? path.join(os.tmpdir(), 'voice-test'),
+    audioInputMode: 'manual',
+    audioSampleRate: 24000,
+    audioTranscriptionEnabled: false,
+    audioOutputVoice: undefined,
+    audioOutputSpeed: undefined,
+    ttsModel: 'gpt-4o-mini-tts',
+    ttsVoice: 'alloy',
+    ttsFrameDurationMs: 250,
+    ttsBackend: 'openai',
+    elevenLabsApiKey: undefined,
+    elevenLabsVoiceId: undefined,
+    elevenLabsModelId: undefined,
+    elevenLabsBaseUrl: undefined,
+    maxMessagesPerMinute: 0,
+    maxAudioBytesPerMinute: 0,
+    maxToolCallsPerMinute: 0,
+    debugChatCompletions: false,
+    debugHttpRequests: false,
+    ...partial,
+  };
+}
+
+function makeToolHost(callTool = vi.fn(async () => ({ ok: true }))): ToolHost {
+  return {
+    listTools: async () => [],
+    callTool,
+  };
+}
+
+function makeToolContext(sessionId: string): ToolContext {
+  return {
+    sessionId,
+    signal: new AbortController().signal,
+    eventStore: {} as ToolContext['eventStore'],
+    sessionHub: {} as ToolContext['sessionHub'],
+    sessionIndex: {} as ToolContext['sessionIndex'],
+    agentRegistry: {} as ToolContext['agentRegistry'],
+    envConfig: makeEnv(),
+    baseToolHost: makeToolHost(),
+  };
+}
+
+describe('VoiceService', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.splice(0).map(async (dir) => {
+        await fs.rm(dir, { recursive: true, force: true });
+      }),
+    );
+  });
+
+  it('reports not-configured without OPENAI_API_KEY', async () => {
+    const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'voice-svc-'));
+    tempDirs.push(dataDir);
+    const service = new VoiceService(
+      {
+        envConfig: makeEnv({ dataDir, apiKey: undefined }),
+        toolHost: makeToolHost(),
+        createToolContext: makeToolContext,
+      },
+      dataDir,
+    );
+    await service.init();
+    expect(service.capabilities().agentRealtime.status).toBe('not-configured');
+  });
+
+  it('creates a conversation and session', async () => {
+    const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'voice-svc-'));
+    tempDirs.push(dataDir);
+    const service = new VoiceService(
+      {
+        envConfig: makeEnv({ dataDir, apiKey: 'test-key' }),
+        toolHost: makeToolHost(),
+        createToolContext: makeToolContext,
+      },
+      dataDir,
+    );
+    await service.init();
+    expect(service.capabilities().agentRealtime.status).toBe('ready');
+
+    const created = await service.createSession({ listsInstanceId: 'default' });
+    expect(created.conversationId).toBeTruthy();
+    expect(created.session.state).toBe('created');
+
+    const loaded = await service.getSession(created.session.id);
+    expect(loaded?.conversationId).toBe(created.conversationId);
+  });
+});

--- a/packages/agent-server/src/voice/service.test.ts
+++ b/packages/agent-server/src/voice/service.test.ts
@@ -105,5 +105,26 @@ describe('VoiceService', () => {
 
     const loaded = await service.getSession(created.session.id);
     expect(loaded?.conversationId).toBe(created.conversationId);
+    service.shutdown();
+  });
+
+  it('persists heartbeat lease timestamps', async () => {
+    const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'voice-svc-'));
+    tempDirs.push(dataDir);
+    const service = new VoiceService(
+      {
+        envConfig: makeEnv({ dataDir, apiKey: 'test-key' }),
+        toolHost: makeToolHost(),
+        createToolContext: makeToolContext,
+      },
+      dataDir,
+    );
+    await service.init();
+    const created = await service.createSession({ listsInstanceId: 'default' });
+    const before = created.session.updatedAtMs;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const heartbeated = await service.heartbeat(created.session.id);
+    expect(heartbeated?.updatedAtMs).toBeGreaterThanOrEqual(before);
+    service.shutdown();
   });
 });

--- a/packages/agent-server/src/voice/service.ts
+++ b/packages/agent-server/src/voice/service.ts
@@ -48,15 +48,16 @@ export class VoiceService {
     dataDir: string,
   ) {
     this.store = new VoiceStore(dataDir);
+    // Match T3 Realtime defaults (OpenAiVoiceProvider: gpt-realtime-2.1 + marin).
     this.model =
       options.model?.trim() ||
       process.env['OPENAI_REALTIME_MODEL']?.trim() ||
-      'gpt-realtime';
+      'gpt-realtime-2.1';
     this.voice =
       options.voice?.trim() ||
       process.env['OPENAI_REALTIME_VOICE']?.trim() ||
       options.envConfig.ttsVoice ||
-      'alloy';
+      'marin';
   }
 
   async init(): Promise<void> {

--- a/packages/agent-server/src/voice/service.ts
+++ b/packages/agent-server/src/voice/service.ts
@@ -44,6 +44,12 @@ interface LiveRealtimeCall {
   listsInstanceId: string;
 }
 
+/** Drop live Realtime sessions that miss heartbeats for this long (client interval is 15s). */
+const HEARTBEAT_LEASE_MS = 45_000;
+const LEASE_REAPER_INTERVAL_MS = 15_000;
+/** Cap retained closed/failed sessions in the durable store. */
+const MAX_TERMINAL_SESSIONS = 100;
+
 export class VoiceService {
   private readonly store: VoiceStore;
   private readonly liveCalls = new Map<VoiceSessionId, LiveRealtimeCall>();
@@ -52,6 +58,7 @@ export class VoiceService {
   private readonly toolAllowlist: string[] | undefined;
   private readonly toolDenylist: string[] | undefined;
   private readonly instructionsOverride: string | undefined;
+  private leaseReaperTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(
     private readonly options: VoiceServiceOptions,
@@ -75,6 +82,14 @@ export class VoiceService {
 
   async init(): Promise<void> {
     await this.store.init();
+    this.startLeaseReaper();
+  }
+
+  shutdown(): void {
+    if (this.leaseReaperTimer) {
+      clearInterval(this.leaseReaperTimer);
+      this.leaseReaperTimer = null;
+    }
   }
 
   capabilities(): VoiceCapabilities {
@@ -200,12 +215,71 @@ export class VoiceService {
   }
 
   async heartbeat(sessionId: VoiceSessionId): Promise<VoiceSessionRecord | null> {
-    const session = await this.store.getSession(sessionId);
-    if (!session) {
-      return null;
+    // Touch via updateSession so the lease timestamp is durable, not only in-memory.
+    return this.store.updateSession(sessionId, {});
+  }
+
+  private startLeaseReaper(): void {
+    if (this.leaseReaperTimer) {
+      return;
     }
-    session.updatedAtMs = Date.now();
-    return session;
+    this.leaseReaperTimer = setInterval(() => {
+      void this.reapStaleLiveCalls().catch((error) => {
+        console.warn('[voice] lease reaper failed', error);
+      });
+    }, LEASE_REAPER_INTERVAL_MS);
+    // Do not keep the process alive solely for the reaper.
+    if (typeof this.leaseReaperTimer.unref === 'function') {
+      this.leaseReaperTimer.unref();
+    }
+  }
+
+  /** @internal Exported for tests via package access pattern. */
+  async reapStaleLiveCalls(nowMs = Date.now()): Promise<string[]> {
+    const reaped: string[] = [];
+    for (const [sessionId, live] of [...this.liveCalls.entries()]) {
+      const session = await this.store.getSession(sessionId);
+      if (!session) {
+        live.sideband.close();
+        this.liveCalls.delete(sessionId);
+        reaped.push(sessionId);
+        continue;
+      }
+      if (session.state === 'closed' || session.state === 'failed') {
+        live.sideband.close();
+        this.liveCalls.delete(sessionId);
+        reaped.push(sessionId);
+        continue;
+      }
+      const age = nowMs - session.updatedAtMs;
+      if (age > HEARTBEAT_LEASE_MS) {
+        const apiKey = this.options.envConfig.apiKey;
+        live.sideband.close();
+        this.liveCalls.delete(sessionId);
+        if (apiKey && live.providerCallId) {
+          await hangupOpenAiRealtimeCall({ apiKey, providerCallId: live.providerCallId }).catch(
+            () => undefined,
+          );
+        }
+        await this.store.updateSession(sessionId, {
+          state: 'failed',
+          lastError: 'heartbeat_lease_expired',
+        });
+        await this.store.appendEvent(sessionId, {
+          type: 'error',
+          code: 'heartbeat_lease_expired',
+          message: 'Realtime session lease expired (missed heartbeats)',
+        });
+        await this.store.appendEvent(sessionId, {
+          type: 'session_state',
+          state: 'failed',
+          message: 'heartbeat_lease_expired',
+        });
+        reaped.push(sessionId);
+      }
+    }
+    await this.store.pruneTerminalSessions(MAX_TERMINAL_SESSIONS);
+    return reaped;
   }
 
   async events(sessionId: VoiceSessionId, afterSequence: number) {
@@ -380,11 +454,14 @@ export class VoiceService {
 
     // Built-in hangup: acknowledge the tool, then close so the client plays the end cue.
     if (isRealtimeEndSessionTool(name)) {
-      const reason =
+      // Protocol close reason is always a success token so the client plays SUCCESS_COMPLETION.
+      // Free-text model detail stays only in the tool result / journal payload.
+      const detail =
         typeof args['reason'] === 'string' && args['reason'].trim().length > 0
           ? args['reason'].trim()
           : 'agent_end';
-      const output = { ok: true, ending: true, reason };
+      const reason = 'agent_end';
+      const output = { ok: true, ending: true, reason, detail };
       await this.store.appendJournal(live.conversationId, {
         kind: 'tool_result',
         toolName: name,

--- a/packages/agent-server/src/voice/service.ts
+++ b/packages/agent-server/src/voice/service.ts
@@ -5,6 +5,7 @@ import { ToolError } from '../tools';
 import {
   buildRealtimeInstructions,
   buildRealtimeToolsFromHost,
+  isRealtimeEndSessionTool,
   isToolAllowedForVoiceRealtime,
 } from './listsTools';
 import {
@@ -376,6 +377,41 @@ export class VoiceService {
       toolCallId: callId,
       payload: args,
     });
+
+    // Built-in hangup: acknowledge the tool, then close so the client plays the end cue.
+    if (isRealtimeEndSessionTool(name)) {
+      const reason =
+        typeof args['reason'] === 'string' && args['reason'].trim().length > 0
+          ? args['reason'].trim()
+          : 'agent_end';
+      const output = { ok: true, ending: true, reason };
+      await this.store.appendJournal(live.conversationId, {
+        kind: 'tool_result',
+        toolName: name,
+        toolCallId: callId,
+        payload: output,
+      });
+      await this.store.appendEvent(sessionId, {
+        type: 'tool',
+        name,
+        status: 'completed',
+      });
+      // Best-effort tool output before hangup (provider may already be tearing down).
+      try {
+        live.sideband.send({
+          type: 'conversation.item.create',
+          item: {
+            type: 'function_call_output',
+            call_id: callId,
+            output: JSON.stringify(output),
+          },
+        });
+      } catch {
+        // ignore
+      }
+      await this.closeSession(sessionId, reason);
+      return;
+    }
 
     const ctx = this.options.createToolContext(`voice:${live.conversationId}`);
     let output: unknown;

--- a/packages/agent-server/src/voice/service.ts
+++ b/packages/agent-server/src/voice/service.ts
@@ -4,9 +4,8 @@ import { ToolError } from '../tools';
 
 import {
   buildRealtimeInstructions,
-  buildRealtimeListsTools,
-  isRealtimeListsTool,
-  pluginToolNameForRealtime,
+  buildRealtimeToolsFromHost,
+  isToolAllowedForVoiceRealtime,
 } from './listsTools';
 import {
   hangupOpenAiRealtimeCall,
@@ -27,6 +26,13 @@ export interface VoiceServiceOptions {
   createToolContext: (sessionId: string) => ToolContext;
   model?: string;
   voice?: string;
+  /**
+   * Realtime tool globs. Missing/empty allowlist => no tools (explicit opt-in).
+   */
+  toolAllowlist?: string[];
+  toolDenylist?: string[];
+  /** Optional instructions override from app config. */
+  instructions?: string;
 }
 
 interface LiveRealtimeCall {
@@ -42,6 +48,9 @@ export class VoiceService {
   private readonly liveCalls = new Map<VoiceSessionId, LiveRealtimeCall>();
   private readonly model: string;
   private readonly voice: string;
+  private readonly toolAllowlist: string[] | undefined;
+  private readonly toolDenylist: string[] | undefined;
+  private readonly instructionsOverride: string | undefined;
 
   constructor(
     private readonly options: VoiceServiceOptions,
@@ -58,6 +67,9 @@ export class VoiceService {
       process.env['OPENAI_REALTIME_VOICE']?.trim() ||
       options.envConfig.ttsVoice ||
       'marin';
+    this.toolAllowlist = options.toolAllowlist;
+    this.toolDenylist = options.toolDenylist;
+    this.instructionsOverride = options.instructions;
   }
 
   async init(): Promise<void> {
@@ -133,14 +145,18 @@ export class VoiceService {
     });
 
     const contextBlock = this.store.recentJournalText(conversation);
-    const tools = buildRealtimeListsTools();
+    const tools = await buildRealtimeToolsFromHost({
+      listTools: () => this.options.toolHost.listTools(),
+      toolAllowlist: this.toolAllowlist,
+      toolDenylist: this.toolDenylist,
+    });
     const negotiated = await negotiateOpenAiRealtimeCall({
       apiKey,
       offerSdp: input.offerSdp,
       session: {
         model: this.model,
         voice: this.voice,
-        instructions: buildRealtimeInstructions(contextBlock),
+        instructions: buildRealtimeInstructions(contextBlock, this.instructionsOverride),
         tools,
       },
     });
@@ -324,7 +340,7 @@ export class VoiceService {
       status: 'started',
     });
 
-    if (!isRealtimeListsTool(name)) {
+    if (!isToolAllowedForVoiceRealtime(name, this.toolAllowlist, this.toolDenylist)) {
       const denied = { error: `Tool not allowed in realtime: ${name}` };
       live.sideband.send({
         type: 'conversation.item.create',
@@ -361,11 +377,10 @@ export class VoiceService {
       payload: args,
     });
 
-    const toolName = pluginToolNameForRealtime(name);
     const ctx = this.options.createToolContext(`voice:${live.conversationId}`);
     let output: unknown;
     try {
-      output = await this.options.toolHost.callTool(toolName, JSON.stringify(args), ctx);
+      output = await this.options.toolHost.callTool(name, JSON.stringify(args), ctx);
       await this.store.appendJournal(live.conversationId, {
         kind: 'tool_result',
         toolName: name,

--- a/packages/agent-server/src/voice/service.ts
+++ b/packages/agent-server/src/voice/service.ts
@@ -78,7 +78,10 @@ export class VoiceService {
     conversationId?: string | null;
     listsInstanceId?: string;
   }) {
-    return this.store.getOrCreateConversation(input);
+    return this.store.getOrCreateConversation({
+      ...(input.conversationId !== undefined ? { conversationId: input.conversationId } : {}),
+      ...(input.listsInstanceId !== undefined ? { listsInstanceId: input.listsInstanceId } : {}),
+    });
   }
 
   async getConversation(id: VoiceConversationId) {
@@ -90,8 +93,8 @@ export class VoiceService {
     listsInstanceId?: string;
   }): Promise<{ conversationId: string; session: VoiceSessionRecord }> {
     const conversation = await this.store.getOrCreateConversation({
-      conversationId: input.conversationId,
-      listsInstanceId: input.listsInstanceId,
+      ...(input.conversationId !== undefined ? { conversationId: input.conversationId } : {}),
+      ...(input.listsInstanceId !== undefined ? { listsInstanceId: input.listsInstanceId } : {}),
     });
     const session = await this.store.createSession({
       conversationId: conversation.id,
@@ -320,7 +323,7 @@ export class VoiceService {
       status: 'started',
     });
 
-    if (!isRealtimeListsTool(name) || name === 'voice_speak' || name === 'voice_ask') {
+    if (!isRealtimeListsTool(name)) {
       const denied = { error: `Tool not allowed in realtime: ${name}` };
       live.sideband.send({
         type: 'conversation.item.create',

--- a/packages/agent-server/src/voice/service.ts
+++ b/packages/agent-server/src/voice/service.ts
@@ -1,0 +1,402 @@
+import type { EnvConfig } from '../envConfig';
+import type { ToolContext, ToolHost } from '../tools';
+import { ToolError } from '../tools';
+
+import {
+  buildRealtimeInstructions,
+  buildRealtimeListsTools,
+  isRealtimeListsTool,
+  pluginToolNameForRealtime,
+} from './listsTools';
+import {
+  hangupOpenAiRealtimeCall,
+  negotiateOpenAiRealtimeCall,
+  OpenAiRealtimeSideband,
+} from './openaiRealtime';
+import { VoiceStore } from './store';
+import type {
+  VoiceCapabilities,
+  VoiceConversationId,
+  VoiceSessionId,
+  VoiceSessionRecord,
+} from './types';
+
+export interface VoiceServiceOptions {
+  envConfig: EnvConfig;
+  toolHost: ToolHost;
+  createToolContext: (sessionId: string) => ToolContext;
+  model?: string;
+  voice?: string;
+}
+
+interface LiveRealtimeCall {
+  sessionId: VoiceSessionId;
+  conversationId: VoiceConversationId;
+  providerCallId: string;
+  sideband: OpenAiRealtimeSideband;
+  listsInstanceId: string;
+}
+
+export class VoiceService {
+  private readonly store: VoiceStore;
+  private readonly liveCalls = new Map<VoiceSessionId, LiveRealtimeCall>();
+  private readonly model: string;
+  private readonly voice: string;
+
+  constructor(
+    private readonly options: VoiceServiceOptions,
+    dataDir: string,
+  ) {
+    this.store = new VoiceStore(dataDir);
+    this.model =
+      options.model?.trim() ||
+      process.env['OPENAI_REALTIME_MODEL']?.trim() ||
+      'gpt-realtime';
+    this.voice =
+      options.voice?.trim() ||
+      process.env['OPENAI_REALTIME_VOICE']?.trim() ||
+      options.envConfig.ttsVoice ||
+      'alloy';
+  }
+
+  async init(): Promise<void> {
+    await this.store.init();
+  }
+
+  capabilities(): VoiceCapabilities {
+    const apiKey = this.options.envConfig.apiKey;
+    return {
+      agentRealtime: {
+        status: apiKey ? 'ready' : 'not-configured',
+        model: this.model,
+        voice: this.voice,
+      },
+    };
+  }
+
+  async createConversation(input: {
+    conversationId?: string | null;
+    listsInstanceId?: string;
+  }) {
+    return this.store.getOrCreateConversation(input);
+  }
+
+  async getConversation(id: VoiceConversationId) {
+    return this.store.getConversation(id);
+  }
+
+  async createSession(input: {
+    conversationId?: string | null;
+    listsInstanceId?: string;
+  }): Promise<{ conversationId: string; session: VoiceSessionRecord }> {
+    const conversation = await this.store.getOrCreateConversation({
+      conversationId: input.conversationId,
+      listsInstanceId: input.listsInstanceId,
+    });
+    const session = await this.store.createSession({
+      conversationId: conversation.id,
+      listsInstanceId: input.listsInstanceId?.trim() || conversation.listsInstanceId,
+    });
+    return { conversationId: conversation.id, session };
+  }
+
+  async getSession(sessionId: VoiceSessionId) {
+    return this.store.getSession(sessionId);
+  }
+
+  async negotiateOffer(input: {
+    sessionId: VoiceSessionId;
+    offerSdp: string;
+  }): Promise<{ answerSdp: string; providerCallId: string }> {
+    const apiKey = this.requireApiKey();
+    const session = await this.store.getSession(input.sessionId);
+    if (!session) {
+      throw new Error('Voice session not found');
+    }
+    if (session.state === 'closed' || session.state === 'failed') {
+      throw new Error(`Voice session is ${session.state}`);
+    }
+
+    const conversation = await this.store.getConversation(session.conversationId);
+    if (!conversation) {
+      throw new Error('Voice conversation not found');
+    }
+
+    await this.store.updateSession(session.id, { state: 'connecting' });
+    await this.store.appendEvent(session.id, {
+      type: 'session_state',
+      state: 'connecting',
+    });
+
+    const contextBlock = this.store.recentJournalText(conversation);
+    const tools = buildRealtimeListsTools();
+    const negotiated = await negotiateOpenAiRealtimeCall({
+      apiKey,
+      offerSdp: input.offerSdp,
+      session: {
+        model: this.model,
+        voice: this.voice,
+        instructions: buildRealtimeInstructions(contextBlock),
+        tools,
+      },
+    });
+
+    await this.store.updateSession(session.id, {
+      state: 'connected',
+      providerCallId: negotiated.providerCallId,
+      lastError: null,
+    });
+    await this.store.appendEvent(session.id, {
+      type: 'session_state',
+      state: 'connected',
+    });
+
+    const sideband = new OpenAiRealtimeSideband(
+      apiKey,
+      negotiated.providerCallId,
+      (event) => this.handleSidebandEvent(session.id, event),
+      (reason) => {
+        void this.failSession(session.id, reason);
+      },
+    );
+    sideband.connect();
+    this.liveCalls.set(session.id, {
+      sessionId: session.id,
+      conversationId: session.conversationId,
+      providerCallId: negotiated.providerCallId,
+      sideband,
+      listsInstanceId: session.listsInstanceId,
+    });
+
+    return {
+      answerSdp: negotiated.answerSdp,
+      providerCallId: negotiated.providerCallId,
+    };
+  }
+
+  async setMuted(sessionId: VoiceSessionId, muted: boolean): Promise<VoiceSessionRecord | null> {
+    return this.store.updateSession(sessionId, { muted });
+  }
+
+  async heartbeat(sessionId: VoiceSessionId): Promise<VoiceSessionRecord | null> {
+    const session = await this.store.getSession(sessionId);
+    if (!session) {
+      return null;
+    }
+    session.updatedAtMs = Date.now();
+    return session;
+  }
+
+  async events(sessionId: VoiceSessionId, afterSequence: number) {
+    return this.store.eventsSince(sessionId, afterSequence);
+  }
+
+  async closeSession(sessionId: VoiceSessionId, reason = 'client_stop'): Promise<void> {
+    const live = this.liveCalls.get(sessionId);
+    if (live) {
+      live.sideband.close();
+      this.liveCalls.delete(sessionId);
+      const apiKey = this.options.envConfig.apiKey;
+      if (apiKey && live.providerCallId) {
+        await hangupOpenAiRealtimeCall({ apiKey, providerCallId: live.providerCallId });
+      }
+    }
+    await this.store.updateSession(sessionId, { state: 'closed', lastError: null });
+    await this.store.appendEvent(sessionId, { type: 'closed', reason });
+    await this.store.appendEvent(sessionId, { type: 'session_state', state: 'closed' });
+  }
+
+  private requireApiKey(): string {
+    const apiKey = this.options.envConfig.apiKey?.trim();
+    if (!apiKey) {
+      throw new Error(
+        'OPENAI_API_KEY is not configured. Set the environment variable on the agent-server host.',
+      );
+    }
+    return apiKey;
+  }
+
+  private async failSession(sessionId: VoiceSessionId, reason: string): Promise<void> {
+    const live = this.liveCalls.get(sessionId);
+    if (live) {
+      live.sideband.close();
+      this.liveCalls.delete(sessionId);
+    }
+    await this.store.updateSession(sessionId, { state: 'failed', lastError: reason });
+    await this.store.appendEvent(sessionId, {
+      type: 'error',
+      code: 'realtime_failed',
+      message: reason,
+    });
+    await this.store.appendEvent(sessionId, { type: 'session_state', state: 'failed', message: reason });
+  }
+
+  private async handleSidebandEvent(
+    sessionId: VoiceSessionId,
+    event: Record<string, unknown>,
+  ): Promise<void> {
+    const type = typeof event['type'] === 'string' ? event['type'] : '';
+    const live = this.liveCalls.get(sessionId);
+    if (!live) {
+      return;
+    }
+
+    if (type === 'response.output_audio_transcript.done' || type === 'response.audio_transcript.done') {
+      const text = typeof event['transcript'] === 'string' ? event['transcript'] : '';
+      if (text.trim()) {
+        await this.store.appendJournal(live.conversationId, {
+          kind: 'assistant_transcript',
+          text: text.trim(),
+        });
+        await this.store.appendEvent(sessionId, {
+          type: 'transcript',
+          role: 'assistant',
+          text: text.trim(),
+          final: true,
+        });
+      }
+      return;
+    }
+
+    if (type === 'conversation.item.input_audio_transcription.completed') {
+      const text = typeof event['transcript'] === 'string' ? event['transcript'] : '';
+      if (text.trim()) {
+        await this.store.appendJournal(live.conversationId, {
+          kind: 'user_transcript',
+          text: text.trim(),
+        });
+        await this.store.appendEvent(sessionId, {
+          type: 'transcript',
+          role: 'user',
+          text: text.trim(),
+          final: true,
+        });
+      }
+      return;
+    }
+
+    if (type === 'response.function_call_arguments.done') {
+      const name = typeof event['name'] === 'string' ? event['name'] : '';
+      const callId = typeof event['call_id'] === 'string' ? event['call_id'] : '';
+      const argsJson = typeof event['arguments'] === 'string' ? event['arguments'] : '{}';
+      await this.executeToolCall({
+        sessionId,
+        live,
+        name,
+        callId,
+        argsJson,
+      });
+      return;
+    }
+
+    if (type === 'error') {
+      const message =
+        typeof event['error'] === 'object' && event['error'] && 'message' in (event['error'] as object)
+          ? String((event['error'] as { message?: unknown }).message ?? 'provider_error')
+          : 'provider_error';
+      await this.store.appendEvent(sessionId, {
+        type: 'error',
+        code: 'provider_error',
+        message,
+      });
+    }
+  }
+
+  private async executeToolCall(input: {
+    sessionId: VoiceSessionId;
+    live: LiveRealtimeCall;
+    name: string;
+    callId: string;
+    argsJson: string;
+  }): Promise<void> {
+    const { sessionId, live, name, callId, argsJson } = input;
+    if (!name || !callId) {
+      return;
+    }
+
+    await this.store.appendEvent(sessionId, {
+      type: 'tool',
+      name,
+      status: 'started',
+    });
+
+    if (!isRealtimeListsTool(name) || name === 'voice_speak' || name === 'voice_ask') {
+      const denied = { error: `Tool not allowed in realtime: ${name}` };
+      live.sideband.send({
+        type: 'conversation.item.create',
+        item: {
+          type: 'function_call_output',
+          call_id: callId,
+          output: JSON.stringify(denied),
+        },
+      });
+      live.sideband.send({ type: 'response.create' });
+      await this.store.appendEvent(sessionId, {
+        type: 'tool',
+        name,
+        status: 'failed',
+        detail: 'not_allowed',
+      });
+      return;
+    }
+
+    let args: Record<string, unknown> = {};
+    try {
+      args = JSON.parse(argsJson) as Record<string, unknown>;
+    } catch {
+      args = {};
+    }
+    if (!args['instance_id'] && live.listsInstanceId) {
+      args['instance_id'] = live.listsInstanceId;
+    }
+
+    await this.store.appendJournal(live.conversationId, {
+      kind: 'tool_request',
+      toolName: name,
+      toolCallId: callId,
+      payload: args,
+    });
+
+    const toolName = pluginToolNameForRealtime(name);
+    const ctx = this.options.createToolContext(`voice:${live.conversationId}`);
+    let output: unknown;
+    try {
+      output = await this.options.toolHost.callTool(toolName, JSON.stringify(args), ctx);
+      await this.store.appendJournal(live.conversationId, {
+        kind: 'tool_result',
+        toolName: name,
+        toolCallId: callId,
+        payload: output,
+      });
+      await this.store.appendEvent(sessionId, {
+        type: 'tool',
+        name,
+        status: 'completed',
+      });
+    } catch (error) {
+      const message =
+        error instanceof ToolError
+          ? error.message
+          : error instanceof Error
+            ? error.message
+            : 'tool_failed';
+      output = { error: message };
+      await this.store.appendEvent(sessionId, {
+        type: 'tool',
+        name,
+        status: 'failed',
+        detail: message,
+      });
+    }
+
+    live.sideband.send({
+      type: 'conversation.item.create',
+      item: {
+        type: 'function_call_output',
+        call_id: callId,
+        output: JSON.stringify(output ?? {}),
+      },
+    });
+    live.sideband.send({ type: 'response.create' });
+  }
+}

--- a/packages/agent-server/src/voice/store.ts
+++ b/packages/agent-server/src/voice/store.ts
@@ -10,6 +10,7 @@ import type {
   VoiceSessionRecord,
   VoiceSessionState,
   VoiceClientEvent,
+  VoiceClientEventInput,
 } from './types';
 
 interface VoiceStoreFile {
@@ -186,10 +187,7 @@ export class VoiceStore {
     return session;
   }
 
-  pushEvent(
-    session: VoiceSessionRecord,
-    event: Omit<VoiceClientEvent, 'sequence'>,
-  ): VoiceClientEvent {
+  pushEvent(session: VoiceSessionRecord, event: VoiceClientEventInput): VoiceClientEvent {
     session.sequence += 1;
     const full = { ...event, sequence: session.sequence } as VoiceClientEvent;
     session.events.push(full);
@@ -202,7 +200,7 @@ export class VoiceStore {
 
   async appendEvent(
     sessionId: VoiceSessionId,
-    event: Omit<VoiceClientEvent, 'sequence'>,
+    event: VoiceClientEventInput,
   ): Promise<VoiceClientEvent | null> {
     await this.init();
     const session = this.data.sessions.find((s) => s.id === sessionId);

--- a/packages/agent-server/src/voice/store.ts
+++ b/packages/agent-server/src/voice/store.ts
@@ -1,0 +1,259 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import type {
+  VoiceConversationId,
+  VoiceConversationRecord,
+  VoiceJournalEntry,
+  VoiceSessionId,
+  VoiceSessionRecord,
+  VoiceSessionState,
+  VoiceClientEvent,
+} from './types';
+
+interface VoiceStoreFile {
+  conversations: VoiceConversationRecord[];
+  sessions: VoiceSessionRecord[];
+}
+
+export class VoiceStore {
+  private readonly filePath: string;
+  private data: VoiceStoreFile = { conversations: [], sessions: [] };
+  private loaded = false;
+  private writeChain: Promise<void> = Promise.resolve();
+
+  constructor(dataDir: string) {
+    this.filePath = path.join(dataDir, 'voice-realtime.json');
+  }
+
+  async init(): Promise<void> {
+    if (this.loaded) {
+      return;
+    }
+    try {
+      const raw = await fs.readFile(this.filePath, 'utf8');
+      const parsed = JSON.parse(raw) as VoiceStoreFile;
+      this.data = {
+        conversations: Array.isArray(parsed.conversations) ? parsed.conversations : [],
+        sessions: Array.isArray(parsed.sessions) ? parsed.sessions : [],
+      };
+    } catch {
+      this.data = { conversations: [], sessions: [] };
+    }
+    this.loaded = true;
+  }
+
+  async listConversations(): Promise<VoiceConversationRecord[]> {
+    await this.init();
+    return [...this.data.conversations].sort((a, b) => b.updatedAtMs - a.updatedAtMs);
+  }
+
+  async getConversation(id: VoiceConversationId): Promise<VoiceConversationRecord | null> {
+    await this.init();
+    return this.data.conversations.find((c) => c.id === id) ?? null;
+  }
+
+  async getOrCreateConversation(options: {
+    conversationId?: string | null;
+    listsInstanceId?: string;
+  }): Promise<VoiceConversationRecord> {
+    await this.init();
+    const existingId = options.conversationId?.trim() ?? '';
+    if (existingId) {
+      const existing = await this.getConversation(existingId);
+      if (existing) {
+        return existing;
+      }
+    }
+    const now = Date.now();
+    const record: VoiceConversationRecord = {
+      id: existingId || randomUUID(),
+      createdAtMs: now,
+      updatedAtMs: now,
+      title: 'Realtime voice',
+      listsInstanceId: options.listsInstanceId?.trim() || 'default',
+      journal: [],
+      activeSessionId: null,
+    };
+    this.data.conversations.push(record);
+    await this.persist();
+    return record;
+  }
+
+  async appendJournal(
+    conversationId: VoiceConversationId,
+    entry: Omit<VoiceJournalEntry, 'id' | 'atMs'> & { id?: string; atMs?: number },
+  ): Promise<VoiceJournalEntry | null> {
+    await this.init();
+    const conversation = this.data.conversations.find((c) => c.id === conversationId);
+    if (!conversation) {
+      return null;
+    }
+    const full: VoiceJournalEntry = {
+      id: entry.id ?? randomUUID(),
+      atMs: entry.atMs ?? Date.now(),
+      kind: entry.kind,
+      ...(entry.text !== undefined ? { text: entry.text } : {}),
+      ...(entry.toolName !== undefined ? { toolName: entry.toolName } : {}),
+      ...(entry.toolCallId !== undefined ? { toolCallId: entry.toolCallId } : {}),
+      ...(entry.payload !== undefined ? { payload: entry.payload } : {}),
+    };
+    conversation.journal.push(full);
+    // Bound journal size for v1.
+    if (conversation.journal.length > 200) {
+      conversation.journal = conversation.journal.slice(-200);
+    }
+    conversation.updatedAtMs = full.atMs;
+    await this.persist();
+    return full;
+  }
+
+  async createSession(options: {
+    conversationId: VoiceConversationId;
+    listsInstanceId: string;
+  }): Promise<VoiceSessionRecord> {
+    await this.init();
+    const conversation = this.data.conversations.find((c) => c.id === options.conversationId);
+    if (!conversation) {
+      throw new Error('Conversation not found');
+    }
+    // Single active session per conversation.
+    if (conversation.activeSessionId) {
+      const prior = this.data.sessions.find((s) => s.id === conversation.activeSessionId);
+      if (prior && prior.state !== 'closed' && prior.state !== 'failed') {
+        prior.state = 'closed';
+        prior.updatedAtMs = Date.now();
+        prior.lastError = 'replaced_by_new_session';
+        this.pushEvent(prior, { type: 'closed', reason: 'replaced_by_new_session' });
+      }
+    }
+    const now = Date.now();
+    const session: VoiceSessionRecord = {
+      id: randomUUID(),
+      conversationId: options.conversationId,
+      createdAtMs: now,
+      updatedAtMs: now,
+      state: 'created',
+      muted: false,
+      listsInstanceId: options.listsInstanceId,
+      providerCallId: null,
+      lastError: null,
+      sequence: 0,
+      events: [],
+    };
+    this.data.sessions.push(session);
+    conversation.activeSessionId = session.id;
+    conversation.updatedAtMs = now;
+    this.pushEvent(session, { type: 'session_state', state: 'created' });
+    await this.persist();
+    return session;
+  }
+
+  async getSession(id: VoiceSessionId): Promise<VoiceSessionRecord | null> {
+    await this.init();
+    return this.data.sessions.find((s) => s.id === id) ?? null;
+  }
+
+  async updateSession(
+    id: VoiceSessionId,
+    patch: Partial<
+      Pick<VoiceSessionRecord, 'state' | 'muted' | 'providerCallId' | 'lastError' | 'listsInstanceId'>
+    >,
+  ): Promise<VoiceSessionRecord | null> {
+    await this.init();
+    const session = this.data.sessions.find((s) => s.id === id);
+    if (!session) {
+      return null;
+    }
+    if (patch.state !== undefined) {
+      session.state = patch.state;
+    }
+    if (patch.muted !== undefined) {
+      session.muted = patch.muted;
+    }
+    if (patch.providerCallId !== undefined) {
+      session.providerCallId = patch.providerCallId;
+    }
+    if (patch.lastError !== undefined) {
+      session.lastError = patch.lastError;
+    }
+    if (patch.listsInstanceId !== undefined) {
+      session.listsInstanceId = patch.listsInstanceId;
+    }
+    session.updatedAtMs = Date.now();
+    await this.persist();
+    return session;
+  }
+
+  pushEvent(
+    session: VoiceSessionRecord,
+    event: Omit<VoiceClientEvent, 'sequence'>,
+  ): VoiceClientEvent {
+    session.sequence += 1;
+    const full = { ...event, sequence: session.sequence } as VoiceClientEvent;
+    session.events.push(full);
+    if (session.events.length > 500) {
+      session.events = session.events.slice(-500);
+    }
+    session.updatedAtMs = Date.now();
+    return full;
+  }
+
+  async appendEvent(
+    sessionId: VoiceSessionId,
+    event: Omit<VoiceClientEvent, 'sequence'>,
+  ): Promise<VoiceClientEvent | null> {
+    await this.init();
+    const session = this.data.sessions.find((s) => s.id === sessionId);
+    if (!session) {
+      return null;
+    }
+    const full = this.pushEvent(session, event);
+    await this.persist();
+    return full;
+  }
+
+  async eventsSince(sessionId: VoiceSessionId, afterSequence: number): Promise<VoiceClientEvent[]> {
+    await this.init();
+    const session = this.data.sessions.find((s) => s.id === sessionId);
+    if (!session) {
+      return [];
+    }
+    return session.events.filter((e) => e.sequence > afterSequence);
+  }
+
+  recentJournalText(conversation: VoiceConversationRecord, maxEntries = 24): string {
+    const slice = conversation.journal.slice(-maxEntries);
+    return slice
+      .map((entry) => {
+        if (entry.kind === 'user_transcript') {
+          return `User: ${entry.text ?? ''}`;
+        }
+        if (entry.kind === 'assistant_transcript') {
+          return `Assistant: ${entry.text ?? ''}`;
+        }
+        if (entry.kind === 'tool_request') {
+          return `Tool call ${entry.toolName ?? ''}: ${JSON.stringify(entry.payload ?? {})}`;
+        }
+        if (entry.kind === 'tool_result') {
+          return `Tool result ${entry.toolName ?? ''}: ${JSON.stringify(entry.payload ?? {})}`;
+        }
+        return entry.text ? `System: ${entry.text}` : '';
+      })
+      .filter((line) => line.trim().length > 0)
+      .join('\n');
+  }
+
+  private async persist(): Promise<void> {
+    this.writeChain = this.writeChain.then(async () => {
+      await fs.mkdir(path.dirname(this.filePath), { recursive: true });
+      const tmp = `${this.filePath}.${process.pid}.tmp`;
+      await fs.writeFile(tmp, JSON.stringify(this.data, null, 2), 'utf8');
+      await fs.rename(tmp, this.filePath);
+    });
+    await this.writeChain;
+  }
+}
+
+export type { VoiceSessionState };

--- a/packages/agent-server/src/voice/store.ts
+++ b/packages/agent-server/src/voice/store.ts
@@ -221,6 +221,33 @@ export class VoiceStore {
     return session.events.filter((e) => e.sequence > afterSequence);
   }
 
+  /**
+   * Drop oldest closed/failed sessions beyond {@code maxTerminal}, keeping active ones.
+   * Also clears activeSessionId on conversations that pointed at pruned sessions.
+   */
+  async pruneTerminalSessions(maxTerminal: number): Promise<number> {
+    await this.init();
+    if (maxTerminal < 0) {
+      return 0;
+    }
+    const terminal = this.data.sessions
+      .filter((s) => s.state === 'closed' || s.state === 'failed')
+      .sort((a, b) => a.updatedAtMs - b.updatedAtMs);
+    const overflow = terminal.length - maxTerminal;
+    if (overflow <= 0) {
+      return 0;
+    }
+    const toRemove = new Set(terminal.slice(0, overflow).map((s) => s.id));
+    this.data.sessions = this.data.sessions.filter((s) => !toRemove.has(s.id));
+    for (const conversation of this.data.conversations) {
+      if (conversation.activeSessionId && toRemove.has(conversation.activeSessionId)) {
+        conversation.activeSessionId = null;
+      }
+    }
+    await this.persist();
+    return toRemove.size;
+  }
+
   recentJournalText(conversation: VoiceConversationRecord, maxEntries = 24): string {
     const slice = conversation.journal.slice(-maxEntries);
     return slice

--- a/packages/agent-server/src/voice/types.ts
+++ b/packages/agent-server/src/voice/types.ts
@@ -50,6 +50,13 @@ export type VoiceClientEvent =
   | { sequence: number; type: 'error'; code: string; message: string }
   | { sequence: number; type: 'closed'; reason: string };
 
+/** Distributive omit — plain Omit collapses union keys and drops event-specific fields. */
+export type VoiceClientEventInput = VoiceClientEvent extends infer Event
+  ? Event extends { sequence: number }
+    ? Omit<Event, 'sequence'>
+    : never
+  : never;
+
 export interface VoiceCapabilities {
   agentRealtime: {
     status: 'ready' | 'not-configured' | 'disabled';

--- a/packages/agent-server/src/voice/types.ts
+++ b/packages/agent-server/src/voice/types.ts
@@ -1,0 +1,73 @@
+export type VoiceConversationId = string;
+export type VoiceSessionId = string;
+
+export type VoiceSessionState =
+  | 'created'
+  | 'connecting'
+  | 'connected'
+  | 'closing'
+  | 'closed'
+  | 'failed';
+
+export interface VoiceJournalEntry {
+  id: string;
+  atMs: number;
+  kind: 'user_transcript' | 'assistant_transcript' | 'tool_request' | 'tool_result' | 'error' | 'system';
+  text?: string;
+  toolName?: string;
+  toolCallId?: string;
+  payload?: unknown;
+}
+
+export interface VoiceConversationRecord {
+  id: VoiceConversationId;
+  createdAtMs: number;
+  updatedAtMs: number;
+  title: string;
+  listsInstanceId: string;
+  journal: VoiceJournalEntry[];
+  activeSessionId: VoiceSessionId | null;
+}
+
+export interface VoiceSessionRecord {
+  id: VoiceSessionId;
+  conversationId: VoiceConversationId;
+  createdAtMs: number;
+  updatedAtMs: number;
+  state: VoiceSessionState;
+  muted: boolean;
+  listsInstanceId: string;
+  providerCallId: string | null;
+  lastError: string | null;
+  sequence: number;
+  events: VoiceClientEvent[];
+}
+
+export type VoiceClientEvent =
+  | { sequence: number; type: 'session_state'; state: VoiceSessionState; message?: string }
+  | { sequence: number; type: 'transcript'; role: 'user' | 'assistant'; text: string; final: boolean }
+  | { sequence: number; type: 'tool'; name: string; status: 'started' | 'completed' | 'failed'; detail?: string }
+  | { sequence: number; type: 'error'; code: string; message: string }
+  | { sequence: number; type: 'closed'; reason: string };
+
+export interface VoiceCapabilities {
+  agentRealtime: {
+    status: 'ready' | 'not-configured' | 'disabled';
+    model: string;
+    voice: string;
+  };
+}
+
+export interface RealtimeSessionConfig {
+  model: string;
+  voice: string;
+  instructions: string;
+  tools: RealtimeFunctionTool[];
+}
+
+export interface RealtimeFunctionTool {
+  type: 'function';
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+}

--- a/packages/mobile-web/android/app/build.gradle
+++ b/packages/mobile-web/android/app/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
     implementation "androidx.media:media:$androidxMediaVersion"
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
+    implementation "io.getstream:stream-webrtc-android:$streamWebRtcVersion"
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.json:json:20240303"

--- a/packages/mobile-web/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile-web/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -59,6 +60,7 @@
             android:name=".voice.AssistantVoiceRuntimeService"
             android:enabled="true"
             android:exported="false"
+            android:stopWithTask="false"
             android:foregroundServiceType="mediaPlayback|microphone"
         />
     </application>

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceAudioRouter.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceAudioRouter.java
@@ -1,0 +1,345 @@
+package com.assistant.mobile.voice;
+
+import android.content.Context;
+import android.media.AudioAttributes;
+import android.media.AudioFocusRequest;
+import android.media.AudioManager;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+
+/**
+ * Single process-local coordinator for AudioManager mode, Bluetooth SCO, and audio focus.
+ * Thread (PcmPlayer / MicStreamer) and future Realtime (WebRTC ADM) must route shared policy here.
+ *
+ * Device objects remain owner-specific (PcmPlayer tracks vs WebRTC ADM). This class only owns
+ * mode / focus / SCO so two capture paths never fight global AudioManager state.
+ */
+final class AssistantVoiceAudioRouter {
+    private static final String TAG = "AssistantVoiceAudioRouter";
+
+    enum FocusKind {
+        NONE,
+        PLAYBACK,
+        CAPTURE,
+        REALTIME
+    }
+
+    interface FocusListener {
+        void onFocusLost(long ownerGeneration, boolean permanent);
+        void onFocusGained(long ownerGeneration);
+        void onFocusCanDuck(long ownerGeneration);
+    }
+
+    private final AudioManager audioManager;
+    private final Handler mainHandler;
+    private final Object lock = new Object();
+
+    private FocusListener focusListener;
+    private long activeOwnerGeneration = 0L;
+    private FocusKind focusKind = FocusKind.NONE;
+    private boolean communicationModeActive = false;
+    private boolean scoStarted = false;
+    private AudioFocusRequest playbackFocusRequest;
+    private AudioFocusRequest captureFocusRequest;
+    private AudioFocusRequest realtimeFocusRequest;
+
+    AssistantVoiceAudioRouter(Context context) {
+        Context app = context == null ? null : context.getApplicationContext();
+        audioManager = app == null ? null : app.getSystemService(AudioManager.class);
+        mainHandler = app == null ? null : new Handler(Looper.getMainLooper());
+        buildFocusRequests();
+    }
+
+    void setFocusListener(FocusListener listener) {
+        synchronized (lock) {
+            focusListener = listener;
+        }
+    }
+
+    long activeOwnerGeneration() {
+        synchronized (lock) {
+            return activeOwnerGeneration;
+        }
+    }
+
+    FocusKind focusKind() {
+        synchronized (lock) {
+            return focusKind;
+        }
+    }
+
+    boolean isCommunicationModeActive() {
+        synchronized (lock) {
+            return communicationModeActive;
+        }
+    }
+
+    boolean requestPlaybackFocus(long ownerGeneration) {
+        synchronized (lock) {
+            if (audioManager == null) {
+                activeOwnerGeneration = ownerGeneration;
+                focusKind = FocusKind.PLAYBACK;
+                return true;
+            }
+            if (focusKind == FocusKind.PLAYBACK && activeOwnerGeneration == ownerGeneration) {
+                return true;
+            }
+            abandonFocusLocked();
+            activeOwnerGeneration = ownerGeneration;
+            boolean granted = requestFocusLocked(playbackFocusRequest, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT);
+            focusKind = granted ? FocusKind.PLAYBACK : FocusKind.NONE;
+            if (!granted) {
+                activeOwnerGeneration = 0L;
+            }
+            return granted;
+        }
+    }
+
+    boolean requestCaptureFocus(long ownerGeneration) {
+        synchronized (lock) {
+            if (audioManager == null) {
+                activeOwnerGeneration = ownerGeneration;
+                focusKind = FocusKind.CAPTURE;
+                return true;
+            }
+            if (focusKind == FocusKind.CAPTURE && activeOwnerGeneration == ownerGeneration) {
+                return true;
+            }
+            abandonFocusLocked();
+            activeOwnerGeneration = ownerGeneration;
+            boolean granted =
+                requestFocusLocked(captureFocusRequest, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE);
+            focusKind = granted ? FocusKind.CAPTURE : FocusKind.NONE;
+            if (!granted) {
+                activeOwnerGeneration = 0L;
+            }
+            return granted;
+        }
+    }
+
+    boolean requestRealtimeFocus(long ownerGeneration) {
+        synchronized (lock) {
+            if (audioManager == null) {
+                activeOwnerGeneration = ownerGeneration;
+                focusKind = FocusKind.REALTIME;
+                return true;
+            }
+            if (focusKind == FocusKind.REALTIME && activeOwnerGeneration == ownerGeneration) {
+                return true;
+            }
+            abandonFocusLocked();
+            activeOwnerGeneration = ownerGeneration;
+            boolean granted =
+                requestFocusLocked(realtimeFocusRequest, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT);
+            focusKind = granted ? FocusKind.REALTIME : FocusKind.NONE;
+            if (!granted) {
+                activeOwnerGeneration = 0L;
+            }
+            return granted;
+        }
+    }
+
+    void abandonFocus(long ownerGeneration) {
+        synchronized (lock) {
+            if (ownerGeneration != 0L && ownerGeneration != activeOwnerGeneration) {
+                return;
+            }
+            abandonFocusLocked();
+        }
+    }
+
+    void enterCommunicationMode(long ownerGeneration) {
+        synchronized (lock) {
+            if (ownerGeneration != 0L) {
+                activeOwnerGeneration = ownerGeneration;
+            }
+            if (audioManager == null || communicationModeActive) {
+                communicationModeActive = audioManager != null || communicationModeActive;
+                return;
+            }
+            try {
+                audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
+                audioManager.setBluetoothScoOn(true);
+                audioManager.startBluetoothSco();
+                scoStarted = true;
+                communicationModeActive = true;
+            } catch (Exception error) {
+                Log.w(TAG, "failed to enter communication mode", error);
+            }
+        }
+    }
+
+    void leaveCommunicationMode(long ownerGeneration) {
+        synchronized (lock) {
+            if (ownerGeneration != 0L
+                && activeOwnerGeneration != 0L
+                && ownerGeneration != activeOwnerGeneration) {
+                return;
+            }
+            leaveCommunicationModeLocked();
+        }
+    }
+
+    /**
+     * Thread → Realtime / full release order:
+     * leave SCO + MODE_NORMAL, abandon focus. Caller advances generation after quiescence.
+     */
+    void releaseAll(long ownerGeneration) {
+        synchronized (lock) {
+            if (ownerGeneration != 0L
+                && activeOwnerGeneration != 0L
+                && ownerGeneration != activeOwnerGeneration) {
+                return;
+            }
+            leaveCommunicationModeLocked();
+            abandonFocusLocked();
+        }
+    }
+
+    void shutdown() {
+        synchronized (lock) {
+            leaveCommunicationModeLocked();
+            abandonFocusLocked();
+            focusListener = null;
+        }
+    }
+
+    private void buildFocusRequests() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O || audioManager == null || mainHandler == null) {
+            playbackFocusRequest = null;
+            captureFocusRequest = null;
+            realtimeFocusRequest = null;
+            return;
+        }
+        AudioManager.OnAudioFocusChangeListener listener = this::dispatchFocusChange;
+        playbackFocusRequest = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
+            .setAudioAttributes(
+                new AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_MEDIA)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build()
+            )
+            .setWillPauseWhenDucked(true)
+            .setOnAudioFocusChangeListener(listener, mainHandler)
+            .build();
+        captureFocusRequest =
+            new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE)
+                .setAudioAttributes(
+                    new AudioAttributes.Builder()
+                        .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                        .build()
+                )
+                .setWillPauseWhenDucked(true)
+                .setOnAudioFocusChangeListener(listener, mainHandler)
+                .build();
+        // Realtime / in-call arming cues share voice-comm usage so they do not fight the call.
+        realtimeFocusRequest = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
+            .setAudioAttributes(
+                new AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build()
+            )
+            .setWillPauseWhenDucked(true)
+            .setOnAudioFocusChangeListener(listener, mainHandler)
+            .build();
+    }
+
+    private void dispatchFocusChange(int change) {
+        long generation;
+        FocusListener listener;
+        synchronized (lock) {
+            generation = activeOwnerGeneration;
+            listener = focusListener;
+        }
+        if (listener == null || generation == 0L) {
+            return;
+        }
+        switch (change) {
+            case AudioManager.AUDIOFOCUS_LOSS:
+            case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
+                listener.onFocusLost(generation, change == AudioManager.AUDIOFOCUS_LOSS);
+                break;
+            case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
+                listener.onFocusCanDuck(generation);
+                break;
+            case AudioManager.AUDIOFOCUS_GAIN:
+                listener.onFocusGained(generation);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private boolean requestFocusLocked(AudioFocusRequest request, int legacyFocusGain) {
+        if (audioManager == null) {
+            return true;
+        }
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && request != null) {
+                return audioManager.requestAudioFocus(request) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
+            }
+            @SuppressWarnings("deprecation")
+            int result = audioManager.requestAudioFocus(
+                null,
+                AudioManager.STREAM_MUSIC,
+                legacyFocusGain
+            );
+            return result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
+        } catch (Exception error) {
+            Log.w(TAG, "requestAudioFocus failed", error);
+            return false;
+        }
+    }
+
+    private void abandonFocusLocked() {
+        if (audioManager == null) {
+            focusKind = FocusKind.NONE;
+            activeOwnerGeneration = 0L;
+            return;
+        }
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                if (focusKind == FocusKind.PLAYBACK && playbackFocusRequest != null) {
+                    audioManager.abandonAudioFocusRequest(playbackFocusRequest);
+                } else if (focusKind == FocusKind.CAPTURE && captureFocusRequest != null) {
+                    audioManager.abandonAudioFocusRequest(captureFocusRequest);
+                } else if (focusKind == FocusKind.REALTIME && realtimeFocusRequest != null) {
+                    audioManager.abandonAudioFocusRequest(realtimeFocusRequest);
+                }
+            } else {
+                @SuppressWarnings("deprecation")
+                int ignored = audioManager.abandonAudioFocus(null);
+            }
+        } catch (Exception error) {
+            Log.w(TAG, "abandonAudioFocus failed", error);
+        }
+        focusKind = FocusKind.NONE;
+        activeOwnerGeneration = 0L;
+    }
+
+    private void leaveCommunicationModeLocked() {
+        if (audioManager == null) {
+            communicationModeActive = false;
+            scoStarted = false;
+            return;
+        }
+        if (!communicationModeActive && !scoStarted) {
+            return;
+        }
+        try {
+            if (scoStarted) {
+                audioManager.stopBluetoothSco();
+                audioManager.setBluetoothScoOn(false);
+            }
+            audioManager.setMode(AudioManager.MODE_NORMAL);
+        } catch (Exception error) {
+            Log.w(TAG, "failed to leave communication mode", error);
+        }
+        scoStarted = false;
+        communicationModeActive = false;
+    }
+}

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceConfig.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceConfig.java
@@ -21,6 +21,9 @@ final class AssistantVoiceConfig {
     static final String AUDIO_MODE_TOOL = "tool";
     static final String AUDIO_MODE_RESPONSE = "response";
     static final String DEFAULT_AUDIO_MODE = AUDIO_MODE_TOOL;
+    static final String RUNTIME_MODE_THREAD = "thread";
+    static final String RUNTIME_MODE_REALTIME = "realtime";
+    static final String DEFAULT_RUNTIME_MODE = RUNTIME_MODE_THREAD;
     static final int DEFAULT_RECOGNITION_START_TIMEOUT_MS = 30000;
     static final int DEFAULT_RECOGNITION_COMPLETION_TIMEOUT_MS = 60000;
     static final int DEFAULT_RECOGNITION_END_SILENCE_MS = 1200;
@@ -42,6 +45,7 @@ final class AssistantVoiceConfig {
 
     private static final String PREFS_NAME = "assistant_voice_runtime";
     private static final String KEY_AUDIO_MODE = "audio_mode";
+    private static final String KEY_RUNTIME_MODE = "voice_runtime_mode";
     private static final String KEY_AUTO_LISTEN_ENABLED = "auto_listen_enabled";
     private static final String KEY_RECOGNITION_START_TIMEOUT_MS = "recognition_start_timeout_ms";
     private static final String KEY_RECOGNITION_COMPLETION_TIMEOUT_MS = "recognition_completion_timeout_ms";
@@ -73,6 +77,7 @@ final class AssistantVoiceConfig {
     private static final String KEY_RUNTIME_ACTIVE_DISPLAY_TITLE = "runtime_active_display_title";
 
     static final String EXTRA_AUDIO_MODE = "audioMode";
+    static final String EXTRA_RUNTIME_MODE = "voiceRuntimeMode";
     static final String EXTRA_AUTO_LISTEN_ENABLED = "autoListenEnabled";
     static final String EXTRA_SELECTED_MIC_DEVICE_ID = "selectedMicDeviceId";
     static final String EXTRA_RECOGNITION_START_TIMEOUT_MS = "recognitionStartTimeoutMs";
@@ -99,6 +104,7 @@ final class AssistantVoiceConfig {
         "notificationTitlePlaybackEnabled";
 
     final String audioMode;
+    final String voiceRuntimeMode;
     final boolean autoListenEnabled;
     final String selectedMicDeviceId;
     final int recognitionStartTimeoutMs;
@@ -125,6 +131,7 @@ final class AssistantVoiceConfig {
 
     AssistantVoiceConfig(
         String audioMode,
+        String voiceRuntimeMode,
         boolean autoListenEnabled,
         String selectedMicDeviceId,
         int recognitionStartTimeoutMs,
@@ -150,6 +157,7 @@ final class AssistantVoiceConfig {
         boolean notificationTitlePlaybackEnabled
     ) {
         this.audioMode = normalizeAudioMode(audioMode);
+        this.voiceRuntimeMode = AssistantVoiceControllerPolicy.normalizeRuntimeMode(voiceRuntimeMode);
         this.autoListenEnabled = autoListenEnabled;
         this.selectedMicDeviceId = normalizeOptional(selectedMicDeviceId);
         this.recognitionStartTimeoutMs = normalizePositiveInt(
@@ -200,6 +208,7 @@ final class AssistantVoiceConfig {
         SharedPreferences prefs = prefs(context);
         return new AssistantVoiceConfig(
             prefs.getString(KEY_AUDIO_MODE, DEFAULT_AUDIO_MODE),
+            prefs.getString(KEY_RUNTIME_MODE, DEFAULT_RUNTIME_MODE),
             prefs.getBoolean(KEY_AUTO_LISTEN_ENABLED, true),
             prefs.getString(KEY_SELECTED_MIC_DEVICE_ID, null),
             prefs.getInt(KEY_RECOGNITION_START_TIMEOUT_MS, DEFAULT_RECOGNITION_START_TIMEOUT_MS),
@@ -242,6 +251,7 @@ final class AssistantVoiceConfig {
         prefs(context)
             .edit()
             .putString(KEY_AUDIO_MODE, config.audioMode)
+            .putString(KEY_RUNTIME_MODE, config.voiceRuntimeMode)
             .putBoolean(KEY_AUTO_LISTEN_ENABLED, config.autoListenEnabled)
             .putString(KEY_SELECTED_MIC_DEVICE_ID, emptyToNull(config.selectedMicDeviceId))
             .putInt(KEY_RECOGNITION_START_TIMEOUT_MS, config.recognitionStartTimeoutMs)
@@ -285,6 +295,9 @@ final class AssistantVoiceConfig {
             intent.hasExtra(EXTRA_AUDIO_MODE)
                 ? intent.getStringExtra(EXTRA_AUDIO_MODE)
                 : fallback.audioMode,
+            intent.hasExtra(EXTRA_RUNTIME_MODE)
+                ? intent.getStringExtra(EXTRA_RUNTIME_MODE)
+                : fallback.voiceRuntimeMode,
             intent.getBooleanExtra(EXTRA_AUTO_LISTEN_ENABLED, fallback.autoListenEnabled),
             intent.hasExtra(EXTRA_SELECTED_MIC_DEVICE_ID)
                 ? intent.getStringExtra(EXTRA_SELECTED_MIC_DEVICE_ID)
@@ -356,6 +369,7 @@ final class AssistantVoiceConfig {
 
     Intent applyToIntent(Intent intent) {
         intent.putExtra(EXTRA_AUDIO_MODE, audioMode);
+        intent.putExtra(EXTRA_RUNTIME_MODE, voiceRuntimeMode);
         intent.putExtra(EXTRA_AUTO_LISTEN_ENABLED, autoListenEnabled);
         intent.putExtra(EXTRA_SELECTED_MIC_DEVICE_ID, emptyToNull(selectedMicDeviceId));
         intent.putExtra(EXTRA_RECOGNITION_START_TIMEOUT_MS, recognitionStartTimeoutMs);
@@ -518,6 +532,10 @@ final class AssistantVoiceConfig {
         return AUDIO_MODE_RESPONSE.equals(audioMode);
     }
 
+    boolean isRealtimeRuntimeMode() {
+        return AssistantVoiceControllerPolicy.isRealtimeRuntimeMode(voiceRuntimeMode);
+    }
+
     boolean allowsNotificationPlay() {
         return !AUDIO_MODE_OFF.equals(audioMode);
     }
@@ -529,6 +547,7 @@ final class AssistantVoiceConfig {
     AssistantVoiceConfig withSelection(String panelId, String sessionId) {
         return new AssistantVoiceConfig(
             audioMode,
+            voiceRuntimeMode,
             autoListenEnabled,
             selectedMicDeviceId,
             recognitionStartTimeoutMs,
@@ -558,6 +577,7 @@ final class AssistantVoiceConfig {
     AssistantVoiceConfig withAssistantBaseUrl(String url) {
         return new AssistantVoiceConfig(
             audioMode,
+            voiceRuntimeMode,
             autoListenEnabled,
             selectedMicDeviceId,
             recognitionStartTimeoutMs,
@@ -594,6 +614,7 @@ final class AssistantVoiceConfig {
         }
         AssistantVoiceConfig config = (AssistantVoiceConfig) other;
         return Objects.equals(audioMode, config.audioMode)
+            && Objects.equals(voiceRuntimeMode, config.voiceRuntimeMode)
             && autoListenEnabled == config.autoListenEnabled
             && Objects.equals(selectedMicDeviceId, config.selectedMicDeviceId)
             && recognitionStartTimeoutMs == config.recognitionStartTimeoutMs
@@ -623,6 +644,7 @@ final class AssistantVoiceConfig {
     public int hashCode() {
         return Objects.hash(
             audioMode,
+            voiceRuntimeMode,
             autoListenEnabled,
             selectedMicDeviceId,
             recognitionStartTimeoutMs,
@@ -655,6 +677,7 @@ final class AssistantVoiceConfig {
         }
         return new AssistantVoiceConfig(
             settings.optString("audioMode", audioMode),
+            settings.optString("voiceRuntimeMode", voiceRuntimeMode),
             settings.optBoolean("autoListenEnabled", autoListenEnabled),
             settings.optString("selectedMicDeviceId", selectedMicDeviceId),
             settings.optInt("recognitionStartTimeoutMs", recognitionStartTimeoutMs),
@@ -693,6 +716,7 @@ final class AssistantVoiceConfig {
     AssistantVoiceConfig withInputContext(boolean enabled, String contextLine) {
         return new AssistantVoiceConfig(
             audioMode,
+            voiceRuntimeMode,
             autoListenEnabled,
             selectedMicDeviceId,
             recognitionStartTimeoutMs,
@@ -722,6 +746,7 @@ final class AssistantVoiceConfig {
     AssistantVoiceConfig withWatchedSessionIds(List<String> sessionIds) {
         return new AssistantVoiceConfig(
             audioMode,
+            voiceRuntimeMode,
             autoListenEnabled,
             selectedMicDeviceId,
             recognitionStartTimeoutMs,
@@ -751,6 +776,7 @@ final class AssistantVoiceConfig {
     AssistantVoiceConfig withPreferredVoiceSessionId(String sessionId) {
         return new AssistantVoiceConfig(
             audioMode,
+            voiceRuntimeMode,
             autoListenEnabled,
             selectedMicDeviceId,
             recognitionStartTimeoutMs,
@@ -780,6 +806,7 @@ final class AssistantVoiceConfig {
     AssistantVoiceConfig withSessionTitles(JSONObject titles) {
         return new AssistantVoiceConfig(
             audioMode,
+            voiceRuntimeMode,
             autoListenEnabled,
             selectedMicDeviceId,
             recognitionStartTimeoutMs,
@@ -809,6 +836,7 @@ final class AssistantVoiceConfig {
     AssistantVoiceConfig withMediaButtonsEnabled(boolean enabled) {
         return new AssistantVoiceConfig(
             audioMode,
+            voiceRuntimeMode,
             autoListenEnabled,
             selectedMicDeviceId,
             recognitionStartTimeoutMs,
@@ -838,6 +866,7 @@ final class AssistantVoiceConfig {
     AssistantVoiceConfig withAudioMode(String mode) {
         return new AssistantVoiceConfig(
             mode,
+            voiceRuntimeMode,
             autoListenEnabled,
             selectedMicDeviceId,
             recognitionStartTimeoutMs,

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceConfig.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceConfig.java
@@ -42,6 +42,8 @@ final class AssistantVoiceConfig {
     static final boolean DEFAULT_TTS_PREFERRED_SESSION_ONLY = false;
     static final boolean DEFAULT_STANDALONE_NOTIFICATION_PLAYBACK_ENABLED = true;
     static final boolean DEFAULT_NOTIFICATION_TITLE_PLAYBACK_ENABLED = false;
+    static final boolean DEFAULT_REALTIME_MUTE_ON_START = false;
+    static final String DEFAULT_REALTIME_LISTS_INSTANCE_ID = "default";
 
     private static final String PREFS_NAME = "assistant_voice_runtime";
     private static final String KEY_AUDIO_MODE = "audio_mode";
@@ -71,6 +73,9 @@ final class AssistantVoiceConfig {
         "standalone_notification_playback_enabled";
     private static final String KEY_NOTIFICATION_TITLE_PLAYBACK_ENABLED =
         "notification_title_playback_enabled";
+    private static final String KEY_REALTIME_CONVERSATION_ID = "realtime_conversation_id";
+    private static final String KEY_REALTIME_MUTE_ON_START = "realtime_mute_on_start";
+    private static final String KEY_REALTIME_LISTS_INSTANCE_ID = "realtime_lists_instance_id";
     private static final String KEY_RUNTIME_STATE = "runtime_state";
     private static final String KEY_RUNTIME_ERROR = "runtime_error";
     private static final String KEY_RUNTIME_ACTIVE_SESSION_ID = "runtime_active_session_id";
@@ -102,6 +107,9 @@ final class AssistantVoiceConfig {
         "standaloneNotificationPlaybackEnabled";
     static final String EXTRA_NOTIFICATION_TITLE_PLAYBACK_ENABLED =
         "notificationTitlePlaybackEnabled";
+    static final String EXTRA_REALTIME_CONVERSATION_ID = "realtimeConversationId";
+    static final String EXTRA_REALTIME_MUTE_ON_START = "realtimeMuteOnStart";
+    static final String EXTRA_REALTIME_LISTS_INSTANCE_ID = "realtimeListsInstanceId";
 
     final String audioMode;
     final String voiceRuntimeMode;
@@ -128,6 +136,9 @@ final class AssistantVoiceConfig {
     final boolean ttsPreferredSessionOnly;
     final boolean standaloneNotificationPlaybackEnabled;
     final boolean notificationTitlePlaybackEnabled;
+    final String realtimeConversationId;
+    final boolean realtimeMuteOnStart;
+    final String realtimeListsInstanceId;
 
     AssistantVoiceConfig(
         String audioMode,
@@ -154,7 +165,10 @@ final class AssistantVoiceConfig {
         boolean mediaButtonsEnabled,
         boolean ttsPreferredSessionOnly,
         boolean standaloneNotificationPlaybackEnabled,
-        boolean notificationTitlePlaybackEnabled
+        boolean notificationTitlePlaybackEnabled,
+        String realtimeConversationId,
+        boolean realtimeMuteOnStart,
+        String realtimeListsInstanceId
     ) {
         this.audioMode = normalizeAudioMode(audioMode);
         this.voiceRuntimeMode = AssistantVoiceControllerPolicy.normalizeRuntimeMode(voiceRuntimeMode);
@@ -202,6 +216,12 @@ final class AssistantVoiceConfig {
         this.ttsPreferredSessionOnly = ttsPreferredSessionOnly;
         this.standaloneNotificationPlaybackEnabled = standaloneNotificationPlaybackEnabled;
         this.notificationTitlePlaybackEnabled = notificationTitlePlaybackEnabled;
+        this.realtimeConversationId = normalizeOptional(realtimeConversationId);
+        this.realtimeMuteOnStart = realtimeMuteOnStart;
+        String listsInstance = normalizeOptional(realtimeListsInstanceId);
+        this.realtimeListsInstanceId = listsInstance.isEmpty()
+            ? DEFAULT_REALTIME_LISTS_INSTANCE_ID
+            : listsInstance;
     }
 
     static AssistantVoiceConfig load(Context context) {
@@ -243,7 +263,10 @@ final class AssistantVoiceConfig {
             prefs.getBoolean(
                 KEY_NOTIFICATION_TITLE_PLAYBACK_ENABLED,
                 DEFAULT_NOTIFICATION_TITLE_PLAYBACK_ENABLED
-            )
+            ),
+            prefs.getString(KEY_REALTIME_CONVERSATION_ID, null),
+            prefs.getBoolean(KEY_REALTIME_MUTE_ON_START, DEFAULT_REALTIME_MUTE_ON_START),
+            prefs.getString(KEY_REALTIME_LISTS_INSTANCE_ID, DEFAULT_REALTIME_LISTS_INSTANCE_ID)
         );
     }
 
@@ -284,6 +307,9 @@ final class AssistantVoiceConfig {
                 KEY_NOTIFICATION_TITLE_PLAYBACK_ENABLED,
                 config.notificationTitlePlaybackEnabled
             )
+            .putString(KEY_REALTIME_CONVERSATION_ID, config.realtimeConversationId)
+            .putBoolean(KEY_REALTIME_MUTE_ON_START, config.realtimeMuteOnStart)
+            .putString(KEY_REALTIME_LISTS_INSTANCE_ID, config.realtimeListsInstanceId)
             .apply();
     }
 
@@ -363,7 +389,14 @@ final class AssistantVoiceConfig {
             intent.getBooleanExtra(
                 EXTRA_NOTIFICATION_TITLE_PLAYBACK_ENABLED,
                 fallback.notificationTitlePlaybackEnabled
-            )
+            ),
+            intent.hasExtra(EXTRA_REALTIME_CONVERSATION_ID)
+                ? intent.getStringExtra(EXTRA_REALTIME_CONVERSATION_ID)
+                : fallback.realtimeConversationId,
+            intent.getBooleanExtra(EXTRA_REALTIME_MUTE_ON_START, fallback.realtimeMuteOnStart),
+            intent.hasExtra(EXTRA_REALTIME_LISTS_INSTANCE_ID)
+                ? intent.getStringExtra(EXTRA_REALTIME_LISTS_INSTANCE_ID)
+                : fallback.realtimeListsInstanceId
         );
     }
 
@@ -398,6 +431,9 @@ final class AssistantVoiceConfig {
             EXTRA_NOTIFICATION_TITLE_PLAYBACK_ENABLED,
             notificationTitlePlaybackEnabled
         );
+        intent.putExtra(EXTRA_REALTIME_CONVERSATION_ID, emptyToNull(realtimeConversationId));
+        intent.putExtra(EXTRA_REALTIME_MUTE_ON_START, realtimeMuteOnStart);
+        intent.putExtra(EXTRA_REALTIME_LISTS_INSTANCE_ID, emptyToNull(realtimeListsInstanceId));
         return intent;
     }
 
@@ -570,7 +606,13 @@ final class AssistantVoiceConfig {
             mediaButtonsEnabled,
             ttsPreferredSessionOnly,
             standaloneNotificationPlaybackEnabled,
-            notificationTitlePlaybackEnabled
+            notificationTitlePlaybackEnabled,
+
+            realtimeConversationId,
+
+            realtimeMuteOnStart,
+
+            realtimeListsInstanceId
         );
     }
 
@@ -600,7 +642,13 @@ final class AssistantVoiceConfig {
             mediaButtonsEnabled,
             ttsPreferredSessionOnly,
             standaloneNotificationPlaybackEnabled,
-            notificationTitlePlaybackEnabled
+            notificationTitlePlaybackEnabled,
+
+            realtimeConversationId,
+
+            realtimeMuteOnStart,
+
+            realtimeListsInstanceId
         );
     }
 
@@ -637,7 +685,10 @@ final class AssistantVoiceConfig {
             && mediaButtonsEnabled == config.mediaButtonsEnabled
             && ttsPreferredSessionOnly == config.ttsPreferredSessionOnly
             && standaloneNotificationPlaybackEnabled == config.standaloneNotificationPlaybackEnabled
-            && notificationTitlePlaybackEnabled == config.notificationTitlePlaybackEnabled;
+            && notificationTitlePlaybackEnabled == config.notificationTitlePlaybackEnabled
+            && Objects.equals(realtimeConversationId, config.realtimeConversationId)
+            && realtimeMuteOnStart == config.realtimeMuteOnStart
+            && Objects.equals(realtimeListsInstanceId, config.realtimeListsInstanceId);
     }
 
     @Override
@@ -667,7 +718,13 @@ final class AssistantVoiceConfig {
             mediaButtonsEnabled,
             ttsPreferredSessionOnly,
             standaloneNotificationPlaybackEnabled,
-            notificationTitlePlaybackEnabled
+            notificationTitlePlaybackEnabled,
+
+            realtimeConversationId,
+
+            realtimeMuteOnStart,
+
+            realtimeListsInstanceId
         );
     }
 
@@ -709,7 +766,10 @@ final class AssistantVoiceConfig {
             settings.optBoolean(
                 "notificationTitlePlaybackEnabled",
                 notificationTitlePlaybackEnabled
-            )
+            ),
+            settings.optString("realtimeConversationId", realtimeConversationId),
+            settings.optBoolean("realtimeMuteOnStart", realtimeMuteOnStart),
+            settings.optString("realtimeListsInstanceId", realtimeListsInstanceId)
         );
     }
 
@@ -739,7 +799,13 @@ final class AssistantVoiceConfig {
             mediaButtonsEnabled,
             ttsPreferredSessionOnly,
             standaloneNotificationPlaybackEnabled,
-            notificationTitlePlaybackEnabled
+            notificationTitlePlaybackEnabled,
+
+            realtimeConversationId,
+
+            realtimeMuteOnStart,
+
+            realtimeListsInstanceId
         );
     }
 
@@ -769,7 +835,13 @@ final class AssistantVoiceConfig {
             mediaButtonsEnabled,
             ttsPreferredSessionOnly,
             standaloneNotificationPlaybackEnabled,
-            notificationTitlePlaybackEnabled
+            notificationTitlePlaybackEnabled,
+
+            realtimeConversationId,
+
+            realtimeMuteOnStart,
+
+            realtimeListsInstanceId
         );
     }
 
@@ -799,7 +871,13 @@ final class AssistantVoiceConfig {
             mediaButtonsEnabled,
             ttsPreferredSessionOnly,
             standaloneNotificationPlaybackEnabled,
-            notificationTitlePlaybackEnabled
+            notificationTitlePlaybackEnabled,
+
+            realtimeConversationId,
+
+            realtimeMuteOnStart,
+
+            realtimeListsInstanceId
         );
     }
 
@@ -829,7 +907,13 @@ final class AssistantVoiceConfig {
             mediaButtonsEnabled,
             ttsPreferredSessionOnly,
             standaloneNotificationPlaybackEnabled,
-            notificationTitlePlaybackEnabled
+            notificationTitlePlaybackEnabled,
+
+            realtimeConversationId,
+
+            realtimeMuteOnStart,
+
+            realtimeListsInstanceId
         );
     }
 
@@ -859,7 +943,13 @@ final class AssistantVoiceConfig {
             enabled,
             ttsPreferredSessionOnly,
             standaloneNotificationPlaybackEnabled,
-            notificationTitlePlaybackEnabled
+            notificationTitlePlaybackEnabled,
+
+            realtimeConversationId,
+
+            realtimeMuteOnStart,
+
+            realtimeListsInstanceId
         );
     }
 
@@ -889,7 +979,13 @@ final class AssistantVoiceConfig {
             mediaButtonsEnabled,
             ttsPreferredSessionOnly,
             standaloneNotificationPlaybackEnabled,
-            notificationTitlePlaybackEnabled
+            notificationTitlePlaybackEnabled,
+
+            realtimeConversationId,
+
+            realtimeMuteOnStart,
+
+            realtimeListsInstanceId
         );
     }
 

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceControllerPolicy.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceControllerPolicy.java
@@ -1,0 +1,68 @@
+package com.assistant.mobile.voice;
+
+/**
+ * Pure helpers for the generation-fenced exclusive owner model described in the Realtime design.
+ * Thread media remains the only live owner until Realtime media lands; these helpers keep admission
+ * and stale-callback rules testable without the full service.
+ */
+final class AssistantVoiceControllerPolicy {
+    static final String OWNER_THREAD = "thread";
+    static final String OWNER_REALTIME = "realtime";
+
+    static final String RUNTIME_MODE_THREAD = "thread";
+    static final String RUNTIME_MODE_REALTIME = "realtime";
+
+    private AssistantVoiceControllerPolicy() {}
+
+    static String normalizeRuntimeMode(String value) {
+        if (value == null) {
+            return RUNTIME_MODE_THREAD;
+        }
+        String trimmed = value.trim().toLowerCase();
+        if (RUNTIME_MODE_REALTIME.equals(trimmed)) {
+            return RUNTIME_MODE_REALTIME;
+        }
+        return RUNTIME_MODE_THREAD;
+    }
+
+    static boolean isRealtimeRuntimeMode(String runtimeMode) {
+        return RUNTIME_MODE_REALTIME.equals(normalizeRuntimeMode(runtimeMode));
+    }
+
+    /** Live Realtime owner pauses Thread auto-admission; preference alone does not. */
+    static boolean shouldPauseThreadAdmission(String liveOwner) {
+        return OWNER_REALTIME.equals(liveOwner);
+    }
+
+    static boolean shouldAcceptThreadAdmission(boolean admissionPaused, boolean runtimeConnected) {
+        return !admissionPaused && runtimeConnected;
+    }
+
+    static boolean isCurrentGeneration(long activeGeneration, long callbackGeneration) {
+        return callbackGeneration > 0L && callbackGeneration == activeGeneration;
+    }
+
+    static long nextGeneration(long currentGeneration) {
+        long next = currentGeneration + 1L;
+        return next <= 0L ? 1L : next;
+    }
+
+    /**
+     * Settings apply that leaves Realtime while a call is live must become StopRealtime.
+     * Phase 1 has no live Realtime media; the predicate is still the contract seam.
+     */
+    static boolean shouldStopRealtimeForConfig(
+        String previousRuntimeMode,
+        String nextRuntimeMode,
+        String liveOwner
+    ) {
+        String previous = normalizeRuntimeMode(previousRuntimeMode);
+        String next = normalizeRuntimeMode(nextRuntimeMode);
+        if (OWNER_REALTIME.equals(liveOwner) && !RUNTIME_MODE_REALTIME.equals(next)) {
+            return true;
+        }
+        return RUNTIME_MODE_REALTIME.equals(previous)
+            && !RUNTIME_MODE_REALTIME.equals(next)
+            && OWNER_REALTIME.equals(liveOwner);
+    }
+}

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceInteractionRules.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceInteractionRules.java
@@ -103,7 +103,15 @@ final class AssistantVoiceInteractionRules {
         boolean promptPlaybackActive,
         boolean listeningActive
     ) {
-        return promptPlaybackActive || listeningActive;
+        return shouldShowNotificationStopAction(promptPlaybackActive, listeningActive, false);
+    }
+
+    static boolean shouldShowNotificationStopAction(
+        boolean promptPlaybackActive,
+        boolean listeningActive,
+        boolean realtimeActive
+    ) {
+        return promptPlaybackActive || listeningActive || realtimeActive;
     }
 
     static boolean shouldShowNotificationSpeakAction(
@@ -113,11 +121,34 @@ final class AssistantVoiceInteractionRules {
         boolean listeningActive,
         boolean runtimeConnected
     ) {
+        return shouldShowNotificationSpeakAction(
+            voiceEnabled,
+            preferredVoiceSessionId,
+            promptPlaybackActive,
+            listeningActive,
+            runtimeConnected,
+            false,
+            false
+        );
+    }
+
+    static boolean shouldShowNotificationSpeakAction(
+        boolean voiceEnabled,
+        String preferredVoiceSessionId,
+        boolean promptPlaybackActive,
+        boolean listeningActive,
+        boolean runtimeConnected,
+        boolean realtimeMode,
+        boolean realtimeActive
+    ) {
+        if (!voiceEnabled || promptPlaybackActive || listeningActive || realtimeActive) {
+            return false;
+        }
+        if (realtimeMode) {
+            // Realtime does not require a preferred Thread session id.
+            return true;
+        }
         String sessionId = preferredVoiceSessionId == null ? "" : preferredVoiceSessionId.trim();
-        return voiceEnabled
-            && !sessionId.isEmpty()
-            && !promptPlaybackActive
-            && !listeningActive
-            && runtimeConnected;
+        return !sessionId.isEmpty() && runtimeConnected;
     }
 }

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceMicStreamer.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceMicStreamer.java
@@ -72,10 +72,20 @@ final class AssistantVoiceMicStreamer {
     private Long activeSequence = null;
     private long nextSequence = 1L;
     private Integer preferredDeviceId = null;
+    private AssistantVoiceAudioRouter audioRouter;
+    private long routerOwnerGeneration = 0L;
 
     AssistantVoiceMicStreamer(Context context) {
         this.context = context.getApplicationContext();
         this.audioManager = (AudioManager) this.context.getSystemService(Context.AUDIO_SERVICE);
+    }
+
+    void setAudioRouter(AssistantVoiceAudioRouter router) {
+        audioRouter = router;
+    }
+
+    void setRouterOwnerGeneration(long generation) {
+        routerOwnerGeneration = generation;
     }
 
     void setPreferredDeviceId(String deviceId) {
@@ -294,6 +304,10 @@ final class AssistantVoiceMicStreamer {
     }
 
     private void startScoRouting() {
+        if (audioRouter != null) {
+            audioRouter.enterCommunicationMode(routerOwnerGeneration);
+            return;
+        }
         try {
             audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
             audioManager.setBluetoothScoOn(true);
@@ -304,6 +318,10 @@ final class AssistantVoiceMicStreamer {
     }
 
     private void stopScoRouting() {
+        if (audioRouter != null) {
+            audioRouter.leaveCommunicationMode(routerOwnerGeneration);
+            return;
+        }
         if (audioManager == null) {
             return;
         }

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoicePcmPlayer.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoicePcmPlayer.java
@@ -98,6 +98,10 @@ final class AssistantVoicePcmPlayer {
     private int framesWritten = 0;
     private long generation = 0L;
     private FocusMode focusMode = FocusMode.NONE;
+    private AssistantVoiceAudioRouter audioRouter;
+    private long routerOwnerGeneration = 0L;
+    /** When true, recognition arming cues request voice-comm focus via the shared router. */
+    private boolean preferVoiceCommunicationCueFocus = false;
 
     AssistantVoicePcmPlayer(Context context) {
         Context appContext = context == null ? null : context.getApplicationContext();
@@ -141,6 +145,24 @@ final class AssistantVoicePcmPlayer {
         }
     }
 
+    void setAudioRouter(AssistantVoiceAudioRouter router) {
+        synchronized (lock) {
+            audioRouter = router;
+        }
+    }
+
+    void setRouterOwnerGeneration(long ownerGeneration) {
+        synchronized (lock) {
+            routerOwnerGeneration = ownerGeneration;
+        }
+    }
+
+    void setPreferVoiceCommunicationCueFocus(boolean prefer) {
+        synchronized (lock) {
+            preferVoiceCommunicationCueFocus = prefer;
+        }
+    }
+
     void setTtsGain(float gain) {
         synchronized (lock) {
             ttsGain = normalizeTtsGain(gain);
@@ -164,9 +186,6 @@ final class AssistantVoicePcmPlayer {
 
     boolean beginRecognitionCaptureFocus() {
         synchronized (lock) {
-            if (audioManager == null) {
-                return true;
-            }
             cancelPendingPlaybackFocusReleaseLocked();
             if (focusMode == FocusMode.CAPTURE) {
                 return true;
@@ -760,9 +779,6 @@ final class AssistantVoicePcmPlayer {
     }
 
     private boolean requestPlaybackFocusIfNeededLocked() {
-        if (audioManager == null) {
-            return true;
-        }
         cancelPendingPlaybackFocusReleaseLocked();
         if (focusMode == FocusMode.PLAYBACK) {
             return true;
@@ -778,7 +794,17 @@ final class AssistantVoicePcmPlayer {
     }
 
     private boolean requestPlaybackFocusLocked() {
+        if (audioRouter != null) {
+            boolean granted = preferVoiceCommunicationCueFocus
+                ? audioRouter.requestRealtimeFocus(routerOwnerGeneration)
+                : audioRouter.requestPlaybackFocus(routerOwnerGeneration);
+            if (granted) {
+                focusMode = FocusMode.PLAYBACK;
+            }
+            return granted;
+        }
         if (audioManager == null) {
+            focusMode = FocusMode.PLAYBACK;
             return true;
         }
         int result;
@@ -799,7 +825,15 @@ final class AssistantVoicePcmPlayer {
     }
 
     private boolean requestCaptureFocusLocked() {
+        if (audioRouter != null) {
+            boolean granted = audioRouter.requestCaptureFocus(routerOwnerGeneration);
+            if (granted) {
+                focusMode = FocusMode.CAPTURE;
+            }
+            return granted;
+        }
         if (audioManager == null) {
+            focusMode = FocusMode.CAPTURE;
             return true;
         }
         int result;
@@ -820,7 +854,16 @@ final class AssistantVoicePcmPlayer {
     }
 
     private void abandonPlaybackFocusLocked() {
-        if (audioManager == null || focusMode != FocusMode.PLAYBACK) {
+        if (focusMode != FocusMode.PLAYBACK) {
+            return;
+        }
+        if (audioRouter != null) {
+            audioRouter.abandonFocus(routerOwnerGeneration);
+            focusMode = FocusMode.NONE;
+            return;
+        }
+        if (audioManager == null) {
+            focusMode = FocusMode.NONE;
             return;
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && playbackFocusRequest != null) {
@@ -832,7 +875,16 @@ final class AssistantVoicePcmPlayer {
     }
 
     private void abandonCaptureFocusLocked() {
-        if (audioManager == null || focusMode != FocusMode.CAPTURE) {
+        if (focusMode != FocusMode.CAPTURE) {
+            return;
+        }
+        if (audioRouter != null) {
+            audioRouter.abandonFocus(routerOwnerGeneration);
+            focusMode = FocusMode.NONE;
+            return;
+        }
+        if (audioManager == null) {
+            focusMode = FocusMode.NONE;
             return;
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && captureFocusRequest != null) {

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoicePlugin.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoicePlugin.java
@@ -452,6 +452,7 @@ public final class AssistantVoicePlugin extends Plugin {
         inputContext.put("contextLine", current.inputContextLine);
 
         JSObject voiceSettings = new JSObject();
+        voiceSettings.put("voiceRuntimeMode", current.voiceRuntimeMode);
         voiceSettings.put("audioMode", current.audioMode);
         voiceSettings.put("autoListenEnabled", current.autoListenEnabled);
         voiceSettings.put("voiceAdapterBaseUrl", current.voiceAdapterBaseUrl);

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoicePlugin.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoicePlugin.java
@@ -97,6 +97,28 @@ public final class AssistantVoicePlugin extends Plugin {
     }
 
     @PluginMethod
+    public void startRealtime(PluginCall call) {
+        Context context = getContext();
+        context.startForegroundService(AssistantVoiceRuntimeService.startRealtimeIntent(context));
+        call.resolve(buildStatePayload());
+    }
+
+    @PluginMethod
+    public void stopRealtime(PluginCall call) {
+        Context context = getContext();
+        context.startService(AssistantVoiceRuntimeService.stopRealtimeIntent(context));
+        call.resolve(buildStatePayload());
+    }
+
+    @PluginMethod
+    public void setRealtimeMuted(PluginCall call) {
+        boolean muted = call.getBoolean("muted", false);
+        Context context = getContext();
+        context.startService(AssistantVoiceRuntimeService.setRealtimeMutedIntent(context, muted));
+        call.resolve(buildStatePayload());
+    }
+
+    @PluginMethod
     public void setVoiceSettings(PluginCall call) {
         AssistantVoiceConfig current = AssistantVoiceConfig.load(getContext());
         AssistantVoiceConfig updated = extractVoiceSettingsConfig(call, current);
@@ -453,6 +475,9 @@ public final class AssistantVoicePlugin extends Plugin {
 
         JSObject voiceSettings = new JSObject();
         voiceSettings.put("voiceRuntimeMode", current.voiceRuntimeMode);
+        voiceSettings.put("realtimeConversationId", current.realtimeConversationId);
+        voiceSettings.put("realtimeMuteOnStart", current.realtimeMuteOnStart);
+        voiceSettings.put("realtimeListsInstanceId", current.realtimeListsInstanceId);
         voiceSettings.put("audioMode", current.audioMode);
         voiceSettings.put("autoListenEnabled", current.autoListenEnabled);
         voiceSettings.put("voiceAdapterBaseUrl", current.voiceAdapterBaseUrl);

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRealtimeClient.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRealtimeClient.java
@@ -45,10 +45,10 @@ final class AssistantVoiceRealtimeClient {
     private static final long EVENTS_POLL_INTERVAL_MS = 1_500L;
 
     interface Listener {
-        void onConnecting();
-        void onConnected(String sessionId, String conversationId);
-        void onFailed(String message);
-        void onClosed(String reason);
+        void onConnecting(long ownerGeneration);
+        void onConnected(String sessionId, String conversationId, long ownerGeneration);
+        void onFailed(String message, long ownerGeneration);
+        void onClosed(String reason, long ownerGeneration);
         void onTranscript(String role, String text, boolean isFinal);
         void onTool(String name, String status, String detail);
     }
@@ -72,6 +72,8 @@ final class AssistantVoiceRealtimeClient {
     private String conversationId = "";
     private boolean muted = false;
     private long eventCursor = 0L;
+    /** Generation stamped when start() is admitted; forwarded on all Listener callbacks. */
+    private long activeOwnerGeneration = 0L;
     private final Runnable heartbeatRunnable = this::heartbeatOnce;
     private final Runnable eventsPollRunnable = this::pollEventsOnce;
 
@@ -101,6 +103,7 @@ final class AssistantVoiceRealtimeClient {
                 sessionId = "";
                 this.conversationId = "";
                 eventCursor = 0L;
+                activeOwnerGeneration = ownerGeneration;
                 startLocked(
                     assistantBaseUrl,
                     conversationId,
@@ -157,8 +160,22 @@ final class AssistantVoiceRealtimeClient {
     }
 
     void release() {
+        if (executor.isShutdown()) {
+            return;
+        }
+        // Must finish dispose + server close; shutdownNow() would cancel the queued cleanup.
+        // Bound wait tightly: onDestroy runs on the main thread and must not ANR.
         executor.execute(() -> cleanupMedia("release", true, false));
-        executor.shutdownNow();
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(3, TimeUnit.SECONDS)) {
+                Log.w(TAG, "release cleanup timed out; forcing shutdown");
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException interrupted) {
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
     }
 
     private void startLocked(
@@ -423,12 +440,14 @@ final class AssistantVoiceRealtimeClient {
         String closingSessionId = sessionId;
         if (notifyServer && !closingSessionId.isEmpty()) {
             try {
-                postJson(
+                // Short timeouts so release()/onDestroy cannot block the main thread on a hung host.
+                postJsonWithTimeout(
                     AssistantVoiceUrlUtils.assistantVoiceSessionCloseUrl(
                         assistantBaseUrl,
                         closingSessionId
                     ),
-                    new JSONObject()
+                    new JSONObject(),
+                    2
                 );
             } catch (Exception ignored) {
             }
@@ -482,31 +501,35 @@ final class AssistantVoiceRealtimeClient {
 
     private void fail(String message) {
         // Always notify failure; cleanup may already have been terminal during restart races.
+        long generation = activeOwnerGeneration;
         cleanupMedia(message, true, false);
         Listener current = listener;
         if (current != null) {
-            mainHandler.post(() -> current.onFailed(message));
+            mainHandler.post(() -> current.onFailed(message, generation));
         }
     }
 
     private void notifyConnecting() {
         Listener current = listener;
+        long generation = activeOwnerGeneration;
         if (current != null) {
-            mainHandler.post(current::onConnecting);
+            mainHandler.post(() -> current.onConnecting(generation));
         }
     }
 
     private void notifyConnected(String sessionId, String conversationId) {
         Listener current = listener;
+        long generation = activeOwnerGeneration;
         if (current != null) {
-            mainHandler.post(() -> current.onConnected(sessionId, conversationId));
+            mainHandler.post(() -> current.onConnected(sessionId, conversationId, generation));
         }
     }
 
     private void notifyClosed(String reason) {
         Listener current = listener;
+        long generation = activeOwnerGeneration;
         if (current != null) {
-            mainHandler.post(() -> current.onClosed(reason));
+            mainHandler.post(() -> current.onClosed(reason, generation));
         }
     }
 
@@ -525,12 +548,29 @@ final class AssistantVoiceRealtimeClient {
     }
 
     private JSONObject postJson(String url, JSONObject body) throws IOException {
+        return postJsonWithClient(httpClient, url, body);
+    }
+
+    private JSONObject postJsonWithTimeout(String url, JSONObject body, long timeoutSeconds)
+        throws IOException {
+        OkHttpClient shortClient = httpClient
+            .newBuilder()
+            .connectTimeout(timeoutSeconds, TimeUnit.SECONDS)
+            .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
+            .writeTimeout(timeoutSeconds, TimeUnit.SECONDS)
+            .callTimeout(timeoutSeconds + 1, TimeUnit.SECONDS)
+            .build();
+        return postJsonWithClient(shortClient, url, body);
+    }
+
+    private JSONObject postJsonWithClient(OkHttpClient client, String url, JSONObject body)
+        throws IOException {
         Request request = new Request.Builder()
             .url(url)
             .post(RequestBody.create(body.toString(), JSON))
             .header("Content-Type", "application/json")
             .build();
-        try (Response response = httpClient.newCall(request).execute()) {
+        try (Response response = client.newCall(request).execute()) {
             String text = response.body() == null ? "" : response.body().string();
             if (!response.isSuccessful()) {
                 throw new IOException("HTTP " + response.code() + ": " + text);

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRealtimeClient.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRealtimeClient.java
@@ -1,0 +1,577 @@
+package com.assistant.mobile.voice;
+
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+
+import org.json.JSONObject;
+import org.webrtc.AudioSource;
+import org.webrtc.AudioTrack;
+import org.webrtc.DataChannel;
+import org.webrtc.IceCandidate;
+import org.webrtc.MediaConstraints;
+import org.webrtc.MediaStream;
+import org.webrtc.PeerConnection;
+import org.webrtc.PeerConnectionFactory;
+import org.webrtc.RtpReceiver;
+import org.webrtc.SdpObserver;
+import org.webrtc.SessionDescription;
+import org.webrtc.audio.JavaAudioDeviceModule;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+/**
+ * Android Realtime WebRTC client: empty ICE servers, non-trickle gather-once offer,
+ * server-proxied SDP answer via Assistant /api/voice.
+ */
+final class AssistantVoiceRealtimeClient {
+    private static final String TAG = "AssistantVoiceRealtime";
+    private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
+    private static final long ICE_GATHER_TIMEOUT_MS = 8_000L;
+    private static final long HEARTBEAT_INTERVAL_MS = 15_000L;
+    private static final long EVENTS_POLL_INTERVAL_MS = 1_500L;
+
+    interface Listener {
+        void onConnecting();
+        void onConnected(String sessionId, String conversationId);
+        void onFailed(String message);
+        void onClosed(String reason);
+        void onTranscript(String role, String text, boolean isFinal);
+        void onTool(String name, String status, String detail);
+    }
+
+    private final Context appContext;
+    private final OkHttpClient httpClient;
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private final AtomicBoolean terminal = new AtomicBoolean(false);
+
+    private Listener listener;
+    private PeerConnectionFactory factory;
+    private JavaAudioDeviceModule audioDeviceModule;
+    private PeerConnection peerConnection;
+    private AudioTrack localAudioTrack;
+    private AudioSource audioSource;
+    private String assistantBaseUrl = "";
+    private String sessionId = "";
+    private String conversationId = "";
+    private boolean muted = false;
+    private long eventCursor = 0L;
+    private final Runnable heartbeatRunnable = this::heartbeatOnce;
+    private final Runnable eventsPollRunnable = this::pollEventsOnce;
+
+    AssistantVoiceRealtimeClient(Context context, OkHttpClient httpClient) {
+        this.appContext = context.getApplicationContext();
+        this.httpClient = httpClient;
+    }
+
+    void setListener(Listener listener) {
+        this.listener = listener;
+    }
+
+    void start(
+        String assistantBaseUrl,
+        String conversationId,
+        String listsInstanceId,
+        boolean muteOnStart,
+        long ownerGeneration,
+        AssistantVoiceAudioRouter audioRouter
+    ) {
+        executor.execute(() -> {
+            try {
+                startLocked(
+                    assistantBaseUrl,
+                    conversationId,
+                    listsInstanceId,
+                    muteOnStart,
+                    ownerGeneration,
+                    audioRouter
+                );
+            } catch (Exception error) {
+                Log.w(TAG, "realtime start failed", error);
+                fail(error.getMessage() == null ? "realtime_start_failed" : error.getMessage());
+            }
+        });
+    }
+
+    void setMuted(boolean muted) {
+        executor.execute(() -> {
+            this.muted = muted;
+            if (localAudioTrack != null) {
+                localAudioTrack.setEnabled(!muted);
+            }
+            if (!sessionId.isEmpty()) {
+                try {
+                    JSONObject body = new JSONObject();
+                    body.put("muted", muted);
+                    postJson(
+                        AssistantVoiceUrlUtils.assistantVoiceSessionMuteUrl(assistantBaseUrl, sessionId),
+                        body
+                    );
+                } catch (Exception error) {
+                    Log.w(TAG, "setMuted request failed", error);
+                }
+            }
+        });
+    }
+
+    void stop(String reason) {
+        executor.execute(() -> teardown(reason == null ? "client_stop" : reason, true));
+    }
+
+    void release() {
+        stop("release");
+        executor.shutdownNow();
+    }
+
+    private void startLocked(
+        String baseUrl,
+        String requestedConversationId,
+        String listsInstanceId,
+        boolean muteOnStart,
+        long ownerGeneration,
+        AssistantVoiceAudioRouter audioRouter
+    ) throws Exception {
+        if (terminal.get()) {
+            return;
+        }
+        notifyConnecting();
+        this.assistantBaseUrl = AssistantVoiceUrlUtils.normalizeBaseUrl(
+            baseUrl,
+            AssistantVoiceConfig.DEFAULT_ASSISTANT_BASE_URL
+        );
+        this.muted = muteOnStart;
+
+        if (audioRouter != null) {
+            boolean focusGranted = audioRouter.requestRealtimeFocus(ownerGeneration);
+            if (!focusGranted) {
+                throw new IllegalStateException("audio_focus_denied");
+            }
+            audioRouter.enterCommunicationMode(ownerGeneration);
+        }
+
+        JSONObject createBody = new JSONObject();
+        if (requestedConversationId != null && !requestedConversationId.trim().isEmpty()) {
+            createBody.put("conversationId", requestedConversationId.trim());
+        }
+        if (listsInstanceId != null && !listsInstanceId.trim().isEmpty()) {
+            createBody.put("listsInstanceId", listsInstanceId.trim());
+        }
+        JSONObject created = postJson(
+            AssistantVoiceUrlUtils.assistantVoiceSessionsUrl(assistantBaseUrl),
+            createBody
+        );
+        sessionId = created.optString("sessionId", "");
+        conversationId = created.optString("conversationId", "");
+        if (sessionId.isEmpty()) {
+            throw new IllegalStateException("voice_session_create_failed");
+        }
+
+        ensureFactory();
+        PeerConnection.RTCConfiguration rtcConfig =
+            new PeerConnection.RTCConfiguration(Collections.emptyList());
+        rtcConfig.sdpSemantics = PeerConnection.SdpSemantics.UNIFIED_PLAN;
+        peerConnection = factory.createPeerConnection(rtcConfig, new PeerObserver());
+        if (peerConnection == null) {
+            throw new IllegalStateException("peer_connection_create_failed");
+        }
+
+        MediaConstraints audioConstraints = new MediaConstraints();
+        audioSource = factory.createAudioSource(audioConstraints);
+        localAudioTrack = factory.createAudioTrack("assistant-audio", audioSource);
+        localAudioTrack.setEnabled(!muted);
+        peerConnection.addTrack(localAudioTrack);
+
+        // Data channel for provider events is optional; server sideband owns tools.
+        peerConnection.createDataChannel("oai-events", new DataChannel.Init());
+
+        CountDownLatch gatherLatch = new CountDownLatch(1);
+        AtomicBoolean gatherDone = new AtomicBoolean(false);
+        peerConnection.createOffer(
+            new SdpObserverAdapter() {
+                @Override
+                public void onCreateSuccess(SessionDescription sessionDescription) {
+                    peerConnection.setLocalDescription(
+                        new SdpObserverAdapter() {
+                            @Override
+                            public void onSetSuccess() {
+                                // wait for ICE gathering complete
+                            }
+                        },
+                        sessionDescription
+                    );
+                }
+            },
+            new MediaConstraints()
+        );
+
+        long deadline = System.currentTimeMillis() + ICE_GATHER_TIMEOUT_MS;
+        while (System.currentTimeMillis() < deadline) {
+            PeerConnection.IceGatheringState state = peerConnection.iceGatheringState();
+            if (state == PeerConnection.IceGatheringState.COMPLETE) {
+                gatherDone.set(true);
+                break;
+            }
+            Thread.sleep(50);
+        }
+        if (!gatherDone.get() && peerConnection.getLocalDescription() == null) {
+            throw new IllegalStateException("ice_gather_timeout");
+        }
+
+        SessionDescription local = peerConnection.getLocalDescription();
+        if (local == null || local.description == null || local.description.trim().isEmpty()) {
+            throw new IllegalStateException("local_sdp_missing");
+        }
+
+        JSONObject offerBody = new JSONObject().put("sdp", local.description);
+        JSONObject answer = postJson(
+            AssistantVoiceUrlUtils.assistantVoiceSessionOfferUrl(assistantBaseUrl, sessionId),
+            offerBody
+        );
+        String answerSdp = answer.optString("sdp", "");
+        if (answerSdp.trim().isEmpty()) {
+            throw new IllegalStateException("remote_sdp_missing");
+        }
+
+        CountDownLatch remoteSet = new CountDownLatch(1);
+        AtomicBoolean remoteOk = new AtomicBoolean(false);
+        peerConnection.setRemoteDescription(
+            new SdpObserverAdapter() {
+                @Override
+                public void onSetSuccess() {
+                    remoteOk.set(true);
+                    remoteSet.countDown();
+                }
+
+                @Override
+                public void onSetFailure(String s) {
+                    remoteSet.countDown();
+                }
+            },
+            new SessionDescription(SessionDescription.Type.ANSWER, answerSdp)
+        );
+        if (!remoteSet.await(5, TimeUnit.SECONDS) || !remoteOk.get()) {
+            throw new IllegalStateException("remote_sdp_set_failed");
+        }
+
+        notifyConnected(sessionId, conversationId);
+        mainHandler.postDelayed(heartbeatRunnable, HEARTBEAT_INTERVAL_MS);
+        mainHandler.postDelayed(eventsPollRunnable, EVENTS_POLL_INTERVAL_MS);
+    }
+
+    private void ensureFactory() {
+        if (factory != null) {
+            return;
+        }
+        PeerConnectionFactory.initialize(
+            PeerConnectionFactory.InitializationOptions.builder(appContext)
+                .createInitializationOptions()
+        );
+        audioDeviceModule =
+            JavaAudioDeviceModule.builder(appContext)
+                .setUseHardwareAcousticEchoCanceler(true)
+                .setUseHardwareNoiseSuppressor(true)
+                .createAudioDeviceModule();
+        factory = PeerConnectionFactory.builder()
+            .setAudioDeviceModule(audioDeviceModule)
+            .createPeerConnectionFactory();
+    }
+
+    private void heartbeatOnce() {
+        if (terminal.get() || sessionId.isEmpty()) {
+            return;
+        }
+        executor.execute(() -> {
+            try {
+                postJson(
+                    AssistantVoiceUrlUtils.assistantVoiceSessionHeartbeatUrl(assistantBaseUrl, sessionId),
+                    new JSONObject()
+                );
+            } catch (Exception error) {
+                Log.w(TAG, "heartbeat failed", error);
+            } finally {
+                if (!terminal.get()) {
+                    mainHandler.postDelayed(heartbeatRunnable, HEARTBEAT_INTERVAL_MS);
+                }
+            }
+        });
+    }
+
+    private void pollEventsOnce() {
+        if (terminal.get() || sessionId.isEmpty()) {
+            return;
+        }
+        executor.execute(() -> {
+            try {
+                String url = AssistantVoiceUrlUtils.assistantVoiceSessionEventsUrl(
+                    assistantBaseUrl,
+                    sessionId,
+                    eventCursor
+                );
+                JSONObject payload = getJson(url);
+                org.json.JSONArray events = payload.optJSONArray("events");
+                if (events != null) {
+                    for (int i = 0; i < events.length(); i += 1) {
+                        JSONObject event = events.optJSONObject(i);
+                        if (event == null) {
+                            continue;
+                        }
+                        long sequence = event.optLong("sequence", 0L);
+                        if (sequence > eventCursor) {
+                            eventCursor = sequence;
+                        }
+                        dispatchEvent(event);
+                    }
+                }
+            } catch (Exception error) {
+                Log.w(TAG, "events poll failed", error);
+            } finally {
+                if (!terminal.get()) {
+                    mainHandler.postDelayed(eventsPollRunnable, EVENTS_POLL_INTERVAL_MS);
+                }
+            }
+        });
+    }
+
+    private void dispatchEvent(JSONObject event) {
+        String type = event.optString("type", "");
+        if ("transcript".equals(type)) {
+            notifyTranscript(
+                event.optString("role", "assistant"),
+                event.optString("text", ""),
+                event.optBoolean("final", true)
+            );
+        } else if ("tool".equals(type)) {
+            notifyTool(
+                event.optString("name", ""),
+                event.optString("status", ""),
+                event.optString("detail", "")
+            );
+        } else if ("error".equals(type)) {
+            // Non-terminal provider error surface; keep call unless session_state fails.
+            Log.w(TAG, "realtime event error=" + event.optString("message", ""));
+        } else if ("session_state".equals(type)) {
+            String state = event.optString("state", "");
+            if ("failed".equals(state) || "closed".equals(state)) {
+                teardown(event.optString("message", state), false);
+            }
+        } else if ("closed".equals(type)) {
+            teardown(event.optString("reason", "closed"), false);
+        }
+    }
+
+    private void teardown(String reason, boolean notifyServer) {
+        if (!terminal.compareAndSet(false, true) && notifyServer) {
+            // already terminal
+        }
+        terminal.set(true);
+        mainHandler.removeCallbacks(heartbeatRunnable);
+        mainHandler.removeCallbacks(eventsPollRunnable);
+        if (notifyServer && !sessionId.isEmpty()) {
+            try {
+                postJson(
+                    AssistantVoiceUrlUtils.assistantVoiceSessionCloseUrl(assistantBaseUrl, sessionId),
+                    new JSONObject()
+                );
+            } catch (Exception ignored) {
+            }
+        }
+        try {
+            if (localAudioTrack != null) {
+                localAudioTrack.setEnabled(false);
+                localAudioTrack.dispose();
+            }
+        } catch (Exception ignored) {
+        }
+        localAudioTrack = null;
+        try {
+            if (audioSource != null) {
+                audioSource.dispose();
+            }
+        } catch (Exception ignored) {
+        }
+        audioSource = null;
+        try {
+            if (peerConnection != null) {
+                peerConnection.close();
+                peerConnection.dispose();
+            }
+        } catch (Exception ignored) {
+        }
+        peerConnection = null;
+        try {
+            if (audioDeviceModule != null) {
+                audioDeviceModule.release();
+            }
+        } catch (Exception ignored) {
+        }
+        audioDeviceModule = null;
+        try {
+            if (factory != null) {
+                factory.dispose();
+            }
+        } catch (Exception ignored) {
+        }
+        factory = null;
+        notifyClosed(reason);
+    }
+
+    private void fail(String message) {
+        teardown(message, true);
+        Listener current = listener;
+        if (current != null) {
+            mainHandler.post(() -> current.onFailed(message));
+        }
+    }
+
+    private void notifyConnecting() {
+        Listener current = listener;
+        if (current != null) {
+            mainHandler.post(current::onConnecting);
+        }
+    }
+
+    private void notifyConnected(String sessionId, String conversationId) {
+        Listener current = listener;
+        if (current != null) {
+            mainHandler.post(() -> current.onConnected(sessionId, conversationId));
+        }
+    }
+
+    private void notifyClosed(String reason) {
+        Listener current = listener;
+        if (current != null) {
+            mainHandler.post(() -> current.onClosed(reason));
+        }
+    }
+
+    private void notifyTranscript(String role, String text, boolean isFinal) {
+        Listener current = listener;
+        if (current != null) {
+            mainHandler.post(() -> current.onTranscript(role, text, isFinal));
+        }
+    }
+
+    private void notifyTool(String name, String status, String detail) {
+        Listener current = listener;
+        if (current != null) {
+            mainHandler.post(() -> current.onTool(name, status, detail));
+        }
+    }
+
+    private JSONObject postJson(String url, JSONObject body) throws IOException {
+        Request request = new Request.Builder()
+            .url(url)
+            .post(RequestBody.create(body.toString(), JSON))
+            .header("Content-Type", "application/json")
+            .build();
+        try (Response response = httpClient.newCall(request).execute()) {
+            String text = response.body() == null ? "" : response.body().string();
+            if (!response.isSuccessful()) {
+                throw new IOException("HTTP " + response.code() + ": " + text);
+            }
+            if (text.trim().isEmpty()) {
+                return new JSONObject();
+            }
+            try {
+                return new JSONObject(text);
+            } catch (Exception error) {
+                throw new IOException("Invalid JSON response", error);
+            }
+        }
+    }
+
+    private JSONObject getJson(String url) throws IOException {
+        Request request = new Request.Builder().url(url).get().build();
+        try (Response response = httpClient.newCall(request).execute()) {
+            String text = response.body() == null ? "" : response.body().string();
+            if (!response.isSuccessful()) {
+                throw new IOException("HTTP " + response.code() + ": " + text);
+            }
+            return text.trim().isEmpty() ? new JSONObject() : new JSONObject(text);
+        } catch (IOException error) {
+            throw error;
+        } catch (Exception error) {
+            throw new IOException("Invalid JSON response", error);
+        }
+    }
+
+    private static class SdpObserverAdapter implements SdpObserver {
+        @Override
+        public void onCreateSuccess(SessionDescription sessionDescription) {}
+
+        @Override
+        public void onSetSuccess() {}
+
+        @Override
+        public void onCreateFailure(String s) {}
+
+        @Override
+        public void onSetFailure(String s) {}
+    }
+
+    private class PeerObserver implements PeerConnection.Observer {
+        @Override
+        public void onSignalingChange(PeerConnection.SignalingState signalingState) {}
+
+        @Override
+        public void onIceConnectionChange(PeerConnection.IceConnectionState iceConnectionState) {
+            if (iceConnectionState == PeerConnection.IceConnectionState.FAILED
+                || iceConnectionState == PeerConnection.IceConnectionState.DISCONNECTED
+                || iceConnectionState == PeerConnection.IceConnectionState.CLOSED) {
+                executor.execute(() -> {
+                    if (!terminal.get()) {
+                        // Grace: disconnect may recover briefly; hard-fail on FAILED.
+                        if (iceConnectionState == PeerConnection.IceConnectionState.FAILED) {
+                            fail("ice_failed");
+                        }
+                    }
+                });
+            }
+        }
+
+        @Override
+        public void onIceConnectionReceivingChange(boolean b) {}
+
+        @Override
+        public void onIceGatheringChange(PeerConnection.IceGatheringState iceGatheringState) {}
+
+        @Override
+        public void onIceCandidate(IceCandidate iceCandidate) {
+            // Non-trickle: candidates are embedded in the gathered local SDP.
+        }
+
+        @Override
+        public void onIceCandidatesRemoved(IceCandidate[] iceCandidates) {}
+
+        @Override
+        public void onAddStream(MediaStream mediaStream) {}
+
+        @Override
+        public void onRemoveStream(MediaStream mediaStream) {}
+
+        @Override
+        public void onDataChannel(DataChannel dataChannel) {}
+
+        @Override
+        public void onRenegotiationNeeded() {}
+
+        @Override
+        public void onAddTrack(RtpReceiver rtpReceiver, MediaStream[] mediaStreams) {
+            // Remote audio is played by WebRTC ADM automatically when track is received.
+        }
+    }
+}

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRealtimeClient.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRealtimeClient.java
@@ -57,7 +57,9 @@ final class AssistantVoiceRealtimeClient {
     private final OkHttpClient httpClient;
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
-    private final AtomicBoolean terminal = new AtomicBoolean(false);
+    /** True while a call is fully torn down / not reusable until the next start resets it. */
+    private final AtomicBoolean terminal = new AtomicBoolean(true);
+    private static final AtomicBoolean FACTORY_INITIALIZED = new AtomicBoolean(false);
 
     private Listener listener;
     private PeerConnectionFactory factory;
@@ -92,6 +94,13 @@ final class AssistantVoiceRealtimeClient {
     ) {
         executor.execute(() -> {
             try {
+                // Previous stop() leaves terminal=true and may leave WebRTC resources half-torn.
+                // Always fully clean and re-arm before starting a new call on the same client.
+                cleanupMedia("restart_cleanup", false, false);
+                terminal.set(false);
+                sessionId = "";
+                this.conversationId = "";
+                eventCursor = 0L;
                 startLocked(
                     assistantBaseUrl,
                     conversationId,
@@ -129,11 +138,26 @@ final class AssistantVoiceRealtimeClient {
     }
 
     void stop(String reason) {
-        executor.execute(() -> teardown(reason == null ? "client_stop" : reason, true));
+        stop(reason, true);
+    }
+
+    /**
+     * @param notifyListener when false, suppresses {@link Listener#onClosed} so a recovery
+     *     restart can tear down media without the service treating the close as end-of-call.
+     */
+    void stop(String reason, boolean notifyListener) {
+        executor.execute(
+            () ->
+                cleanupMedia(
+                    reason == null ? "client_stop" : reason,
+                    true,
+                    notifyListener
+                )
+        );
     }
 
     void release() {
-        stop("release");
+        executor.execute(() -> cleanupMedia("release", true, false));
         executor.shutdownNow();
     }
 
@@ -146,7 +170,8 @@ final class AssistantVoiceRealtimeClient {
         AssistantVoiceAudioRouter audioRouter
     ) throws Exception {
         if (terminal.get()) {
-            return;
+            // Should not happen after start() re-arms terminal=false; treat as hard failure.
+            throw new IllegalStateException("realtime_client_terminal");
         }
         notifyConnecting();
         this.assistantBaseUrl = AssistantVoiceUrlUtils.normalizeBaseUrl(
@@ -156,6 +181,8 @@ final class AssistantVoiceRealtimeClient {
         this.muted = muteOnStart;
 
         if (audioRouter != null) {
+            // Drop any stale focus/mode from a previous call before re-requesting.
+            audioRouter.releaseAll(0L);
             boolean focusGranted = audioRouter.requestRealtimeFocus(ownerGeneration);
             if (!focusGranted) {
                 throw new IllegalStateException("audio_focus_denied");
@@ -276,10 +303,13 @@ final class AssistantVoiceRealtimeClient {
         if (factory != null) {
             return;
         }
-        PeerConnectionFactory.initialize(
-            PeerConnectionFactory.InitializationOptions.builder(appContext)
-                .createInitializationOptions()
-        );
+        // PeerConnectionFactory.initialize must run only once per process.
+        if (FACTORY_INITIALIZED.compareAndSet(false, true)) {
+            PeerConnectionFactory.initialize(
+                PeerConnectionFactory.InitializationOptions.builder(appContext)
+                    .createInitializationOptions()
+            );
+        }
         audioDeviceModule =
             JavaAudioDeviceModule.builder(appContext)
                 .setUseHardwareAcousticEchoCanceler(true)
@@ -374,21 +404,39 @@ final class AssistantVoiceRealtimeClient {
     }
 
     private void teardown(String reason, boolean notifyServer) {
-        if (!terminal.compareAndSet(false, true) && notifyServer) {
-            // already terminal
-        }
+        cleanupMedia(reason, notifyServer, true);
+    }
+
+    /**
+     * Releases WebRTC + session resources so a later start() can succeed.
+     *
+     * @param notifyServer close the assistant voice session over HTTP when appropriate
+     * @param notifyListener fire onClosed once when leaving an active call
+     */
+    private void cleanupMedia(String reason, boolean notifyServer, boolean notifyListener) {
+        boolean wasActive = terminal.compareAndSet(false, true);
+        // Always force terminal so a partially-started call cannot leave the client "open".
         terminal.set(true);
         mainHandler.removeCallbacks(heartbeatRunnable);
         mainHandler.removeCallbacks(eventsPollRunnable);
-        if (notifyServer && !sessionId.isEmpty()) {
+
+        String closingSessionId = sessionId;
+        if (notifyServer && !closingSessionId.isEmpty()) {
             try {
                 postJson(
-                    AssistantVoiceUrlUtils.assistantVoiceSessionCloseUrl(assistantBaseUrl, sessionId),
+                    AssistantVoiceUrlUtils.assistantVoiceSessionCloseUrl(
+                        assistantBaseUrl,
+                        closingSessionId
+                    ),
                     new JSONObject()
                 );
             } catch (Exception ignored) {
             }
         }
+        sessionId = "";
+        conversationId = "";
+        eventCursor = 0L;
+
         try {
             if (localAudioTrack != null) {
                 localAudioTrack.setEnabled(false);
@@ -426,11 +474,15 @@ final class AssistantVoiceRealtimeClient {
         } catch (Exception ignored) {
         }
         factory = null;
-        notifyClosed(reason);
+
+        if (notifyListener && wasActive) {
+            notifyClosed(reason == null ? "closed" : reason);
+        }
     }
 
     private void fail(String message) {
-        teardown(message, true);
+        // Always notify failure; cleanup may already have been terminal during restart races.
+        cleanupMedia(message, true, false);
         Listener current = listener;
         if (current != null) {
             mainHandler.post(() -> current.onFailed(message));

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
@@ -136,7 +136,16 @@ public final class AssistantVoiceRuntimeService extends Service {
         .build();
     private AssistantVoicePcmPlayer player;
     private AssistantVoiceMicStreamer micStreamer;
+    private AssistantVoiceAudioRouter audioRouter;
     private MediaSession mediaSession;
+    /** Monotonic controller generation; advanced on exclusive-owner transitions. */
+    private long controllerGeneration = 1L;
+    /** Generation stamped onto the currently admitted Thread media interaction. */
+    private long activeMediaGeneration = 0L;
+    /** Live exclusive owner: thread or realtime (realtime media lands in a later phase). */
+    private String liveOwner = AssistantVoiceControllerPolicy.OWNER_THREAD;
+    /** When true, automatic Thread queue admission is paused (Realtime live owner). */
+    private boolean threadAdmissionPaused = false;
 
     private final Runnable reconnectRunnable = this::connectAdapterSocketIfNeeded;
     private final Runnable assistantReconnectRunnable = this::connectAssistantSocketIfNeeded;
@@ -298,8 +307,11 @@ public final class AssistantVoiceRuntimeService extends Service {
     @Override
     public void onCreate() {
         super.onCreate();
+        audioRouter = new AssistantVoiceAudioRouter(this);
         micStreamer = new AssistantVoiceMicStreamer(this);
+        micStreamer.setAudioRouter(audioRouter);
         player = new AssistantVoicePcmPlayer(this);
+        player.setAudioRouter(audioRouter);
         config = AssistantVoiceConfig.load(this);
         micStreamer.setPreferredDeviceId(config.selectedMicDeviceId);
         player.setTtsGain(config.ttsGain);
@@ -407,6 +419,9 @@ public final class AssistantVoiceRuntimeService extends Service {
         if (micStreamer != null) {
             micStreamer.release();
         }
+        if (audioRouter != null) {
+            audioRouter.shutdown();
+        }
         networkExecutor.shutdownNow();
         httpClient.dispatcher().cancelAll();
         httpClient.dispatcher().executorService().shutdownNow();
@@ -437,8 +452,20 @@ public final class AssistantVoiceRuntimeService extends Service {
         boolean selectedSessionChanged =
             !previous.selectedSessionId.equals(updated.selectedSessionId);
         boolean audioModeChanged = !previous.audioMode.equals(updated.audioMode);
+        boolean runtimeModeChanged = !previous.voiceRuntimeMode.equals(updated.voiceRuntimeMode);
         boolean adapterUrlChanged = !previous.voiceAdapterBaseUrl.equals(updated.voiceAdapterBaseUrl);
         boolean assistantUrlChanged = !previous.assistantBaseUrl.equals(updated.assistantBaseUrl);
+
+        // Contract seam for Phase 3: leaving Realtime while it is the live owner must stop it.
+        if (
+            AssistantVoiceControllerPolicy.shouldStopRealtimeForConfig(
+                previous.voiceRuntimeMode,
+                updated.voiceRuntimeMode,
+                liveOwner
+            )
+        ) {
+            stopRealtimeOwner("config_runtime_mode");
+        }
 
         if (!updated.isEnabled()) {
             clearQueuedVoiceItems();
@@ -448,6 +475,16 @@ public final class AssistantVoiceRuntimeService extends Service {
             syncMediaSession();
             updateState(STATE_DISABLED, null);
             return;
+        }
+
+        if (runtimeModeChanged) {
+            Log.d(
+                TAG,
+                "applyConfig voiceRuntimeMode "
+                    + safe(previous.voiceRuntimeMode)
+                    + " -> "
+                    + safe(updated.voiceRuntimeMode)
+            );
         }
 
         boolean switchedToManualMode =
@@ -1578,6 +1615,12 @@ public final class AssistantVoiceRuntimeService extends Service {
             Log.d(TAG, "enqueueQueueItem dropped invalid item=" + describeQueueItem(item));
             return;
         }
+        if (threadAdmissionPaused && !front) {
+            // Automatic admission is paused while Realtime owns media; manual front-of-queue
+            // recovery is still allowed when Thread is live again (front used after resume).
+            Log.d(TAG, "enqueueQueueItem dropped admission_paused " + describeQueueItem(item));
+            return;
+        }
         if (shouldDedupManualAutoListenQueueItem(item, activeQueueItem)) {
             Log.d(TAG, "enqueueQueueItem deduped active manual auto-listen item=" + describeQueueItem(item));
             return;
@@ -1644,7 +1687,132 @@ public final class AssistantVoiceRuntimeService extends Service {
         queuedVoiceItems.clear();
     }
 
+    /**
+     * Stops the active Thread interaction and clears the local FIFO only.
+     * Durable notifications are intentionally retained for later manual recovery.
+     */
+    void stopAndClearQueue(String reason) {
+        Log.d(TAG, "stopAndClearQueue reason=" + safe(reason));
+        clearQueuedVoiceItems();
+        clearPendingManualPreemptState("stop_and_clear:" + safe(reason));
+        stopCurrentInteraction(false, "stop_and_clear_queue:" + safe(reason));
+    }
+
+    void pauseThreadAdmission() {
+        threadAdmissionPaused = true;
+        Log.d(TAG, "pauseThreadAdmission generation=" + controllerGeneration);
+    }
+
+    void resumeThreadAdmission() {
+        threadAdmissionPaused = false;
+        Log.d(TAG, "resumeThreadAdmission generation=" + controllerGeneration);
+        drainVoiceQueueIfPossible();
+    }
+
+    boolean isThreadAdmissionPaused() {
+        return threadAdmissionPaused;
+    }
+
+    long controllerGeneration() {
+        return controllerGeneration;
+    }
+
+    String liveOwner() {
+        return liveOwner;
+    }
+
+    /**
+     * Waits for Thread media to become idle after stop. Phase 1 is synchronous: stop releases
+     * local player/mic immediately; adapter ACKs for stale generations are ignored via fencing.
+     */
+    boolean awaitMediaQuiescence() {
+        if (hasActiveInteraction()) {
+            stopCurrentInteraction(false, "await_media_quiescence");
+        }
+        if (audioRouter != null) {
+            audioRouter.releaseAll(activeMediaGeneration == 0L ? controllerGeneration : activeMediaGeneration);
+        }
+        activeMediaGeneration = 0L;
+        if (player != null) {
+            player.setRouterOwnerGeneration(controllerGeneration);
+        }
+        if (micStreamer != null) {
+            micStreamer.setRouterOwnerGeneration(controllerGeneration);
+        }
+        return !hasActiveInteraction();
+    }
+
+    long advanceControllerGeneration(String reason) {
+        controllerGeneration = AssistantVoiceControllerPolicy.nextGeneration(controllerGeneration);
+        activeMediaGeneration = 0L;
+        if (player != null) {
+            player.setRouterOwnerGeneration(controllerGeneration);
+        }
+        if (micStreamer != null) {
+            micStreamer.setRouterOwnerGeneration(controllerGeneration);
+        }
+        Log.d(
+            TAG,
+            "advanceControllerGeneration reason=" + safe(reason) + " generation=" + controllerGeneration
+        );
+        return controllerGeneration;
+    }
+
+    boolean isCurrentMediaGeneration(long generation) {
+        return AssistantVoiceControllerPolicy.isCurrentGeneration(activeMediaGeneration, generation)
+            || (activeMediaGeneration == 0L
+                && AssistantVoiceControllerPolicy.isCurrentGeneration(controllerGeneration, generation));
+    }
+
+    private long admitThreadMediaGeneration() {
+        activeMediaGeneration = controllerGeneration;
+        if (player != null) {
+            player.setRouterOwnerGeneration(activeMediaGeneration);
+        }
+        if (micStreamer != null) {
+            micStreamer.setRouterOwnerGeneration(activeMediaGeneration);
+        }
+        liveOwner = AssistantVoiceControllerPolicy.OWNER_THREAD;
+        return activeMediaGeneration;
+    }
+
+    /**
+     * Phase-1 stub for the exclusive Realtime owner transition without WebRTC media.
+     * Preempts Thread (stop + clear FIFO + pause admission) and advances generation so later
+     * Realtime media can plug into the same fence.
+     */
+    void prepareRealtimeOwnerPreempt(String reason) {
+        stopAndClearQueue(reason);
+        awaitMediaQuiescence();
+        pauseThreadAdmission();
+        liveOwner = AssistantVoiceControllerPolicy.OWNER_REALTIME;
+        advanceControllerGeneration("prepare_realtime:" + safe(reason));
+        if (player != null) {
+            player.setPreferVoiceCommunicationCueFocus(true);
+        }
+    }
+
+    void stopRealtimeOwner(String reason) {
+        if (!AssistantVoiceControllerPolicy.OWNER_REALTIME.equals(liveOwner)) {
+            return;
+        }
+        Log.d(TAG, "stopRealtimeOwner reason=" + safe(reason));
+        if (audioRouter != null) {
+            audioRouter.releaseAll(controllerGeneration);
+        }
+        if (player != null) {
+            player.setPreferVoiceCommunicationCueFocus(false);
+        }
+        liveOwner = AssistantVoiceControllerPolicy.OWNER_THREAD;
+        advanceControllerGeneration("stop_realtime:" + safe(reason));
+        resumeThreadAdmission();
+    }
+
     private void drainVoiceQueueIfPossible() {
+        if (threadAdmissionPaused) {
+            Log.d(TAG, "drainVoiceQueueIfPossible blocked reason=admission_paused " + describeRuntimeState());
+            return;
+        }
         String blockedReason = explainQueueDrainBlock();
         if (!blockedReason.isEmpty()) {
             Log.d(TAG, "drainVoiceQueueIfPossible blocked reason=" + blockedReason + " " + describeRuntimeState());
@@ -1863,6 +2031,7 @@ public final class AssistantVoiceRuntimeService extends Service {
                 Log.d(TAG, "adapter client_identity clientIdPresent=" + !adapterClientId.isEmpty());
                 if (!hasActiveInteraction()) {
                     updateState(STATE_IDLE, null);
+                    drainVoiceQueueIfPossible();
                 }
                 return;
             }
@@ -1927,6 +2096,15 @@ public final class AssistantVoiceRuntimeService extends Service {
                 "ignoring media_tts_end requestId=" + requestId
                     + " active=" + activeTtsRequestId
                     + " pendingPreemptStop=" + pendingManualPreemptStopRequestId
+            );
+            return;
+        }
+        if (threadAdmissionPaused && !matchesManualPreemptStop && activeMediaGeneration != controllerGeneration) {
+            Log.d(
+                TAG,
+                "ignoring media_tts_end stale generation requestId=" + requestId
+                    + " mediaGeneration=" + activeMediaGeneration
+                    + " controllerGeneration=" + controllerGeneration
             );
             return;
         }
@@ -2215,6 +2393,7 @@ public final class AssistantVoiceRuntimeService extends Service {
         AssistantVoiceEventLog.put(details, "queueItem", describeQueueItem(item));
         AssistantVoiceEventLog.put(details, "textLength", trim(item.spokenText).length());
         recordVoiceEvent("tts_begin", details);
+        admitThreadMediaGeneration();
         activeQueueItem = item;
         activeVoiceSessionId = item.sessionId;
         activePromptToolName = item.executionMode;
@@ -2434,6 +2613,7 @@ public final class AssistantVoiceRuntimeService extends Service {
         }
 
         String requestId = UUID.randomUUID().toString();
+        admitThreadMediaGeneration();
         activeVoiceSessionId = sessionId.trim();
         activePromptToolName = "manual_listen".equals(reason) ? "voice_manual" : activePromptToolName;
         activeSttRequestId = requestId;
@@ -3666,15 +3846,40 @@ public final class AssistantVoiceRuntimeService extends Service {
         if (!config.isEnabled()) {
             return "voice_mode_disabled";
         }
+        if (threadAdmissionPaused) {
+            return "admission_paused";
+        }
         if (!isRuntimeConnected()) {
             return "runtime_not_connected";
+        }
+        AssistantVoiceQueueItem next = queuedVoiceItems.get(0);
+        if (shouldWaitForAdapterClientIdentity(adapterSocketConnected, adapterClientId, next)) {
+            return "adapter_client_identity_missing";
         }
         return "";
     }
 
+    static boolean shouldWaitForAdapterClientIdentity(
+        boolean adapterSocketConnected,
+        String adapterClientId,
+        AssistantVoiceQueueItem item
+    ) {
+        return adapterSocketConnected
+            && item != null
+            && !item.isListenOnly()
+            && item.hasSpeech()
+            && trim(adapterClientId).isEmpty();
+    }
+
     private String describeRuntimeState() {
         return "state=" + safe(runtimeState)
+            + " liveOwner=" + safe(liveOwner)
+            + " generation=" + controllerGeneration
+            + " mediaGeneration=" + activeMediaGeneration
+            + " admissionPaused=" + threadAdmissionPaused
+            + " runtimeMode=" + safe(config == null ? "" : config.voiceRuntimeMode)
             + " adapterSocketConnected=" + adapterSocketConnected
+            + " adapterClientIdPresent=" + !adapterClientId.isEmpty()
             + " assistantSocketConnected=" + assistantSocketConnected
             + " activeTtsRequestId=" + safe(activeTtsRequestId)
             + " pendingManualPreemptStopRequestId=" + safe(pendingManualPreemptStopRequestId)

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
@@ -14,6 +14,7 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
+import android.os.PowerManager;
 import android.util.Base64;
 import android.util.Log;
 import android.view.KeyEvent;
@@ -67,6 +68,12 @@ public final class AssistantVoiceRuntimeService extends Service {
     static final String ACTION_NOTIFICATION_SPEAKER = "com.assistant.mobile.voice.NOTIFICATION_SPEAKER";
     static final String ACTION_NOTIFICATION_MIC = "com.assistant.mobile.voice.NOTIFICATION_MIC";
     static final String ACTION_NOTIFICATION_DISMISS = "com.assistant.mobile.voice.NOTIFICATION_DISMISS";
+    static final String ACTION_START_REALTIME = "com.assistant.mobile.voice.START_REALTIME";
+    static final String ACTION_STOP_REALTIME = "com.assistant.mobile.voice.STOP_REALTIME";
+    static final String ACTION_SET_REALTIME_MUTED = "com.assistant.mobile.voice.SET_REALTIME_MUTED";
+    static final String EXTRA_REALTIME_MUTED = "realtimeMuted";
+    public static final String STATE_REALTIME_CONNECTING = "realtime_connecting";
+    public static final String STATE_REALTIME_ACTIVE = "realtime_active";
     static final String EXTRA_MANUAL_LISTEN_SESSION_ID = "manualListenSessionId";
     static final String EXTRA_PLAY_TEXT_SESSION_ID = "playTextSessionId";
     static final String EXTRA_PLAY_TEXT_TEXT = "playTextText";
@@ -137,7 +144,12 @@ public final class AssistantVoiceRuntimeService extends Service {
     private AssistantVoicePcmPlayer player;
     private AssistantVoiceMicStreamer micStreamer;
     private AssistantVoiceAudioRouter audioRouter;
+    private AssistantVoiceRealtimeClient realtimeClient;
+    private PowerManager.WakeLock realtimeWakeLock;
     private MediaSession mediaSession;
+    private String realtimeSessionId = "";
+    private String realtimeConversationId = "";
+    private boolean realtimeMuted = false;
     /** Monotonic controller generation; advanced on exclusive-owner transitions. */
     private long controllerGeneration = 1L;
     /** Generation stamped onto the currently admitted Thread media interaction. */
@@ -312,6 +324,66 @@ public final class AssistantVoiceRuntimeService extends Service {
         micStreamer.setAudioRouter(audioRouter);
         player = new AssistantVoicePcmPlayer(this);
         player.setAudioRouter(audioRouter);
+        realtimeClient = new AssistantVoiceRealtimeClient(this, httpClient);
+        realtimeClient.setListener(new AssistantVoiceRealtimeClient.Listener() {
+            @Override
+            public void onConnecting() {
+                mainHandler.post(() -> updateState(STATE_REALTIME_CONNECTING, null));
+            }
+
+            @Override
+            public void onConnected(String sessionId, String conversationId) {
+                mainHandler.post(() -> {
+                    realtimeSessionId = sessionId == null ? "" : sessionId;
+                    realtimeConversationId = conversationId == null ? "" : conversationId;
+                    if (!realtimeConversationId.isEmpty() && config != null) {
+                        try {
+                            JSONObject patch = new JSONObject();
+                            patch.put("realtimeConversationId", realtimeConversationId);
+                            config = config.withVoiceSettings(patch);
+                            AssistantVoiceConfig.save(AssistantVoiceRuntimeService.this, config);
+                        } catch (Exception ignored) {
+                        }
+                    }
+                    acquireRealtimeWakeLock();
+                    updateState(STATE_REALTIME_ACTIVE, null);
+                });
+            }
+
+            @Override
+            public void onFailed(String message) {
+                mainHandler.post(() -> {
+                    releaseRealtimeWakeLock();
+                    stopRealtimeOwner("realtime_failed");
+                    updateState(STATE_ERROR, message);
+                    emitRuntimeError(message == null ? "Realtime failed" : message);
+                });
+            }
+
+            @Override
+            public void onClosed(String reason) {
+                mainHandler.post(() -> {
+                    releaseRealtimeWakeLock();
+                    if (AssistantVoiceControllerPolicy.OWNER_REALTIME.equals(liveOwner)) {
+                        stopRealtimeOwner(reason == null ? "realtime_closed" : reason);
+                    }
+                    if (!STATE_ERROR.equals(runtimeState)) {
+                        updateState(resolveInactiveState(), null);
+                    }
+                });
+            }
+
+            @Override
+            public void onTranscript(String role, String text, boolean isFinal) {
+                // Native authority owns speech; transcript events are available for future UI sheets.
+                Log.d(TAG, "realtime transcript role=" + role + " final=" + isFinal + " len=" + (text == null ? 0 : text.length()));
+            }
+
+            @Override
+            public void onTool(String name, String status, String detail) {
+                Log.d(TAG, "realtime tool name=" + name + " status=" + status + " detail=" + safe(detail));
+            }
+        });
         config = AssistantVoiceConfig.load(this);
         micStreamer.setPreferredDeviceId(config.selectedMicDeviceId);
         player.setTtsGain(config.ttsGain);
@@ -402,8 +474,35 @@ public final class AssistantVoiceRuntimeService extends Service {
             applyConfig(updated);
             return START_STICKY;
         }
+        if (ACTION_START_REALTIME.equals(action)) {
+            startRealtimeCall("intent_start");
+            return START_STICKY;
+        }
+        if (ACTION_STOP_REALTIME.equals(action)) {
+            stopRealtimeCall("intent_stop");
+            return START_STICKY;
+        }
+        if (ACTION_SET_REALTIME_MUTED.equals(action)) {
+            boolean muted = intent != null && intent.getBooleanExtra(EXTRA_REALTIME_MUTED, false);
+            setRealtimeMuted(muted);
+            return START_STICKY;
+        }
 
         return START_STICKY;
+    }
+
+    public static Intent startRealtimeIntent(Context context) {
+        return new Intent(context, AssistantVoiceRuntimeService.class).setAction(ACTION_START_REALTIME);
+    }
+
+    public static Intent stopRealtimeIntent(Context context) {
+        return new Intent(context, AssistantVoiceRuntimeService.class).setAction(ACTION_STOP_REALTIME);
+    }
+
+    public static Intent setRealtimeMutedIntent(Context context, boolean muted) {
+        return new Intent(context, AssistantVoiceRuntimeService.class)
+            .setAction(ACTION_SET_REALTIME_MUTED)
+            .putExtra(EXTRA_REALTIME_MUTED, muted);
     }
 
     @Override
@@ -419,6 +518,11 @@ public final class AssistantVoiceRuntimeService extends Service {
         if (micStreamer != null) {
             micStreamer.release();
         }
+        if (realtimeClient != null) {
+            realtimeClient.release();
+            realtimeClient = null;
+        }
+        releaseRealtimeWakeLock();
         if (audioRouter != null) {
             audioRouter.shutdown();
         }
@@ -1789,6 +1893,13 @@ public final class AssistantVoiceRuntimeService extends Service {
         advanceControllerGeneration("prepare_realtime:" + safe(reason));
         if (player != null) {
             player.setPreferVoiceCommunicationCueFocus(true);
+            // Arming cue on voice-comm route when entering Realtime.
+            if (config != null && config.recognitionCueEnabled) {
+                player.playRecognitionCue(
+                    "__realtime_arming__:" + controllerGeneration,
+                    AssistantVoicePcmPlayer.RecognitionCueType.ARMING
+                );
+            }
         }
     }
 
@@ -1800,12 +1911,93 @@ public final class AssistantVoiceRuntimeService extends Service {
         if (audioRouter != null) {
             audioRouter.releaseAll(controllerGeneration);
         }
+        boolean success = reason == null
+            || (!reason.contains("fail") && !reason.contains("error") && !reason.contains("ice"));
         if (player != null) {
             player.setPreferVoiceCommunicationCueFocus(false);
+            if (config != null && config.recognitionCueEnabled) {
+                player.playRecognitionCue(
+                    "__realtime_completion__:" + controllerGeneration,
+                    success
+                        ? AssistantVoicePcmPlayer.RecognitionCueType.SUCCESS_COMPLETION
+                        : AssistantVoicePcmPlayer.RecognitionCueType.FAILURE_COMPLETION
+                );
+            }
         }
         liveOwner = AssistantVoiceControllerPolicy.OWNER_THREAD;
+        realtimeSessionId = "";
         advanceControllerGeneration("stop_realtime:" + safe(reason));
         resumeThreadAdmission();
+    }
+
+    private void startRealtimeCall(String reason) {
+        if (config == null || !config.isEnabled()) {
+            emitRuntimeError("Enable native voice before starting Realtime");
+            return;
+        }
+        if (realtimeClient == null) {
+            emitRuntimeError("Realtime client unavailable");
+            return;
+        }
+        if (AssistantVoiceControllerPolicy.OWNER_REALTIME.equals(liveOwner)
+            && (STATE_REALTIME_ACTIVE.equals(runtimeState)
+                || STATE_REALTIME_CONNECTING.equals(runtimeState))) {
+            Log.d(TAG, "startRealtimeCall ignored already active");
+            return;
+        }
+        prepareRealtimeOwnerPreempt(reason);
+        realtimeMuted = config.realtimeMuteOnStart;
+        realtimeClient.start(
+            config.assistantBaseUrl,
+            config.realtimeConversationId,
+            config.realtimeListsInstanceId,
+            config.realtimeMuteOnStart,
+            controllerGeneration,
+            audioRouter
+        );
+    }
+
+    private void stopRealtimeCall(String reason) {
+        if (realtimeClient != null) {
+            realtimeClient.stop(reason);
+        }
+        releaseRealtimeWakeLock();
+        stopRealtimeOwner(reason);
+        updateState(resolveInactiveState(), null);
+    }
+
+    private void setRealtimeMuted(boolean muted) {
+        realtimeMuted = muted;
+        if (realtimeClient != null) {
+            realtimeClient.setMuted(muted);
+        }
+        refreshNotification();
+    }
+
+    private void acquireRealtimeWakeLock() {
+        if (realtimeWakeLock != null && realtimeWakeLock.isHeld()) {
+            return;
+        }
+        PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
+        if (powerManager == null) {
+            return;
+        }
+        realtimeWakeLock = powerManager.newWakeLock(
+            PowerManager.PARTIAL_WAKE_LOCK,
+            "assistant:voice-realtime"
+        );
+        realtimeWakeLock.setReferenceCounted(false);
+        realtimeWakeLock.acquire(60 * 60 * 1000L);
+    }
+
+    private void releaseRealtimeWakeLock() {
+        if (realtimeWakeLock != null && realtimeWakeLock.isHeld()) {
+            try {
+                realtimeWakeLock.release();
+            } catch (Exception ignored) {
+            }
+        }
+        realtimeWakeLock = null;
     }
 
     private void drainVoiceQueueIfPossible() {

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
@@ -327,13 +327,28 @@ public final class AssistantVoiceRuntimeService extends Service {
         realtimeClient = new AssistantVoiceRealtimeClient(this, httpClient);
         realtimeClient.setListener(new AssistantVoiceRealtimeClient.Listener() {
             @Override
-            public void onConnecting() {
-                mainHandler.post(() -> updateState(STATE_REALTIME_CONNECTING, null));
+            public void onConnecting(long ownerGeneration) {
+                mainHandler.post(() -> {
+                    if (!isRealtimeCallbackCurrent(ownerGeneration)) {
+                        return;
+                    }
+                    updateState(STATE_REALTIME_CONNECTING, null);
+                });
             }
 
             @Override
-            public void onConnected(String sessionId, String conversationId) {
+            public void onConnected(String sessionId, String conversationId, long ownerGeneration) {
                 mainHandler.post(() -> {
+                    if (!isRealtimeCallbackCurrent(ownerGeneration)) {
+                        Log.d(
+                            TAG,
+                            "onConnected ignored stale generation="
+                                + ownerGeneration
+                                + " current="
+                                + controllerGeneration
+                        );
+                        return;
+                    }
                     realtimeSessionId = sessionId == null ? "" : sessionId;
                     realtimeConversationId = conversationId == null ? "" : conversationId;
                     if (!realtimeConversationId.isEmpty() && config != null) {
@@ -345,28 +360,62 @@ public final class AssistantVoiceRuntimeService extends Service {
                         } catch (Exception ignored) {
                         }
                     }
+                    // Arming cue on ready (connected), not at preempt.
+                    if (player != null && config != null && config.recognitionCueEnabled) {
+                        player.playRecognitionCue(
+                            "__realtime_arming__:" + controllerGeneration,
+                            AssistantVoicePcmPlayer.RecognitionCueType.ARMING
+                        );
+                    }
                     acquireRealtimeWakeLock();
                     updateState(STATE_REALTIME_ACTIVE, null);
                 });
             }
 
             @Override
-            public void onFailed(String message) {
+            public void onFailed(String message, long ownerGeneration) {
                 mainHandler.post(() -> {
+                    // Generation match only — never let a superseded call tear down a newer one.
+                    if (!isRealtimeCallbackCurrent(ownerGeneration)) {
+                        Log.d(
+                            TAG,
+                            "onFailed ignored stale generation="
+                                + ownerGeneration
+                                + " current="
+                                + controllerGeneration
+                        );
+                        return;
+                    }
                     releaseRealtimeWakeLock();
-                    stopRealtimeOwner("realtime_failed");
+                    stopRealtimeOwner("realtime_failed", false);
                     updateState(STATE_ERROR, message);
                     emitRuntimeError(message == null ? "Realtime failed" : message);
                 });
             }
 
             @Override
-            public void onClosed(String reason) {
+            public void onClosed(String reason, long ownerGeneration) {
                 mainHandler.post(() -> {
-                    releaseRealtimeWakeLock();
-                    if (AssistantVoiceControllerPolicy.OWNER_REALTIME.equals(liveOwner)) {
-                        stopRealtimeOwner(reason == null ? "realtime_closed" : reason);
+                    // Generation match only. Intentional stop already advanced the generation and
+                    // ran stopRealtimeOwner; late closes from that generation must not run again
+                    // against a newer Realtime call.
+                    if (!isRealtimeCallbackCurrent(ownerGeneration)) {
+                        Log.d(
+                            TAG,
+                            "onClosed ignored stale generation="
+                                + ownerGeneration
+                                + " current="
+                                + controllerGeneration
+                                + " reason="
+                                + safe(reason)
+                        );
+                        return;
                     }
+                    releaseRealtimeWakeLock();
+                    stopRealtimeOwner(
+                        reason == null ? "realtime_closed" : reason,
+                        isRealtimeCloseSuccessful(reason)
+                    );
                     if (!STATE_ERROR.equals(runtimeState)) {
                         updateState(resolveInactiveState(), null);
                     }
@@ -820,6 +869,23 @@ public final class AssistantVoiceRuntimeService extends Service {
     static boolean hasActiveRealtimeInteraction(String state, String liveOwner) {
         return isRealtimeActiveState(state)
             || AssistantVoiceControllerPolicy.OWNER_REALTIME.equals(trim(liveOwner));
+    }
+
+    /**
+     * While Realtime is the exclusive owner, only Realtime/error/disabled states may be applied.
+     * Thread socket reconnect handlers must not force IDLE/CONNECTING mid-call.
+     */
+    static boolean shouldAcceptStateUpdateWhileRealtimeOwner(
+        boolean realtimeOwnerActive,
+        String nextState
+    ) {
+        if (!realtimeOwnerActive) {
+            return true;
+        }
+        String normalized = trim(nextState);
+        return isRealtimeActiveState(normalized)
+            || STATE_ERROR.equals(normalized)
+            || STATE_DISABLED.equals(normalized);
     }
 
     /** @deprecated Prefer {@link #hasActiveRealtimeInteraction(String, String)}. */
@@ -1981,9 +2047,8 @@ public final class AssistantVoiceRuntimeService extends Service {
     }
 
     /**
-     * Phase-1 stub for the exclusive Realtime owner transition without WebRTC media.
-     * Preempts Thread (stop + clear FIFO + pause admission) and advances generation so later
-     * Realtime media can plug into the same fence.
+     * Preempts Thread (stop + clear FIFO + pause admission) and advances generation so Realtime
+     * media can own the audio path. Arming cue plays later on connected+ready.
      */
     void prepareRealtimeOwnerPreempt(String reason) {
         stopAndClearQueue(reason);
@@ -1993,26 +2058,21 @@ public final class AssistantVoiceRuntimeService extends Service {
         advanceControllerGeneration("prepare_realtime:" + safe(reason));
         if (player != null) {
             player.setPreferVoiceCommunicationCueFocus(true);
-            // Arming cue on voice-comm route when entering Realtime.
-            if (config != null && config.recognitionCueEnabled) {
-                player.playRecognitionCue(
-                    "__realtime_arming__:" + controllerGeneration,
-                    AssistantVoicePcmPlayer.RecognitionCueType.ARMING
-                );
-            }
         }
     }
 
     void stopRealtimeOwner(String reason) {
+        stopRealtimeOwner(reason, isRealtimeCloseSuccessful(reason));
+    }
+
+    void stopRealtimeOwner(String reason, boolean success) {
         if (!AssistantVoiceControllerPolicy.OWNER_REALTIME.equals(liveOwner)) {
             return;
         }
-        Log.d(TAG, "stopRealtimeOwner reason=" + safe(reason));
+        Log.d(TAG, "stopRealtimeOwner reason=" + safe(reason) + " success=" + success);
         if (audioRouter != null) {
             audioRouter.releaseAll(controllerGeneration);
         }
-        boolean success = reason == null
-            || (!reason.contains("fail") && !reason.contains("error") && !reason.contains("ice"));
         if (player != null) {
             player.setPreferVoiceCommunicationCueFocus(false);
             if (config != null && config.recognitionCueEnabled) {
@@ -2028,6 +2088,34 @@ public final class AssistantVoiceRuntimeService extends Service {
         realtimeSessionId = "";
         advanceControllerGeneration("stop_realtime:" + safe(reason));
         resumeThreadAdmission();
+    }
+
+    /**
+     * Explicit success/failure for completion cues. Avoid free-text substring sniffing so provider
+     * drops like {@code sideband_closed} are not mislabeled as success.
+     */
+    static boolean isRealtimeCloseSuccessful(String reason) {
+        String normalized = trim(reason);
+        if (normalized.isEmpty()) {
+            return true;
+        }
+        if (normalized.startsWith("intent_")
+            || normalized.startsWith("config_")
+            || "client_stop".equals(normalized)
+            || "user_stop".equals(normalized)
+            || "manual_stop".equals(normalized)
+            || "stale_owner_recover".equals(normalized)
+            || "agent_end".equals(normalized)
+            || "user_request".equals(normalized)
+            || "done".equals(normalized)) {
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isRealtimeCallbackCurrent(long ownerGeneration) {
+        return AssistantVoiceControllerPolicy.OWNER_REALTIME.equals(liveOwner)
+            && AssistantVoiceControllerPolicy.isCurrentGeneration(controllerGeneration, ownerGeneration);
     }
 
     private void startRealtimeCall(String reason) {
@@ -2075,7 +2163,7 @@ public final class AssistantVoiceRuntimeService extends Service {
         releaseRealtimeWakeLock();
         // Owner fence returns to Thread immediately; client async teardown must not leave us
         // stuck in REALTIME_ACTIVE so the next start is ignored.
-        stopRealtimeOwner(reason);
+        stopRealtimeOwner(reason, isRealtimeCloseSuccessful(reason));
         updateState(resolveInactiveState(), null);
     }
 
@@ -2087,6 +2175,7 @@ public final class AssistantVoiceRuntimeService extends Service {
         refreshNotification();
     }
 
+    @SuppressWarnings("deprecation")
     private void acquireRealtimeWakeLock() {
         if (realtimeWakeLock != null && realtimeWakeLock.isHeld()) {
             return;
@@ -2100,7 +2189,9 @@ public final class AssistantVoiceRuntimeService extends Service {
             "assistant:voice-realtime"
         );
         realtimeWakeLock.setReferenceCounted(false);
-        realtimeWakeLock.acquire(60 * 60 * 1000L);
+        // No fixed timeout: long background calls must not lose the lock after 1h.
+        // Released generation-scoped in releaseRealtimeWakeLock()/stop paths.
+        realtimeWakeLock.acquire();
     }
 
     private void releaseRealtimeWakeLock() {
@@ -3712,6 +3803,21 @@ public final class AssistantVoiceRuntimeService extends Service {
         String normalizedError = trim(maybeErrorMessage);
         if (normalizedState.isEmpty()) {
             normalizedState = STATE_DISABLED;
+        }
+        // While Realtime owns media, ignore Thread-path idle/connecting/speaking/listening
+        // stomps from adapter/assistant socket lifecycle (reconnects during a live call).
+        if (!shouldAcceptStateUpdateWhileRealtimeOwner(
+            AssistantVoiceControllerPolicy.OWNER_REALTIME.equals(liveOwner),
+            normalizedState
+        )) {
+            Log.d(
+                TAG,
+                "updateState ignored while realtime owner previous="
+                    + previousState
+                    + " next="
+                    + normalizedState
+            );
+            return;
         }
         if (runtimeState.equals(normalizedState) && normalizedError.isEmpty()) {
             return;

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
@@ -419,7 +419,7 @@ public final class AssistantVoiceRuntimeService extends Service {
         }
         if (ACTION_STOP_CURRENT_INTERACTION.equals(action)) {
             recordVoiceEvent("service_action_stop_current_interaction", null);
-            stopCurrentInteraction(isPromptPlaybackActive(), "manual_stop");
+            handleUserStopRequest("notification_stop");
             return START_STICKY;
         }
         if (ACTION_START_MANUAL_LISTEN.equals(action)) {
@@ -427,7 +427,7 @@ public final class AssistantVoiceRuntimeService extends Service {
             JSONObject details = AssistantVoiceEventLog.details();
             AssistantVoiceEventLog.put(details, "sessionId", safe(sessionId));
             recordVoiceEvent("service_action_start_manual_listen", details);
-            startManualListen(sessionId);
+            handleUserStartRequest(sessionId, "notification_speak");
             return START_STICKY;
         }
         if (ACTION_RETARGET_ACTIVE_RECOGNITION.equals(action)) {
@@ -653,7 +653,7 @@ public final class AssistantVoiceRuntimeService extends Service {
                         Log.d(TAG, "MediaSession onPlay ignored: media buttons disabled");
                         return;
                     }
-                    startManualListen("");
+                    handleMediaButtonStart("media_session_play");
                 });
             }
 
@@ -692,14 +692,17 @@ public final class AssistantVoiceRuntimeService extends Service {
     }
 
     private void handleMediaButtonKeyCode(int keyCode) {
+        boolean activeInteraction = hasActiveInteraction() || isRealtimeMediaInteractionActive();
         Log.d(
             TAG,
             "handleMediaButtonKeyCode keyCode="
                 + KeyEvent.keyCodeToString(keyCode)
                 + " runtimeState="
                 + runtimeState
+                + " runtimeMode="
+                + (config == null ? "" : config.voiceRuntimeMode)
                 + " hasActiveInteraction="
-                + hasActiveInteraction()
+                + activeInteraction
         );
         switch (keyCode) {
             case KeyEvent.KEYCODE_MEDIA_PLAY:
@@ -707,10 +710,10 @@ public final class AssistantVoiceRuntimeService extends Service {
             case KeyEvent.KEYCODE_MEDIA_STOP:
             case KeyEvent.KEYCODE_HEADSETHOOK:
             case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:
-                if (shouldToggleMediaButtonToStop(runtimeState, hasActiveInteraction())) {
+                if (shouldToggleMediaButtonToStop(runtimeState, activeInteraction)) {
                     handleMediaSessionStop();
                 } else {
-                    startManualListen("");
+                    handleMediaButtonStart("media_button");
                 }
                 return;
             default:
@@ -718,21 +721,68 @@ public final class AssistantVoiceRuntimeService extends Service {
         }
     }
 
+    private void handleMediaButtonStart(String reason) {
+        if (config == null || !config.mediaButtonsEnabled) {
+            Log.d(TAG, "handleMediaButtonStart ignored: media buttons disabled");
+            return;
+        }
+        handleUserStartRequest("", reason);
+    }
+
     private void handleMediaSessionStop() {
-        if (!config.mediaButtonsEnabled) {
+        if (config == null || !config.mediaButtonsEnabled) {
             Log.d(TAG, "handleMediaSessionStop ignored: media buttons disabled");
             return;
         }
+        handleUserStopRequest("media_button");
+    }
+
+    /**
+     * Shared start entry for headset media buttons and the notification Speak action.
+     * Realtime mode starts a Realtime call; Thread mode starts bounded STT listen.
+     */
+    private void handleUserStartRequest(String sessionId, String reason) {
+        if (config == null || !config.isEnabled()) {
+            Log.d(TAG, "handleUserStartRequest ignored: voice disabled reason=" + safe(reason));
+            return;
+        }
+        if (shouldStartRealtimeFromMediaButton(config.voiceRuntimeMode)) {
+            Log.d(TAG, "handleUserStartRequest realtime reason=" + safe(reason));
+            startRealtimeCall(reason);
+            return;
+        }
+        Log.d(TAG, "handleUserStartRequest thread reason=" + safe(reason));
+        startManualListen(sessionId == null ? "" : sessionId);
+    }
+
+    /**
+     * Shared stop entry for headset media buttons and the notification Stop action.
+     */
+    private void handleUserStopRequest(String reason) {
         Log.d(
             TAG,
-            "handleMediaSessionStop runtimeState="
+            "handleUserStopRequest reason="
+                + safe(reason)
+                + " runtimeState="
                 + runtimeState
+                + " runtimeMode="
+                + (config == null ? "" : config.voiceRuntimeMode)
+                + " liveOwner="
+                + liveOwner
                 + " promptPlaybackActive="
                 + isPromptPlaybackActive()
                 + " activeSttRequestId="
                 + !activeSttRequestId.isEmpty()
         );
+        if (hasActiveRealtimeInteraction(runtimeState, liveOwner)) {
+            stopRealtimeCall(reason);
+            return;
+        }
         stopCurrentInteraction(isPromptPlaybackActive(), "manual_stop");
+    }
+
+    private boolean isRealtimeMediaInteractionActive() {
+        return hasActiveRealtimeInteraction(runtimeState, liveOwner);
     }
 
     static boolean shouldHandleMediaButtonKeyEvent(KeyEvent event) {
@@ -741,10 +791,45 @@ public final class AssistantVoiceRuntimeService extends Service {
             && event.getRepeatCount() == 0;
     }
 
+    static boolean isRealtimeRuntimeMode(String voiceRuntimeMode) {
+        return AssistantVoiceConfig.RUNTIME_MODE_REALTIME.equals(trim(voiceRuntimeMode));
+    }
+
+    static boolean isRealtimeActiveState(String state) {
+        String normalized = trim(state);
+        return STATE_REALTIME_ACTIVE.equals(normalized)
+            || STATE_REALTIME_CONNECTING.equals(normalized);
+    }
+
+    /**
+     * Headset/media start uses Realtime when the user selected Realtime runtime mode.
+     * Thread mode continues to start bounded STT listen.
+     */
+    static boolean shouldStartRealtimeFromMediaButton(String voiceRuntimeMode) {
+        return isRealtimeRuntimeMode(voiceRuntimeMode);
+    }
+
+    /**
+     * True while a Realtime call is connecting/active or ownership is still Realtime
+     * (covers brief transition windows where state lags owner).
+     */
+    static boolean hasActiveRealtimeInteraction(String state, String liveOwner) {
+        return isRealtimeActiveState(state)
+            || AssistantVoiceControllerPolicy.OWNER_REALTIME.equals(trim(liveOwner));
+    }
+
+    /** @deprecated Prefer {@link #hasActiveRealtimeInteraction(String, String)}. */
+    static boolean shouldStopRealtimeFromMediaButton(String state, String liveOwner) {
+        return hasActiveRealtimeInteraction(state, liveOwner);
+    }
+
     static boolean shouldStopForMediaButtonToggle(String state, boolean hasActiveInteraction) {
+        // Callers should OR realtime activity into hasActiveInteraction; state checks cover
+        // Thread listening/speaking and Realtime connecting/active when the flag lags.
         return hasActiveInteraction
             || STATE_LISTENING.equals(trim(state))
-            || STATE_SPEAKING.equals(trim(state));
+            || STATE_SPEAKING.equals(trim(state))
+            || isRealtimeActiveState(state);
     }
 
     static boolean shouldToggleMediaButtonToStop(String state, boolean hasActiveInteraction) {
@@ -775,12 +860,16 @@ public final class AssistantVoiceRuntimeService extends Service {
         }
         boolean enabled = config.isEnabled() && config.mediaButtonsEnabled && !destroyed;
         int mediaPlaybackState = resolveMediaSessionPlaybackState(runtimeState);
+        boolean playingForSpeed =
+            STATE_SPEAKING.equals(runtimeState)
+                || STATE_LISTENING.equals(runtimeState)
+                || STATE_REALTIME_ACTIVE.equals(runtimeState);
         PlaybackState.Builder playbackState = new PlaybackState.Builder()
             .setActions(enabled ? MEDIA_SESSION_PLAYBACK_ACTIONS : 0L)
             .setState(
                 mediaPlaybackState,
                 PlaybackState.PLAYBACK_POSITION_UNKNOWN,
-                STATE_SPEAKING.equals(runtimeState) || STATE_LISTENING.equals(runtimeState) ? 1.0f : 0.0f
+                playingForSpeed ? 1.0f : 0.0f
             );
         mediaSession.setPlaybackState(playbackState.build());
         mediaSession.setActive(enabled);
@@ -858,16 +947,20 @@ public final class AssistantVoiceRuntimeService extends Service {
             PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT
         );
 
+        boolean realtimeActive = isRealtimeMediaInteractionActive();
         boolean showSpeakAction = AssistantVoiceInteractionRules.shouldShowNotificationSpeakAction(
             config.allowsNotificationSpeak(),
             config.preferredVoiceSessionId,
             isPromptPlaybackActive(),
             !activeSttRequestId.isEmpty(),
-            isRuntimeConnected()
+            isRuntimeConnected(),
+            isRealtimeRuntimeMode(config.voiceRuntimeMode),
+            realtimeActive
         );
         boolean showStopAction = AssistantVoiceInteractionRules.shouldShowNotificationStopAction(
             isPromptPlaybackActive(),
-            !activeSttRequestId.isEmpty()
+            !activeSttRequestId.isEmpty(),
+            realtimeActive
         );
         String notificationSessionTitle = resolveNotificationSessionTitle();
 
@@ -1097,7 +1190,10 @@ public final class AssistantVoiceRuntimeService extends Service {
         switch (trim(state)) {
             case STATE_LISTENING:
             case STATE_SPEAKING:
+            case STATE_REALTIME_ACTIVE:
                 return PlaybackState.STATE_PLAYING;
+            case STATE_REALTIME_CONNECTING:
+                return PlaybackState.STATE_BUFFERING;
             case STATE_DISABLED:
                 return PlaybackState.STATE_STOPPED;
             case STATE_ERROR:
@@ -1935,18 +2031,29 @@ public final class AssistantVoiceRuntimeService extends Service {
             emitRuntimeError("Enable native voice before starting Realtime");
             return;
         }
+        if (STATE_REALTIME_ACTIVE.equals(runtimeState)
+            || STATE_REALTIME_CONNECTING.equals(runtimeState)) {
+            Log.d(TAG, "startRealtimeCall ignored already active state=" + runtimeState);
+            return;
+        }
+        // If a previous call left liveOwner stuck without an active connection (failed restart),
+        // recover by forcing a clean Thread owner before pre-empting again. Suppress onClosed so
+        // the async teardown of the old client cannot tear down the new call.
+        if (AssistantVoiceControllerPolicy.OWNER_REALTIME.equals(liveOwner)) {
+            Log.d(TAG, "startRealtimeCall recovering stale realtime owner before restart");
+            if (realtimeClient != null) {
+                realtimeClient.stop("stale_owner_recover", false);
+            }
+            releaseRealtimeWakeLock();
+            stopRealtimeOwner("stale_owner_recover");
+        }
         if (realtimeClient == null) {
             emitRuntimeError("Realtime client unavailable");
             return;
         }
-        if (AssistantVoiceControllerPolicy.OWNER_REALTIME.equals(liveOwner)
-            && (STATE_REALTIME_ACTIVE.equals(runtimeState)
-                || STATE_REALTIME_CONNECTING.equals(runtimeState))) {
-            Log.d(TAG, "startRealtimeCall ignored already active");
-            return;
-        }
         prepareRealtimeOwnerPreempt(reason);
         realtimeMuted = config.realtimeMuteOnStart;
+        updateState(STATE_REALTIME_CONNECTING, null);
         realtimeClient.start(
             config.assistantBaseUrl,
             config.realtimeConversationId,
@@ -1962,6 +2069,8 @@ public final class AssistantVoiceRuntimeService extends Service {
             realtimeClient.stop(reason);
         }
         releaseRealtimeWakeLock();
+        // Owner fence returns to Thread immediately; client async teardown must not leave us
+        // stuck in REALTIME_ACTIVE so the next start is ignored.
         stopRealtimeOwner(reason);
         updateState(resolveInactiveState(), null);
     }

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
@@ -560,15 +560,19 @@ public final class AssistantVoiceRuntimeService extends Service {
         boolean adapterUrlChanged = !previous.voiceAdapterBaseUrl.equals(updated.voiceAdapterBaseUrl);
         boolean assistantUrlChanged = !previous.assistantBaseUrl.equals(updated.assistantBaseUrl);
 
-        // Contract seam for Phase 3: leaving Realtime while it is the live owner must stop it.
+        // Leaving Realtime preference (or an active Realtime owner) must fully stop the call —
+        // owner fence alone leaves WebRTC/media live and the next mic press can race.
         if (
             AssistantVoiceControllerPolicy.shouldStopRealtimeForConfig(
                 previous.voiceRuntimeMode,
                 updated.voiceRuntimeMode,
                 liveOwner
             )
+            || (AssistantVoiceControllerPolicy.isRealtimeRuntimeMode(previous.voiceRuntimeMode)
+                && !AssistantVoiceControllerPolicy.isRealtimeRuntimeMode(updated.voiceRuntimeMode)
+                && isRealtimeActiveState(runtimeState))
         ) {
-            stopRealtimeOwner("config_runtime_mode");
+            stopRealtimeCall("config_runtime_mode");
         }
 
         if (!updated.isEnabled()) {

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceUrlUtils.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceUrlUtils.java
@@ -82,6 +82,39 @@ final class AssistantVoiceUrlUtils {
         return joinApiPath(baseUrl, "api/plugins/notifications/operations/clear");
     }
 
+    static String assistantVoiceCapabilitiesUrl(String baseUrl) {
+        return joinApiPath(baseUrl, "api/voice/capabilities");
+    }
+
+    static String assistantVoiceSessionsUrl(String baseUrl) {
+        return joinApiPath(baseUrl, "api/voice/sessions");
+    }
+
+    static String assistantVoiceSessionOfferUrl(String baseUrl, String sessionId) {
+        return joinApiPath(baseUrl, "api/voice/sessions/" + encode(sessionId) + "/offer");
+    }
+
+    static String assistantVoiceSessionHeartbeatUrl(String baseUrl, String sessionId) {
+        return joinApiPath(baseUrl, "api/voice/sessions/" + encode(sessionId) + "/heartbeat");
+    }
+
+    static String assistantVoiceSessionMuteUrl(String baseUrl, String sessionId) {
+        return joinApiPath(baseUrl, "api/voice/sessions/" + encode(sessionId) + "/mute");
+    }
+
+    static String assistantVoiceSessionEventsUrl(String baseUrl, String sessionId, long after) {
+        return joinApiPath(baseUrl, "api/voice/sessions/" + encode(sessionId) + "/events")
+            + "?after=" + after;
+    }
+
+    static String assistantVoiceSessionCloseUrl(String baseUrl, String sessionId) {
+        return joinApiPath(baseUrl, "api/voice/sessions/" + encode(sessionId) + "/close");
+    }
+
+    private static String encode(String value) {
+        return Uri.encode(value == null ? "" : value);
+    }
+
     private static String joinApiPath(String baseUrl, String suffix) {
         Uri base = Uri.parse(normalizeBaseUrl(baseUrl, AssistantVoiceConfig.DEFAULT_ASSISTANT_BASE_URL));
         return base.buildUpon()

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceAudioRouterTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceAudioRouterTest.java
@@ -1,0 +1,60 @@
+package com.assistant.mobile.voice;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.os.Build;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = Build.VERSION_CODES.N)
+public final class AssistantVoiceAudioRouterTest {
+    @Test
+    public void requestAndReleaseFocusTracksOwnerGeneration() {
+        AssistantVoiceAudioRouter router =
+            new AssistantVoiceAudioRouter(RuntimeEnvironment.getApplication());
+
+        assertTrue(router.requestPlaybackFocus(7L));
+        assertEquals(7L, router.activeOwnerGeneration());
+        assertEquals(AssistantVoiceAudioRouter.FocusKind.PLAYBACK, router.focusKind());
+
+        router.abandonFocus(7L);
+        assertEquals(0L, router.activeOwnerGeneration());
+        assertEquals(AssistantVoiceAudioRouter.FocusKind.NONE, router.focusKind());
+    }
+
+    @Test
+    public void staleGenerationCannotLeaveCommunicationMode() {
+        AssistantVoiceAudioRouter router =
+            new AssistantVoiceAudioRouter(RuntimeEnvironment.getApplication());
+
+        router.enterCommunicationMode(3L);
+        assertTrue(router.isCommunicationModeActive());
+
+        router.leaveCommunicationMode(2L);
+        assertTrue(router.isCommunicationModeActive());
+
+        router.leaveCommunicationMode(3L);
+        assertFalse(router.isCommunicationModeActive());
+    }
+
+    @Test
+    public void releaseAllClearsModeAndFocus() {
+        AssistantVoiceAudioRouter router =
+            new AssistantVoiceAudioRouter(RuntimeEnvironment.getApplication());
+
+        assertTrue(router.requestCaptureFocus(9L));
+        router.enterCommunicationMode(9L);
+        router.releaseAll(9L);
+
+        assertEquals(AssistantVoiceAudioRouter.FocusKind.NONE, router.focusKind());
+        assertFalse(router.isCommunicationModeActive());
+        assertEquals(0L, router.activeOwnerGeneration());
+    }
+}

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceConfigTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceConfigTest.java
@@ -185,6 +185,7 @@ public final class AssistantVoiceConfigTest {
     private static AssistantVoiceConfig createConfigWithAudioMode(String audioMode) {
         return new AssistantVoiceConfig(
             audioMode,
+            AssistantVoiceConfig.DEFAULT_RUNTIME_MODE,
             true,
             "",
             AssistantVoiceConfig.DEFAULT_RECOGNITION_START_TIMEOUT_MS,
@@ -289,6 +290,7 @@ public final class AssistantVoiceConfigTest {
     ) {
         return new AssistantVoiceConfig(
             AssistantVoiceConfig.AUDIO_MODE_TOOL,
+            AssistantVoiceConfig.DEFAULT_RUNTIME_MODE,
             true,
             "",
             AssistantVoiceConfig.DEFAULT_RECOGNITION_START_TIMEOUT_MS,

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceConfigTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceConfigTest.java
@@ -208,7 +208,10 @@ public final class AssistantVoiceConfigTest {
             false,
             false,
             true,
-            false
+            false,
+            "",
+            false,
+            AssistantVoiceConfig.DEFAULT_REALTIME_LISTS_INSTANCE_ID
         );
     }
 
@@ -313,7 +316,10 @@ public final class AssistantVoiceConfigTest {
             mediaButtonsEnabled,
             false,
             true,
-            false
+            false,
+            "",
+            false,
+            AssistantVoiceConfig.DEFAULT_REALTIME_LISTS_INSTANCE_ID
         );
     }
 

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceControllerPolicyTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceControllerPolicyTest.java
@@ -1,0 +1,61 @@
+package com.assistant.mobile.voice;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public final class AssistantVoiceControllerPolicyTest {
+    @Test
+    public void normalizeRuntimeModeDefaultsToThread() {
+        assertEquals("thread", AssistantVoiceControllerPolicy.normalizeRuntimeMode(null));
+        assertEquals("thread", AssistantVoiceControllerPolicy.normalizeRuntimeMode(""));
+        assertEquals("thread", AssistantVoiceControllerPolicy.normalizeRuntimeMode("THREAD"));
+        assertEquals("realtime", AssistantVoiceControllerPolicy.normalizeRuntimeMode(" Realtime "));
+    }
+
+    @Test
+    public void threadAdmissionPausedOnlyWhenRealtimeIsLiveOwner() {
+        assertFalse(AssistantVoiceControllerPolicy.shouldPauseThreadAdmission("thread"));
+        assertTrue(AssistantVoiceControllerPolicy.shouldPauseThreadAdmission("realtime"));
+    }
+
+    @Test
+    public void generationFenceRequiresExactMatch() {
+        assertTrue(AssistantVoiceControllerPolicy.isCurrentGeneration(4L, 4L));
+        assertFalse(AssistantVoiceControllerPolicy.isCurrentGeneration(4L, 3L));
+        assertFalse(AssistantVoiceControllerPolicy.isCurrentGeneration(4L, 0L));
+    }
+
+    @Test
+    public void nextGenerationIsMonotonicAndSkipsZero() {
+        assertEquals(2L, AssistantVoiceControllerPolicy.nextGeneration(1L));
+        assertEquals(1L, AssistantVoiceControllerPolicy.nextGeneration(Long.MAX_VALUE));
+    }
+
+    @Test
+    public void shouldStopRealtimeWhenLeavingRealtimeWhileLive() {
+        assertTrue(
+            AssistantVoiceControllerPolicy.shouldStopRealtimeForConfig(
+                "realtime",
+                "thread",
+                "realtime"
+            )
+        );
+        assertFalse(
+            AssistantVoiceControllerPolicy.shouldStopRealtimeForConfig(
+                "realtime",
+                "thread",
+                "thread"
+            )
+        );
+        assertFalse(
+            AssistantVoiceControllerPolicy.shouldStopRealtimeForConfig(
+                "thread",
+                "realtime",
+                "thread"
+            )
+        );
+    }
+}

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceInteractionRulesTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceInteractionRulesTest.java
@@ -391,6 +391,8 @@ public final class AssistantVoiceInteractionRulesTest {
         assertTrue(AssistantVoiceInteractionRules.shouldShowNotificationStopAction(false, true));
         assertTrue(AssistantVoiceInteractionRules.shouldShowNotificationStopAction(true, true));
         assertFalse(AssistantVoiceInteractionRules.shouldShowNotificationStopAction(false, false));
+        assertTrue(AssistantVoiceInteractionRules.shouldShowNotificationStopAction(false, false, true));
+        assertFalse(AssistantVoiceInteractionRules.shouldShowNotificationStopAction(false, false, false));
     }
 
     @Test
@@ -436,6 +438,28 @@ public final class AssistantVoiceInteractionRulesTest {
             false,
             false,
             false
+        ));
+    }
+
+    @Test
+    public void showsNotificationSpeakActionInRealtimeModeWithoutThreadSession() {
+        assertTrue(AssistantVoiceInteractionRules.shouldShowNotificationSpeakAction(
+            true,
+            "",
+            false,
+            false,
+            false,
+            true,
+            false
+        ));
+        assertFalse(AssistantVoiceInteractionRules.shouldShowNotificationSpeakAction(
+            true,
+            "",
+            false,
+            false,
+            false,
+            true,
+            true
         ));
     }
 }

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRuntimeServiceTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRuntimeServiceTest.java
@@ -1212,7 +1212,10 @@ public final class AssistantVoiceRuntimeServiceTest {
             false,
             false,
             true,
-            false
+            false,
+            "",
+            false,
+            AssistantVoiceConfig.DEFAULT_REALTIME_LISTS_INSTANCE_ID
         );
     }
 

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRuntimeServiceTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRuntimeServiceTest.java
@@ -536,6 +536,18 @@ public final class AssistantVoiceRuntimeServiceTest {
             )
         );
         assertEquals(
+            android.media.session.PlaybackState.STATE_PLAYING,
+            AssistantVoiceRuntimeService.resolveMediaSessionPlaybackState(
+                AssistantVoiceRuntimeService.STATE_REALTIME_ACTIVE
+            )
+        );
+        assertEquals(
+            android.media.session.PlaybackState.STATE_BUFFERING,
+            AssistantVoiceRuntimeService.resolveMediaSessionPlaybackState(
+                AssistantVoiceRuntimeService.STATE_REALTIME_CONNECTING
+            )
+        );
+        assertEquals(
             android.media.session.PlaybackState.STATE_PAUSED,
             AssistantVoiceRuntimeService.resolveMediaSessionPlaybackState(
                 AssistantVoiceRuntimeService.STATE_IDLE
@@ -578,10 +590,71 @@ public final class AssistantVoiceRuntimeServiceTest {
             )
         );
         assertEquals(
+            true,
+            AssistantVoiceRuntimeService.shouldStopForMediaButtonToggle(
+                AssistantVoiceRuntimeService.STATE_REALTIME_ACTIVE,
+                false
+            )
+        );
+        assertEquals(
+            true,
+            AssistantVoiceRuntimeService.shouldStopForMediaButtonToggle(
+                AssistantVoiceRuntimeService.STATE_REALTIME_CONNECTING,
+                false
+            )
+        );
+        assertEquals(
             false,
             AssistantVoiceRuntimeService.shouldStopForMediaButtonToggle(
                 AssistantVoiceRuntimeService.STATE_IDLE,
                 false
+            )
+        );
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.N)
+    public void shouldStartRealtimeFromMediaButtonWhenRuntimeModeIsRealtime() {
+        assertEquals(
+            true,
+            AssistantVoiceRuntimeService.shouldStartRealtimeFromMediaButton(
+                AssistantVoiceConfig.RUNTIME_MODE_REALTIME
+            )
+        );
+        assertEquals(
+            false,
+            AssistantVoiceRuntimeService.shouldStartRealtimeFromMediaButton(
+                AssistantVoiceConfig.RUNTIME_MODE_THREAD
+            )
+        );
+        assertEquals(
+            false,
+            AssistantVoiceRuntimeService.shouldStartRealtimeFromMediaButton("")
+        );
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.N)
+    public void shouldStopRealtimeFromMediaButtonForActiveStateOrRealtimeOwner() {
+        assertEquals(
+            true,
+            AssistantVoiceRuntimeService.shouldStopRealtimeFromMediaButton(
+                AssistantVoiceRuntimeService.STATE_REALTIME_ACTIVE,
+                AssistantVoiceControllerPolicy.OWNER_THREAD
+            )
+        );
+        assertEquals(
+            true,
+            AssistantVoiceRuntimeService.shouldStopRealtimeFromMediaButton(
+                AssistantVoiceRuntimeService.STATE_IDLE,
+                AssistantVoiceControllerPolicy.OWNER_REALTIME
+            )
+        );
+        assertEquals(
+            false,
+            AssistantVoiceRuntimeService.shouldStopRealtimeFromMediaButton(
+                AssistantVoiceRuntimeService.STATE_IDLE,
+                AssistantVoiceControllerPolicy.OWNER_THREAD
             )
         );
     }

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRuntimeServiceTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRuntimeServiceTest.java
@@ -955,25 +955,108 @@ public final class AssistantVoiceRuntimeServiceTest {
 
     @Test
     @Config(sdk = Build.VERSION_CODES.N)
-    public void buildAdapterTtsRequestBodyTreatsClientIdAsOptional() {
-        assertFalse(
-            AssistantVoiceRuntimeService.buildAdapterTtsRequestBody("", "request-1", "hello", "")
-                .has("clientId")
+    public void controllerPolicyMatchesRealtimePreemptRules() {
+        assertTrue(
+            AssistantVoiceControllerPolicy.shouldPauseThreadAdmission(
+                AssistantVoiceControllerPolicy.OWNER_REALTIME
+            )
         );
+        assertFalse(
+            AssistantVoiceControllerPolicy.shouldAcceptThreadAdmission(true, true)
+        );
+        assertTrue(
+            AssistantVoiceControllerPolicy.shouldAcceptThreadAdmission(false, true)
+        );
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.N)
+    public void shouldWaitForAdapterClientIdentityBeforeDirectTtsPlayback() {
+        AssistantVoiceQueueItem ttsItem = new AssistantVoiceQueueItem(
+            "notification-1",
+            "voice_speak",
+            "test",
+            "event-1",
+            "session-1",
+            "Session 1",
+            "Session 1",
+            "hello",
+            "speak",
+            null,
+            false,
+            false
+        );
+        AssistantVoiceQueueItem listenOnlyItem = new AssistantVoiceQueueItem(
+            "notification-2",
+            "voice_ask",
+            "test",
+            "event-2",
+            "session-1",
+            "Session 1",
+            "Session 1",
+            "",
+            "listen_only",
+            null,
+            false,
+            true
+        );
+
+        assertTrue(
+            AssistantVoiceRuntimeService.shouldWaitForAdapterClientIdentity(true, "", ttsItem)
+        );
+        assertTrue(
+            AssistantVoiceRuntimeService.shouldWaitForAdapterClientIdentity(
+                true,
+                "   ",
+                ttsItem
+            )
+        );
+        assertFalse(
+            AssistantVoiceRuntimeService.shouldWaitForAdapterClientIdentity(
+                true,
+                "client-1",
+                ttsItem
+            )
+        );
+        assertFalse(
+            AssistantVoiceRuntimeService.shouldWaitForAdapterClientIdentity(false, "", ttsItem)
+        );
+        assertFalse(
+            AssistantVoiceRuntimeService.shouldWaitForAdapterClientIdentity(
+                true,
+                "",
+                listenOnlyItem
+            )
+        );
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.N)
+    public void buildAdapterTtsRequestBodyIncludesDirectMediaClientId() {
         assertEquals(
             "request-1",
-            AssistantVoiceRuntimeService.buildAdapterTtsRequestBody("", "request-1", "hello", "")
+            AssistantVoiceRuntimeService.buildAdapterTtsRequestBody(
+                "client-1",
+                "request-1",
+                "hello",
+                ""
+            )
                 .optString("requestId")
         );
         assertEquals(
             "hello",
-            AssistantVoiceRuntimeService.buildAdapterTtsRequestBody("", "request-1", "hello", "")
+            AssistantVoiceRuntimeService.buildAdapterTtsRequestBody(
+                "client-1",
+                "request-1",
+                "hello",
+                ""
+            )
                 .optString("text")
         );
         assertEquals(
             "session-1",
             AssistantVoiceRuntimeService.buildAdapterTtsRequestBody(
-                "",
+                "client-1",
                 "request-1",
                 "hello",
                 " session-1 "
@@ -1106,6 +1189,7 @@ public final class AssistantVoiceRuntimeServiceTest {
     ) {
         return new AssistantVoiceConfig(
             audioMode,
+            AssistantVoiceConfig.DEFAULT_RUNTIME_MODE,
             true,
             "",
             AssistantVoiceConfig.DEFAULT_RECOGNITION_START_TIMEOUT_MS,

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRuntimeServiceTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRuntimeServiceTest.java
@@ -661,6 +661,58 @@ public final class AssistantVoiceRuntimeServiceTest {
 
     @Test
     @Config(sdk = Build.VERSION_CODES.N)
+    public void shouldAcceptStateUpdateWhileRealtimeOwnerBlocksThreadStates() {
+        assertEquals(
+            true,
+            AssistantVoiceRuntimeService.shouldAcceptStateUpdateWhileRealtimeOwner(
+                false,
+                AssistantVoiceRuntimeService.STATE_IDLE
+            )
+        );
+        assertEquals(
+            false,
+            AssistantVoiceRuntimeService.shouldAcceptStateUpdateWhileRealtimeOwner(
+                true,
+                AssistantVoiceRuntimeService.STATE_IDLE
+            )
+        );
+        assertEquals(
+            false,
+            AssistantVoiceRuntimeService.shouldAcceptStateUpdateWhileRealtimeOwner(
+                true,
+                AssistantVoiceRuntimeService.STATE_CONNECTING
+            )
+        );
+        assertEquals(
+            true,
+            AssistantVoiceRuntimeService.shouldAcceptStateUpdateWhileRealtimeOwner(
+                true,
+                AssistantVoiceRuntimeService.STATE_REALTIME_ACTIVE
+            )
+        );
+        assertEquals(
+            true,
+            AssistantVoiceRuntimeService.shouldAcceptStateUpdateWhileRealtimeOwner(
+                true,
+                AssistantVoiceRuntimeService.STATE_ERROR
+            )
+        );
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.N)
+    public void isRealtimeCloseSuccessfulOnlyForUserOrAgentStops() {
+        assertEquals(true, AssistantVoiceRuntimeService.isRealtimeCloseSuccessful(null));
+        assertEquals(true, AssistantVoiceRuntimeService.isRealtimeCloseSuccessful("intent_stop"));
+        assertEquals(true, AssistantVoiceRuntimeService.isRealtimeCloseSuccessful("user_request"));
+        assertEquals(true, AssistantVoiceRuntimeService.isRealtimeCloseSuccessful("agent_end"));
+        assertEquals(false, AssistantVoiceRuntimeService.isRealtimeCloseSuccessful("sideband_closed"));
+        assertEquals(false, AssistantVoiceRuntimeService.isRealtimeCloseSuccessful("realtime_failed"));
+        assertEquals(false, AssistantVoiceRuntimeService.isRealtimeCloseSuccessful("ice_failed"));
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.N)
     public void resolveRecognitionSubmitSessionIdKeepsActiveRecognitionTarget() {
         assertEquals(
             "session-old",

--- a/packages/mobile-web/android/variables.gradle
+++ b/packages/mobile-web/android/variables.gradle
@@ -16,4 +16,5 @@ ext {
     androidxEspressoCoreVersion = '3.7.0'
     cordovaAndroidVersion = '14.0.1'
     okhttpVersion = '4.12.0'
+    streamWebRtcVersion = '1.3.10'
 }

--- a/packages/web-client/public/index.html
+++ b/packages/web-client/public/index.html
@@ -352,6 +352,20 @@
               <option value="realtime">Realtime</option>
             </select>
           </label>
+          <div id="realtime-voice-controls" class="voice-settings-grid" style="display: none">
+            <label class="settings-dropdown-item" for="realtime-mute-on-start-checkbox">
+              <input type="checkbox" id="realtime-mute-on-start-checkbox" />
+              Mute Realtime on start
+            </label>
+            <div class="voice-settings-actions" style="display: flex; gap: 8px; flex-wrap: wrap">
+              <button type="button" id="realtime-start-button" class="list-item-form-input">
+                Start Realtime call
+              </button>
+              <button type="button" id="realtime-stop-button" class="list-item-form-input">
+                Stop Realtime call
+              </button>
+            </div>
+          </div>
           <label class="list-item-form-label" for="audio-mode-select">
             <span class="list-item-form-label-text">Thread audio mode</span>
             <select id="audio-mode-select" class="list-item-form-input">

--- a/packages/web-client/public/index.html
+++ b/packages/web-client/public/index.html
@@ -345,8 +345,15 @@
           </button>
         </div>
         <div class="voice-settings-grid">
+          <label class="list-item-form-label" for="voice-runtime-mode-select">
+            <span class="list-item-form-label-text">Voice runtime</span>
+            <select id="voice-runtime-mode-select" class="list-item-form-input">
+              <option value="thread">Thread (queue)</option>
+              <option value="realtime">Realtime</option>
+            </select>
+          </label>
           <label class="list-item-form-label" for="audio-mode-select">
-            <span class="list-item-form-label-text">Audio Mode</span>
+            <span class="list-item-form-label-text">Thread audio mode</span>
             <select id="audio-mode-select" class="list-item-form-input">
               <option value="off">Off</option>
               <option value="manual">Manual</option>

--- a/packages/web-client/src/controllers/speechAudioController.test.ts
+++ b/packages/web-client/src/controllers/speechAudioController.test.ts
@@ -109,6 +109,10 @@ function createVoiceSettingsInputs(): {
 
 function createInitialVoiceSettings(overrides?: Partial<VoiceSettings>): VoiceSettings {
   return {
+    voiceRuntimeMode: 'thread',
+    realtimeConversationId: '',
+    realtimeMuteOnStart: false,
+    realtimeListsInstanceId: 'default',
     audioMode: 'off',
     autoListenEnabled: false,
     standaloneNotificationPlaybackEnabled: false,

--- a/packages/web-client/src/controllers/speechAudioController.ts
+++ b/packages/web-client/src/controllers/speechAudioController.ts
@@ -1422,23 +1422,37 @@ export class SpeechAudioController {
     enabled: boolean;
     mode: 'idle' | 'speaking' | 'listening' | 'realtime';
   } {
-    if (this.isNativeRealtimeActive()) {
+    // Active interactions stay actionable even if audioMode flipped mid-call.
+    if (
+      this.nativeRuntimeState === 'realtime_active' ||
+      this.nativeRuntimeState === 'realtime_connecting'
+    ) {
       return { enabled: true, mode: 'realtime' };
     }
-    if (this.isNativeListening()) {
+    if (this.nativeRuntimeState === 'listening') {
       return { enabled: true, mode: 'listening' };
     }
-    if (this.isNativeSpeaking()) {
+    if (this.nativeRuntimeState === 'speaking') {
       return { enabled: true, mode: 'speaking' };
     }
-    if (!this.isUsingNativeVoiceRuntime()) {
+
+    const bridgeAvailable = Boolean(
+      this.options.useNativeVoiceRuntime && this.options.nativeVoiceBridge?.isAvailable(),
+    );
+    if (!bridgeAvailable) {
+      return { enabled: false, mode: 'idle' };
+    }
+    // Native rejects starts when audioMode is off.
+    if (this.currentAudioMode === 'off') {
       return { enabled: false, mode: 'idle' };
     }
     if (this.isRealtimeRuntimeMode()) {
       // Realtime does not require a Thread session selection.
       return { enabled: true, mode: 'idle' };
     }
-    const hasSession = Boolean(sessionId && sessionId.trim().length > 0);
+    const hasSession =
+      Boolean(sessionId && sessionId.trim().length > 0) ||
+      Boolean(this.currentVoiceSettings.preferredVoiceSessionId?.trim());
     return { enabled: hasSession, mode: 'idle' };
   }
 

--- a/packages/web-client/src/controllers/speechAudioController.ts
+++ b/packages/web-client/src/controllers/speechAudioController.ts
@@ -104,6 +104,9 @@ export interface AssistantNativeVoiceBridgeTarget {
   setAssistantBaseUrl?: (args: AssistantNativeVoiceUrlArgs) => void | Promise<void>;
   stopCurrentInteraction?: () => void | Promise<void>;
   startManualListen?: (args?: AssistantNativeVoiceStartListenArgs) => void | Promise<void>;
+  startRealtime?: () => void | Promise<void>;
+  stopRealtime?: () => void | Promise<void>;
+  setRealtimeMuted?: (args: { muted: boolean }) => void | Promise<void>;
   playText?: (args: AssistantNativeVoicePlayTextArgs) => void | Promise<void>;
   listInputDevices?: () =>
     | AssistantNativeVoiceInputDevice[]
@@ -206,6 +209,18 @@ export class AssistantNativeVoiceBridge {
 
   startManualListen(sessionId?: string | null): boolean {
     return this.invoke('startManualListen', { sessionId: sessionId ?? null });
+  }
+
+  startRealtime(): boolean {
+    return this.invoke('startRealtime');
+  }
+
+  stopRealtime(): boolean {
+    return this.invoke('stopRealtime');
+  }
+
+  setRealtimeMuted(muted: boolean): boolean {
+    return this.invoke('setRealtimeMuted', { muted });
   }
 
   playText(args: AssistantNativeVoicePlayTextArgs): boolean {

--- a/packages/web-client/src/controllers/speechAudioController.ts
+++ b/packages/web-client/src/controllers/speechAudioController.ts
@@ -71,6 +71,8 @@ export type AssistantNativeVoiceRuntimeState =
   | 'idle'
   | 'speaking'
   | 'listening'
+  | 'realtime_connecting'
+  | 'realtime_active'
   | 'error';
 
 export interface AssistantNativeVoiceStatePayload {
@@ -1411,15 +1413,18 @@ export class SpeechAudioController {
 
   getVoiceFabState(): {
     enabled: boolean;
-    mode: 'idle' | 'speaking' | 'listening';
+    mode: 'idle' | 'speaking' | 'listening' | 'realtime';
   } {
     return this.getVoiceFabStateForSession(this.options.getSessionId());
   }
 
   getVoiceFabStateForSession(sessionId: string | null): {
     enabled: boolean;
-    mode: 'idle' | 'speaking' | 'listening';
+    mode: 'idle' | 'speaking' | 'listening' | 'realtime';
   } {
+    if (this.isNativeRealtimeActive()) {
+      return { enabled: true, mode: 'realtime' };
+    }
     if (this.isNativeListening()) {
       return { enabled: true, mode: 'listening' };
     }
@@ -1428,6 +1433,10 @@ export class SpeechAudioController {
     }
     if (!this.isUsingNativeVoiceRuntime()) {
       return { enabled: false, mode: 'idle' };
+    }
+    if (this.isRealtimeRuntimeMode()) {
+      // Realtime does not require a Thread session selection.
+      return { enabled: true, mode: 'idle' };
     }
     const hasSession = Boolean(sessionId && sessionId.trim().length > 0);
     return { enabled: hasSession, mode: 'idle' };
@@ -1445,6 +1454,21 @@ export class SpeechAudioController {
     if (!this.isUsingNativeVoiceRuntime()) {
       return false;
     }
+    // Push settings first so native voiceRuntimeMode matches the UI (dropdown) before start.
+    try {
+      await this.options.nativeVoiceBridge?.setVoiceSettings(this.currentVoiceSettings);
+    } catch (error) {
+      this.logState('fab-start-settings-sync-failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    if (this.isRealtimeRuntimeMode()) {
+      const started = this.options.nativeVoiceBridge?.startRealtime() ?? false;
+      if (!started) {
+        this.logState('fab-start-abort', { reason: 'native-realtime-start-unavailable' });
+      }
+      return started;
+    }
     const normalizedSessionId = sessionId?.trim() ?? '';
     if (!normalizedSessionId) {
       return false;
@@ -1461,6 +1485,10 @@ export class SpeechAudioController {
   }
 
   stopVoiceFromFab(): boolean {
+    if (this.isNativeRealtimeActive()) {
+      this.options.nativeVoiceBridge?.stopRealtime();
+      return true;
+    }
     if (this.isNativeInteractionActive()) {
       this.options.nativeVoiceBridge?.stopCurrentInteraction();
       return true;
@@ -1535,15 +1563,17 @@ export class SpeechAudioController {
     micButton.setAttribute('aria-hidden', 'false');
     const isNativeSpeaking = this.isNativeSpeaking();
     const isNativeListening = this.isNativeListening();
+    const isNativeRealtime = this.isNativeRealtimeActive();
     const shouldShowStop =
       isNativeListening ||
+      isNativeRealtime ||
       (!this.isUsingNativeVoiceRuntime() &&
         !this.isSpeechInputActive &&
         !this.isTtsPlaying &&
         this.options.isOutputActive());
     micButton.classList.toggle('stopping', shouldShowStop);
     micButton.classList.toggle('native-speaking', isNativeSpeaking);
-    micButton.classList.toggle('native-listening', isNativeListening);
+    micButton.classList.toggle('native-listening', isNativeListening || isNativeRealtime);
     this.renderMicButtonIcon(
       this.isSpeechInputActive || shouldShowStop
         ? 'stop'
@@ -1556,6 +1586,7 @@ export class SpeechAudioController {
       micButton.disabled &&
       (isNativeSpeaking ||
         isNativeListening ||
+        isNativeRealtime ||
         this.isSpeechInputActive ||
         this.isTtsPlaying ||
         this.options.isOutputActive() ||
@@ -1570,6 +1601,8 @@ export class SpeechAudioController {
     let label = 'Voice input';
     if (isNativeSpeaking) {
       label = 'Stop playback';
+    } else if (isNativeRealtime) {
+      label = 'Stop realtime call';
     } else if (isNativeListening) {
       label = 'Stop listening';
     } else if (this.isSpeechInputActive) {
@@ -1655,7 +1688,7 @@ export class SpeechAudioController {
   }
 
   private isNativeInteractionActive(): boolean {
-    return this.isNativeSpeaking() || this.isNativeListening();
+    return this.isNativeSpeaking() || this.isNativeListening() || this.isNativeRealtimeActive();
   }
 
   private isNativeSpeaking(): boolean {
@@ -1664,6 +1697,18 @@ export class SpeechAudioController {
 
   private isNativeListening(): boolean {
     return this.isNativeRuntimeAvailable() && this.nativeRuntimeState === 'listening';
+  }
+
+  private isNativeRealtimeActive(): boolean {
+    return (
+      this.isNativeRuntimeAvailable()
+      && (this.nativeRuntimeState === 'realtime_active'
+        || this.nativeRuntimeState === 'realtime_connecting')
+    );
+  }
+
+  private isRealtimeRuntimeMode(): boolean {
+    return this.currentVoiceSettings.voiceRuntimeMode === 'realtime';
   }
 
   private renderMicButtonIcon(mode: 'microphone' | 'speaker' | 'stop'): void {

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -528,6 +528,7 @@ async function main(): Promise<void> {
     voiceSettingsButton: voiceSettingsButtonEl,
     voiceSettingsModal: voiceSettingsModalEl,
     voiceSettingsCloseButton: voiceSettingsCloseButtonEl,
+    voiceRuntimeModeSelect: voiceRuntimeModeSelectEl,
     audioModeSelect: audioModeSelectEl,
     autoListenCheckbox: autoListenCheckboxEl,
     standaloneNotificationPlaybackCheckbox: standaloneNotificationPlaybackCheckboxEl,
@@ -3982,6 +3983,7 @@ async function main(): Promise<void> {
     const currentSettings = getCurrentVoiceSettings();
     const nextSettings = normalizeVoiceSettings({
       ...currentSettings,
+      voiceRuntimeMode: voiceRuntimeModeSelectEl.value,
       audioMode: audioModeSelectEl.value,
       autoListenEnabled: autoListenCheckboxEl.checked,
       standaloneNotificationPlaybackEnabled: standaloneNotificationPlaybackCheckboxEl.checked,
@@ -4018,6 +4020,7 @@ async function main(): Promise<void> {
     openVoiceSettingsModal();
   });
   [
+    voiceRuntimeModeSelectEl,
     audioModeSelectEl,
     autoListenCheckboxEl,
     standaloneNotificationPlaybackCheckboxEl,
@@ -4062,6 +4065,7 @@ async function main(): Promise<void> {
   voiceTtsGainSliderEl.addEventListener('input', syncTtsGainLabelFromSlider);
   const resetVoiceSettingsInputs = (): void => {
     const settings = getCurrentVoiceSettings();
+    voiceRuntimeModeSelectEl.value = settings.voiceRuntimeMode;
     audioModeSelectEl.value = settings.audioMode;
     autoListenCheckboxEl.checked = settings.autoListenEnabled;
     standaloneNotificationPlaybackCheckboxEl.checked =

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -4069,7 +4069,7 @@ async function main(): Promise<void> {
     voiceStartupPreRollSliderEl,
     voiceTtsGainSliderEl,
   ]
-    .filter((control): control is HTMLElement => control != null)
+    .filter((control): control is HTMLInputElement | HTMLSelectElement => control != null)
     .forEach((control) => {
       control.addEventListener('change', () => syncVoiceSettingsFromInputs());
     });

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -1185,24 +1185,64 @@ async function main(): Promise<void> {
         panelId?: string;
         panelType?: string;
       } | null) ?? null;
-    if (active?.panelType !== 'chat') {
-      return null;
+    // Prefer the bound chat panel session when a chat panel is active.
+    if (active?.panelType === 'chat') {
+      const panelId = typeof active.panelId === 'string' ? active.panelId.trim() : '';
+      if (panelId) {
+        const binding = panelHostController?.getPanelBinding(panelId);
+        const boundSessionId =
+          binding?.mode === 'fixed' ? normalizeSessionId(binding.sessionId) : null;
+        if (boundSessionId) {
+          return boundSessionId;
+        }
+      }
     }
-    const panelId = typeof active.panelId === 'string' ? active.panelId.trim() : '';
-    if (!panelId) {
-      return normalizeSessionId(inputSessionId);
+    // Keep the last selected input session when browsing non-chat panels (lists, etc.)
+    // so Thread FAB is not permanently greyed outside a chat view.
+    return normalizeSessionId(inputSessionId);
+  }
+
+  function resolveVoiceFabState(): {
+    enabled: boolean;
+    mode: 'idle' | 'speaking' | 'listening' | 'realtime';
+  } {
+    const voiceSettings = getCurrentVoiceSettings();
+    const targetSessionId = resolveVoiceFabTargetSessionId({
+      inputSessionId: getVoiceFabPanelSessionId(),
+      nativeVoiceBridgeSelectedSessionId,
+      preferredVoiceSessionId: voiceSettings.preferredVoiceSessionId,
+    });
+
+    if (isNativeRealtimeRuntimeState(nativeVoiceRuntimeState)) {
+      return { enabled: true, mode: 'realtime' };
     }
-    const binding = panelHostController?.getPanelBinding(panelId);
-    const boundSessionId = binding?.mode === 'fixed' ? normalizeSessionId(binding.sessionId) : null;
-    return boundSessionId ?? normalizeSessionId(inputSessionId);
+    if (nativeVoiceRuntimeState === 'speaking') {
+      return { enabled: true, mode: 'speaking' };
+    }
+    if (nativeVoiceRuntimeState === 'listening') {
+      return { enabled: true, mode: 'listening' };
+    }
+
+    if (!useNativeVoiceRuntime || !nativeVoiceBridge.isAvailable()) {
+      return { enabled: false, mode: 'idle' };
+    }
+    // Native service rejects starts when audioMode is off.
+    if (voiceSettings.audioMode === 'off') {
+      return { enabled: false, mode: 'idle' };
+    }
+    if (voiceSettings.voiceRuntimeMode === 'realtime') {
+      return { enabled: true, mode: 'idle' };
+    }
+    return { enabled: Boolean(targetSessionId), mode: 'idle' };
   }
 
   function getVoiceFabSpeechController() {
+    const voiceSettings = getCurrentVoiceSettings();
     const panelSessionId = getVoiceFabPanelSessionId();
     const targetSessionId = resolveVoiceFabTargetSessionId({
       inputSessionId: panelSessionId,
       nativeVoiceBridgeSelectedSessionId,
-      preferredVoiceSessionId: currentVoiceSettings.preferredVoiceSessionId,
+      preferredVoiceSessionId: voiceSettings.preferredVoiceSessionId,
     });
     const controller = resolveVoiceFabController({
       inputSessionId: panelSessionId,
@@ -1217,34 +1257,22 @@ async function main(): Promise<void> {
         return null;
       }
       return {
-        getVoiceFabState: () => {
-          const voiceSettings = getCurrentVoiceSettings();
-          if (isNativeRealtimeRuntimeState(nativeVoiceRuntimeState)) {
-            return { enabled: true, mode: 'realtime' as const };
-          }
-          if (nativeVoiceRuntimeState === 'speaking') {
-            return { enabled: true, mode: 'speaking' as const };
-          }
-          if (nativeVoiceRuntimeState === 'listening') {
-            return { enabled: true, mode: 'listening' as const };
-          }
-          if (voiceSettings.voiceRuntimeMode === 'realtime') {
-            return { enabled: true, mode: 'idle' as const };
-          }
-          return {
-            enabled: Boolean(targetSessionId),
-            mode: 'idle' as const,
-          };
-        },
+        getVoiceFabState: () => resolveVoiceFabState(),
         startVoiceFromFab: async () => {
           // Push latest settings before start so native mode matches the dropdown.
-          const voiceSettings = getCurrentVoiceSettings();
+          const latestSettings = getCurrentVoiceSettings();
           await nativeVoiceBridge.setSessionTitles(getNativeVoiceSessionTitles());
-          await nativeVoiceBridge.setVoiceSettings(voiceSettings);
-          if (voiceSettings.voiceRuntimeMode === 'realtime') {
+          await nativeVoiceBridge.setVoiceSettings(latestSettings);
+          if (latestSettings.voiceRuntimeMode === 'realtime') {
             return nativeVoiceBridge.startRealtime();
           }
-          const normalizedTargetSessionId = normalizeSessionId(targetSessionId);
+          const normalizedTargetSessionId = normalizeSessionId(
+            resolveVoiceFabTargetSessionId({
+              inputSessionId: getVoiceFabPanelSessionId(),
+              nativeVoiceBridgeSelectedSessionId,
+              preferredVoiceSessionId: latestSettings.preferredVoiceSessionId,
+            }),
+          );
           if (!normalizedTargetSessionId) {
             return false;
           }
@@ -1264,23 +1292,21 @@ async function main(): Promise<void> {
       };
     }
     return {
-      getVoiceFabState: () => {
-        const baseState = controller.getVoiceFabStateForSession(targetSessionId);
-        if (isNativeRealtimeRuntimeState(nativeVoiceRuntimeState)) {
-          return { enabled: true, mode: 'realtime' as const };
-        }
-        if (nativeVoiceRuntimeState === 'speaking') {
-          return { enabled: true, mode: 'speaking' as const };
-        }
-        if (nativeVoiceRuntimeState === 'listening') {
-          return { enabled: true, mode: 'listening' as const };
-        }
-        return baseState;
-      },
+      getVoiceFabState: () => resolveVoiceFabState(),
       startVoiceFromFab: async () => {
         // Ensure native mode is current even if async settings sync is still in flight.
-        await nativeVoiceBridge.setVoiceSettings(getCurrentVoiceSettings());
-        return controller.startVoiceFromFabForSession(targetSessionId);
+        const latestSettings = getCurrentVoiceSettings();
+        await nativeVoiceBridge.setVoiceSettings(latestSettings);
+        if (latestSettings.voiceRuntimeMode === 'realtime') {
+          return nativeVoiceBridge.startRealtime();
+        }
+        const latestTarget =
+          resolveVoiceFabTargetSessionId({
+            inputSessionId: getVoiceFabPanelSessionId(),
+            nativeVoiceBridgeSelectedSessionId,
+            preferredVoiceSessionId: latestSettings.preferredVoiceSessionId,
+          }) ?? targetSessionId;
+        return controller.startVoiceFromFabForSession(latestTarget);
       },
       stopVoiceFromFab: () => controller.stopVoiceFromFab(),
     };

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -3981,9 +3981,13 @@ async function main(): Promise<void> {
   };
   const syncVoiceSettingsFromInputs = (overrides?: Partial<VoiceSettings>): void => {
     const currentSettings = getCurrentVoiceSettings();
+    const realtimeMuteOnStartCheckbox = document.getElementById(
+      'realtime-mute-on-start-checkbox',
+    ) as HTMLInputElement | null;
     const nextSettings = normalizeVoiceSettings({
       ...currentSettings,
       voiceRuntimeMode: voiceRuntimeModeSelectEl.value,
+      realtimeMuteOnStart: realtimeMuteOnStartCheckbox?.checked ?? currentSettings.realtimeMuteOnStart,
       audioMode: audioModeSelectEl.value,
       autoListenEnabled: autoListenCheckboxEl.checked,
       standaloneNotificationPlaybackEnabled: standaloneNotificationPlaybackCheckboxEl.checked,
@@ -4019,8 +4023,36 @@ async function main(): Promise<void> {
   voiceSettingsButtonEl.addEventListener('click', () => {
     openVoiceSettingsModal();
   });
+  const realtimeMuteOnStartCheckboxEl = document.getElementById(
+    'realtime-mute-on-start-checkbox',
+  ) as HTMLInputElement | null;
+  const realtimeStartButtonEl = document.getElementById(
+    'realtime-start-button',
+  ) as HTMLButtonElement | null;
+  const realtimeStopButtonEl = document.getElementById(
+    'realtime-stop-button',
+  ) as HTMLButtonElement | null;
+  const realtimeVoiceControlsEl = document.getElementById('realtime-voice-controls');
+  const syncRealtimeControlsVisibility = (): void => {
+    if (!realtimeVoiceControlsEl) {
+      return;
+    }
+    realtimeVoiceControlsEl.style.display =
+      voiceRuntimeModeSelectEl.value === 'realtime' ? '' : 'none';
+  };
+  voiceRuntimeModeSelectEl.addEventListener('change', () => {
+    syncRealtimeControlsVisibility();
+  });
+  realtimeStartButtonEl?.addEventListener('click', () => {
+    syncVoiceSettingsFromInputs({ voiceRuntimeMode: 'realtime' });
+    nativeVoiceBridge.startRealtime();
+  });
+  realtimeStopButtonEl?.addEventListener('click', () => {
+    nativeVoiceBridge.stopRealtime();
+  });
   [
     voiceRuntimeModeSelectEl,
+    realtimeMuteOnStartCheckboxEl,
     audioModeSelectEl,
     autoListenCheckboxEl,
     standaloneNotificationPlaybackCheckboxEl,
@@ -4036,9 +4068,11 @@ async function main(): Promise<void> {
     voiceRecognitionCueGainSliderEl,
     voiceStartupPreRollSliderEl,
     voiceTtsGainSliderEl,
-  ].forEach((control) => {
-    control.addEventListener('change', () => syncVoiceSettingsFromInputs());
-  });
+  ]
+    .filter((control): control is HTMLElement => control != null)
+    .forEach((control) => {
+      control.addEventListener('change', () => syncVoiceSettingsFromInputs());
+    });
   voicePreferredSessionButtonEl.addEventListener('click', () => {
     const settings = getCurrentVoiceSettings();
     const useMobilePickerPlacement = isMobileViewport();
@@ -4066,6 +4100,10 @@ async function main(): Promise<void> {
   const resetVoiceSettingsInputs = (): void => {
     const settings = getCurrentVoiceSettings();
     voiceRuntimeModeSelectEl.value = settings.voiceRuntimeMode;
+    if (realtimeMuteOnStartCheckboxEl) {
+      realtimeMuteOnStartCheckboxEl.checked = settings.realtimeMuteOnStart;
+    }
+    syncRealtimeControlsVisibility();
     audioModeSelectEl.value = settings.audioMode;
     autoListenCheckboxEl.checked = settings.autoListenEnabled;
     standaloneNotificationPlaybackCheckboxEl.checked =

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -1218,11 +1218,18 @@ async function main(): Promise<void> {
       }
       return {
         getVoiceFabState: () => {
+          const voiceSettings = getCurrentVoiceSettings();
+          if (isNativeRealtimeRuntimeState(nativeVoiceRuntimeState)) {
+            return { enabled: true, mode: 'realtime' as const };
+          }
           if (nativeVoiceRuntimeState === 'speaking') {
             return { enabled: true, mode: 'speaking' as const };
           }
           if (nativeVoiceRuntimeState === 'listening') {
             return { enabled: true, mode: 'listening' as const };
+          }
+          if (voiceSettings.voiceRuntimeMode === 'realtime') {
+            return { enabled: true, mode: 'idle' as const };
           }
           return {
             enabled: Boolean(targetSessionId),
@@ -1230,14 +1237,24 @@ async function main(): Promise<void> {
           };
         },
         startVoiceFromFab: async () => {
+          // Push latest settings before start so native mode matches the dropdown.
+          const voiceSettings = getCurrentVoiceSettings();
+          await nativeVoiceBridge.setSessionTitles(getNativeVoiceSessionTitles());
+          await nativeVoiceBridge.setVoiceSettings(voiceSettings);
+          if (voiceSettings.voiceRuntimeMode === 'realtime') {
+            return nativeVoiceBridge.startRealtime();
+          }
           const normalizedTargetSessionId = normalizeSessionId(targetSessionId);
           if (!normalizedTargetSessionId) {
             return false;
           }
-          await nativeVoiceBridge.setSessionTitles(getNativeVoiceSessionTitles());
           return nativeVoiceBridge.startManualListen(normalizedTargetSessionId);
         },
         stopVoiceFromFab: () => {
+          if (isNativeRealtimeRuntimeState(nativeVoiceRuntimeState)) {
+            void nativeVoiceBridge.stopRealtime();
+            return true;
+          }
           if (nativeVoiceRuntimeState === 'speaking' || nativeVoiceRuntimeState === 'listening') {
             void nativeVoiceBridge.stopCurrentInteraction();
             return true;
@@ -1249,6 +1266,9 @@ async function main(): Promise<void> {
     return {
       getVoiceFabState: () => {
         const baseState = controller.getVoiceFabStateForSession(targetSessionId);
+        if (isNativeRealtimeRuntimeState(nativeVoiceRuntimeState)) {
+          return { enabled: true, mode: 'realtime' as const };
+        }
         if (nativeVoiceRuntimeState === 'speaking') {
           return { enabled: true, mode: 'speaking' as const };
         }
@@ -1257,7 +1277,11 @@ async function main(): Promise<void> {
         }
         return baseState;
       },
-      startVoiceFromFab: () => controller.startVoiceFromFabForSession(targetSessionId),
+      startVoiceFromFab: async () => {
+        // Ensure native mode is current even if async settings sync is still in flight.
+        await nativeVoiceBridge.setVoiceSettings(getCurrentVoiceSettings());
+        return controller.startVoiceFromFabForSession(targetSessionId);
+      },
       stopVoiceFromFab: () => controller.stopVoiceFromFab(),
     };
   }
@@ -1276,11 +1300,16 @@ async function main(): Promise<void> {
     return label || normalizedSessionId.slice(0, 8);
   }
 
-  function getVoiceFabSessionChipState(mode: 'idle' | 'speaking' | 'listening'): {
+  function getVoiceFabSessionChipState(
+    mode: 'idle' | 'speaking' | 'listening' | 'realtime',
+  ): {
     visible: boolean;
     interactive: boolean;
     title: string | null;
   } {
+    if (mode === 'realtime') {
+      return { visible: false, interactive: false, title: null };
+    }
     const panelSessionId = getVoiceFabPanelSessionId();
     return resolveVoiceFabSessionChipState({
       mode,
@@ -1406,6 +1435,10 @@ async function main(): Promise<void> {
       }
       entry.inputRuntime.setVoiceSettingsFromExternal(settings);
     }
+    // Always push to native. Relying only on speech-controller notify misses the
+    // no-primary-panel path and can leave native voiceRuntimeMode stale (e.g. still
+    // realtime after the settings dropdown switches to thread).
+    syncNativeVoiceSettings();
   }
 
   function syncNativeAssistantBaseUrl(): void {
@@ -1432,11 +1465,19 @@ async function main(): Promise<void> {
       case 'idle':
       case 'speaking':
       case 'listening':
+      case 'realtime_connecting':
+      case 'realtime_active':
       case 'error':
         return value;
       default:
         return null;
     }
+  }
+
+  function isNativeRealtimeRuntimeState(
+    state: AssistantNativeVoiceRuntimeState | null,
+  ): boolean {
+    return state === 'realtime_active' || state === 'realtime_connecting';
   }
 
   function applyNativeVoiceRuntimePayload(

--- a/packages/web-client/src/panels/input/runtime.test.ts
+++ b/packages/web-client/src/panels/input/runtime.test.ts
@@ -92,6 +92,10 @@ describe('createInputRuntime', () => {
       initialBriefModeEnabled: false,
       speechFeaturesEnabled: false,
       initialVoiceSettings: {
+        voiceRuntimeMode: 'thread',
+        realtimeConversationId: '',
+        realtimeMuteOnStart: false,
+        realtimeListsInstanceId: 'default',
         audioMode: 'tool',
         autoListenEnabled: true,
         standaloneNotificationPlaybackEnabled: true,

--- a/packages/web-client/src/utils/nativeVoiceSelection.ts
+++ b/packages/web-client/src/utils/nativeVoiceSelection.ts
@@ -75,7 +75,9 @@ export function resolveVoiceFabController<T>(
 ): T | null {
   if (
     input.nativeRuntimeState === 'speaking' ||
-    input.nativeRuntimeState === 'listening'
+    input.nativeRuntimeState === 'listening' ||
+    input.nativeRuntimeState === 'realtime_active' ||
+    input.nativeRuntimeState === 'realtime_connecting'
   ) {
     return input.activeController ?? input.primaryController ?? null;
   }

--- a/packages/web-client/src/utils/nativeVoiceSelection.ts
+++ b/packages/web-client/src/utils/nativeVoiceSelection.ts
@@ -9,6 +9,8 @@ export type NativeVoiceRuntimeState =
   | 'idle'
   | 'speaking'
   | 'listening'
+  | 'realtime_connecting'
+  | 'realtime_active'
   | 'error'
   | null;
 

--- a/packages/web-client/src/utils/voiceFab.ts
+++ b/packages/web-client/src/utils/voiceFab.ts
@@ -1,7 +1,9 @@
+export type VoiceFabMode = 'idle' | 'speaking' | 'listening' | 'realtime';
+
 interface VoiceFabSpeechController {
   getVoiceFabState: () => {
     enabled: boolean;
-    mode: 'idle' | 'speaking' | 'listening';
+    mode: VoiceFabMode;
   };
   startVoiceFromFab: () => Promise<boolean>;
   stopVoiceFromFab: () => boolean;
@@ -11,7 +13,7 @@ export interface VoiceFabOptions {
   button: HTMLButtonElement | null;
   isVisible: () => boolean;
   getSpeechController: () => VoiceFabSpeechController | null;
-  getSessionChipState: (mode: 'idle' | 'speaking' | 'listening') => {
+  getSessionChipState: (mode: VoiceFabMode) => {
     visible: boolean;
     interactive: boolean;
     title: string | null;
@@ -73,7 +75,12 @@ export function setupVoiceFab(options: VoiceFabOptions): VoiceFabHandle {
     chip.hidden = true;
   };
 
-  const renderSessionChip = (mode: 'idle' | 'speaking' | 'listening'): void => {
+  const renderSessionChip = (mode: VoiceFabMode): void => {
+    // Realtime is a separate conversation — hide Thread session chip while active.
+    if (mode === 'realtime') {
+      hideSessionChip();
+      return;
+    }
     const chipState = options.getSessionChipState(mode);
     const title = chipState.title?.trim() ?? '';
     if (!chipState.visible || !title) {
@@ -108,7 +115,11 @@ export function setupVoiceFab(options: VoiceFabOptions): VoiceFabHandle {
     renderSessionChip(state.mode);
     button.classList.add('voice-fab');
     button.classList.toggle('voice-fab-speaking', state.mode === 'speaking');
-    button.classList.toggle('voice-fab-listening', state.mode === 'listening');
+    // Reuse the red stop treatment for Thread listen and active Realtime.
+    button.classList.toggle(
+      'voice-fab-listening',
+      state.mode === 'listening' || state.mode === 'realtime',
+    );
     button.classList.toggle('voice-fab-disabled', !state.enabled);
     button.disabled = !state.enabled && state.mode === 'idle';
 
@@ -120,6 +131,10 @@ export function setupVoiceFab(options: VoiceFabOptions): VoiceFabHandle {
       button.innerHTML = STOP_ICON;
       button.setAttribute('aria-label', 'Stop voice listening');
       button.setAttribute('title', 'Stop voice listening');
+    } else if (state.mode === 'realtime') {
+      button.innerHTML = STOP_ICON;
+      button.setAttribute('aria-label', 'Stop realtime call');
+      button.setAttribute('title', 'Stop realtime call');
     } else {
       button.innerHTML = MICROPHONE_ICON;
       button.setAttribute('aria-label', state.enabled ? 'Start voice input' : 'No selected session');
@@ -134,7 +149,7 @@ export function setupVoiceFab(options: VoiceFabOptions): VoiceFabHandle {
       return;
     }
     const state = controller.getVoiceFabState();
-    if (state.mode === 'speaking' || state.mode === 'listening') {
+    if (state.mode === 'speaking' || state.mode === 'listening' || state.mode === 'realtime') {
       controller.stopVoiceFromFab();
       update();
       return;

--- a/packages/web-client/src/utils/voiceRuntimeMode.ts
+++ b/packages/web-client/src/utils/voiceRuntimeMode.ts
@@ -1,0 +1,18 @@
+export type VoiceRuntimeMode = 'thread' | 'realtime';
+
+export function getDefaultVoiceRuntimeMode(): VoiceRuntimeMode {
+  return 'thread';
+}
+
+export function normalizeVoiceRuntimeMode(
+  value: string | null | undefined,
+): VoiceRuntimeMode {
+  switch (typeof value === 'string' ? value.trim().toLowerCase() : '') {
+    case 'realtime':
+      return 'realtime';
+    case 'thread':
+      return 'thread';
+    default:
+      return getDefaultVoiceRuntimeMode();
+  }
+}

--- a/packages/web-client/src/utils/voiceSettings.ts
+++ b/packages/web-client/src/utils/voiceSettings.ts
@@ -1,4 +1,8 @@
 import { normalizeAudioMode, type AudioMode } from './audioMode';
+import {
+  normalizeVoiceRuntimeMode,
+  type VoiceRuntimeMode,
+} from './voiceRuntimeMode';
 
 export const DEFAULT_VOICE_ADAPTER_BASE_URL = 'https://assistant/agent-voice-adapter';
 export const DEFAULT_RECOGNITION_START_TIMEOUT_MS = 30_000;
@@ -17,6 +21,8 @@ export const MIN_TTS_GAIN_PERCENT = MIN_TTS_GAIN * 100;
 export const MAX_TTS_GAIN_PERCENT = MAX_TTS_GAIN * 100;
 
 export interface VoiceSettings {
+  /** Exclusive native owner preference: Thread FIFO vs Realtime duplex (media later). */
+  voiceRuntimeMode: VoiceRuntimeMode;
   audioMode: AudioMode;
   autoListenEnabled: boolean;
   standaloneNotificationPlaybackEnabled: boolean;
@@ -142,6 +148,7 @@ export function createDefaultVoiceSettings(options?: {
 }): VoiceSettings {
   const isAndroid = options?.isCapacitorAndroid === true;
   return {
+    voiceRuntimeMode: 'thread',
     audioMode: isAndroid ? 'tool' : 'off',
     autoListenEnabled: isAndroid,
     standaloneNotificationPlaybackEnabled: isAndroid,
@@ -172,6 +179,11 @@ export function normalizeVoiceSettings(
 
   const record = value as Record<string, unknown>;
   return {
+    voiceRuntimeMode: normalizeVoiceRuntimeMode(
+      typeof record['voiceRuntimeMode'] === 'string'
+        ? record['voiceRuntimeMode']
+        : defaults.voiceRuntimeMode,
+    ),
     audioMode: normalizeAudioMode(
       typeof record['audioMode'] === 'string' ? record['audioMode'] : defaults.audioMode,
     ),
@@ -225,6 +237,7 @@ export function normalizeVoiceSettings(
 
 export function areVoiceSettingsEqual(left: VoiceSettings, right: VoiceSettings): boolean {
   return (
+    left.voiceRuntimeMode === right.voiceRuntimeMode &&
     left.audioMode === right.audioMode &&
     left.autoListenEnabled === right.autoListenEnabled &&
     left.standaloneNotificationPlaybackEnabled === right.standaloneNotificationPlaybackEnabled &&

--- a/packages/web-client/src/utils/voiceSettings.ts
+++ b/packages/web-client/src/utils/voiceSettings.ts
@@ -21,8 +21,11 @@ export const MIN_TTS_GAIN_PERCENT = MIN_TTS_GAIN * 100;
 export const MAX_TTS_GAIN_PERCENT = MAX_TTS_GAIN * 100;
 
 export interface VoiceSettings {
-  /** Exclusive native owner preference: Thread FIFO vs Realtime duplex (media later). */
+  /** Exclusive native owner preference: Thread FIFO vs Realtime duplex. */
   voiceRuntimeMode: VoiceRuntimeMode;
+  realtimeConversationId: string;
+  realtimeMuteOnStart: boolean;
+  realtimeListsInstanceId: string;
   audioMode: AudioMode;
   autoListenEnabled: boolean;
   standaloneNotificationPlaybackEnabled: boolean;
@@ -149,6 +152,9 @@ export function createDefaultVoiceSettings(options?: {
   const isAndroid = options?.isCapacitorAndroid === true;
   return {
     voiceRuntimeMode: 'thread',
+    realtimeConversationId: '',
+    realtimeMuteOnStart: false,
+    realtimeListsInstanceId: 'default',
     audioMode: isAndroid ? 'tool' : 'off',
     autoListenEnabled: isAndroid,
     standaloneNotificationPlaybackEnabled: isAndroid,
@@ -184,6 +190,13 @@ export function normalizeVoiceSettings(
         ? record['voiceRuntimeMode']
         : defaults.voiceRuntimeMode,
     ),
+    realtimeConversationId: normalizeOptionalString(record['realtimeConversationId']),
+    realtimeMuteOnStart:
+      typeof record['realtimeMuteOnStart'] === 'boolean'
+        ? record['realtimeMuteOnStart']
+        : defaults.realtimeMuteOnStart,
+    realtimeListsInstanceId:
+      normalizeOptionalString(record['realtimeListsInstanceId']) || defaults.realtimeListsInstanceId,
     audioMode: normalizeAudioMode(
       typeof record['audioMode'] === 'string' ? record['audioMode'] : defaults.audioMode,
     ),
@@ -238,6 +251,9 @@ export function normalizeVoiceSettings(
 export function areVoiceSettingsEqual(left: VoiceSettings, right: VoiceSettings): boolean {
   return (
     left.voiceRuntimeMode === right.voiceRuntimeMode &&
+    left.realtimeConversationId === right.realtimeConversationId &&
+    left.realtimeMuteOnStart === right.realtimeMuteOnStart &&
+    left.realtimeListsInstanceId === right.realtimeListsInstanceId &&
     left.audioMode === right.audioMode &&
     left.autoListenEnabled === right.autoListenEnabled &&
     left.standaloneNotificationPlaybackEnabled === right.standaloneNotificationPlaybackEnabled &&

--- a/packages/web-client/src/utils/webClientElements.test.ts
+++ b/packages/web-client/src/utils/webClientElements.test.ts
@@ -26,6 +26,7 @@ describe('getWebClientElements', () => {
     expect(elements?.voiceSettingsButton.id).toBe('voice-settings-button');
     expect(elements?.voiceSettingsModal.id).toBe('voice-settings-modal');
     expect(elements?.voiceSettingsCloseButton.id).toBe('voice-settings-close-button');
+    expect(elements?.voiceRuntimeModeSelect?.id).toBe('voice-runtime-mode-select');
     expect(elements?.audioModeSelect?.id).toBe('audio-mode-select');
     expect(elements?.autoListenCheckbox?.id).toBe('auto-listen-checkbox');
     expect(elements?.standaloneNotificationPlaybackCheckbox?.id).toBe(

--- a/packages/web-client/src/utils/webClientElements.ts
+++ b/packages/web-client/src/utils/webClientElements.ts
@@ -4,6 +4,7 @@ export interface WebClientElements {
   voiceSettingsButton: HTMLButtonElement;
   voiceSettingsModal: HTMLElement;
   voiceSettingsCloseButton: HTMLButtonElement;
+  voiceRuntimeModeSelect: HTMLSelectElement;
   audioModeSelect: HTMLSelectElement;
   autoListenCheckbox: HTMLInputElement;
   standaloneNotificationPlaybackCheckbox: HTMLInputElement;
@@ -85,6 +86,7 @@ export function getWebClientElements(): WebClientElements | null {
   const voiceSettingsButton = getElement<HTMLButtonElement>('voice-settings-button');
   const voiceSettingsModal = getElement<HTMLElement>('voice-settings-modal');
   const voiceSettingsCloseButton = getElement<HTMLButtonElement>('voice-settings-close-button');
+  const voiceRuntimeModeSelect = getElement<HTMLSelectElement>('voice-runtime-mode-select');
   const audioModeSelect = getElement<HTMLSelectElement>('audio-mode-select');
   const autoListenCheckbox = getElement<HTMLInputElement>('auto-listen-checkbox');
   const standaloneNotificationPlaybackCheckbox = getElement<HTMLInputElement>(
@@ -160,6 +162,7 @@ export function getWebClientElements(): WebClientElements | null {
     !voiceSettingsButton ||
     !voiceSettingsModal ||
     !voiceSettingsCloseButton ||
+    !voiceRuntimeModeSelect ||
     !audioModeSelect ||
     !autoListenCheckbox ||
     !standaloneNotificationPlaybackCheckbox ||
@@ -201,6 +204,7 @@ export function getWebClientElements(): WebClientElements | null {
     voiceSettingsButton,
     voiceSettingsModal,
     voiceSettingsCloseButton,
+    voiceRuntimeModeSelect,
     audioModeSelect,
     autoListenCheckbox,
     standaloneNotificationPlaybackCheckbox,


### PR DESCRIPTION
## Summary

- Add end-to-end Android OpenAI Realtime duplex voice: server `/api/voice/*` (session, SDP negotiate, sideband tools/events), WebRTC client with exclusive Thread vs Realtime ownership, wake lock, and web settings/FAB/media-button controls.
- Keep the OpenAI API key server-side only; Realtime tools are explicit opt-in via config allowlist/denylist globs; include `realtime_end_session` hangup.
- Harden lifecycle after review: fence Thread `runtimeState` stomps during Realtime, generation-guard client callbacks, complete WebRTC teardown on release, server heartbeat lease reaper, success-token hangup cues, and untimed wake lock.

## Test plan

- [x] Voice unit tests (`listsTools`, `VoiceService`) pass
- [x] Keel iterative-review clean (ownership/lease findings fixed)
- [x] Deployed to `assistant.service` and verified listening on `:3000`
- [x] Android default flavor installed on connected devices
- [ ] Smoke Realtime start/stop, mute, hangup tool, and Thread exclusivity on device
- [ ] Confirm missing heartbeat reaps server-side live call after ~45s

