### PR TITLE
Add unified interaction end tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Added a unified `interaction_end` tool for text and Realtime agents, including Android Auto Listen suppression for the completed turn when an agent ends the interaction. ([#118](https://github.com/kcosr/assistant/pull/118))
 - Added a Realtime mic mute toggle FAB stacked above the floating microphone control so uplink audio can be muted while keeping the duplex call active. ([#116](https://github.com/kcosr/assistant/pull/116))
 - Added Realtime-specific persistent notification controls for Realtime mode (Start call + Mute/Unmute when idle; Mute/Unmute + End call when live) instead of Thread speak/mode/media-button actions. ([#116](https://github.com/kcosr/assistant/pull/116))
 - Added Realtime speakerphone preference (default on) so duplex voice uses the phone loudspeaker when no Bluetooth headset is connected, instead of the quiet earpiece. ([#114](https://github.com/kcosr/assistant/pull/114))

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -76,11 +76,11 @@ OpenAI TTS requires `OPENAI_API_KEY`.
 
 Realtime duplex voice reuses the same server-side OpenAI credential as TTS/chat:
 
-| Variable | Default | Description |
-| --- | --- | --- |
-| `OPENAI_API_KEY` | - | **Required** for Realtime. Held only on the agent-server host; never sent to Android/web clients. |
-| `OPENAI_REALTIME_MODEL` | `gpt-realtime-2.1` | Pinned Realtime model id (matches T3). |
-| `OPENAI_REALTIME_VOICE` | `marin` | OpenAI Realtime output voice (matches T3 default; female). |
+| Variable                | Default            | Description                                                                                       |
+| ----------------------- | ------------------ | ------------------------------------------------------------------------------------------------- |
+| `OPENAI_API_KEY`        | -                  | **Required** for Realtime. Held only on the agent-server host; never sent to Android/web clients. |
+| `OPENAI_REALTIME_MODEL` | `gpt-realtime-2.1` | Pinned Realtime model id (matches T3).                                                            |
+| `OPENAI_REALTIME_VOICE` | `marin`            | OpenAI Realtime output voice (matches T3 default; female).                                        |
 
 **Storage plan:** set `OPENAI_API_KEY` in the agent-server environment (systemd unit, shell profile, or secrets manager that injects env). Do not put the raw key in client apps, Capacitor assets, or committed `config.json`. Optional `${OPENAI_API_KEY}` substitution in `config.json` is fine for other agent fields; Realtime reads the env via `loadEnvConfig()` the same way OpenAI TTS does.
 
@@ -94,32 +94,44 @@ Realtime tool exposure is **explicit opt-in**. Configure under `voice.realtime`:
 {
   "voice": {
     "realtime": {
-      "toolAllowlist": ["lists_*", "web_search"],
+      "toolAllowlist": ["interaction_end", "lists_*", "web_search"],
       "toolDenylist": []
     }
   }
 }
 ```
 
-| Field | Description |
-| --- | --- |
-| `toolAllowlist` | Glob patterns for tool names available on Realtime sessions. Missing or empty ⇒ **no** host tools (hangup may still be built-in). |
-| `toolDenylist` | Optional globs removed after allowlist matching. |
-| `instructions` | Optional system-instruction override for the Realtime model. |
+| Field           | Description                                                                                                                                              |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `toolAllowlist` | Glob patterns for tool names available on Realtime sessions. Missing or empty ⇒ **no** tools. Add `interaction_end` to let the voice agent end its call. |
+| `toolDenylist`  | Optional globs removed after allowlist matching.                                                                                                         |
+| `instructions`  | Optional system-instruction override for the Realtime model.                                                                                             |
 
 Text agents use per-agent `toolAllowlist` / `toolDenylist` independently of this block.
+
+#### Built-in `interaction_end` tool
+
+`interaction_end` gives text and Realtime agents one shared way to honor requests such as
+“we can stop now.” Add it to each text agent's `toolAllowlist` and to
+`voice.realtime.toolAllowlist` where the behavior is wanted.
+
+- In a text-agent turn, the tool returns normally so the agent can complete its final response.
+  Android correlates the tool call with that response and suppresses Auto Listen for that turn.
+- In a Realtime session, the same tool ends the live call immediately. The voice agent should say
+  any brief goodbye before calling it.
+- The optional `reason` argument is a short diagnostic string such as `user_request` or `done`.
 
 #### Built-in `web_search` tool
 
 `web_search` is a **built-in** tool (not a plugin). It runs the local Grok CLI headless for live public web and X research.
 
-| Item | Detail |
-| --- | --- |
-| Parameters | `query` (required natural-language question), `continue` (optional bool to resume prior Grok session for this conversation) |
-| Enable for text agents | Add `web_search` to the agent’s `toolAllowlist` |
-| Enable for Realtime | Add `web_search` to `voice.realtime.toolAllowlist` |
-| Host prerequisites | `grok` on `PATH` (or `ASSISTANT_GROK_BIN`); Grok auth (`~/.grok/auth.json` and/or `XAI_API_KEY`); do not lock off `bypassPermissions` in Grok requirements; avoid untrusted Grok MCP servers for the service user |
-| Not the same as | Plugin `search_*` tools (in-app notes/lists search) |
+| Item                   | Detail                                                                                                                                                                                                            |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Parameters             | `query` (required natural-language question), `continue` (optional bool to resume prior Grok session for this conversation)                                                                                       |
+| Enable for text agents | Add `web_search` to the agent’s `toolAllowlist`                                                                                                                                                                   |
+| Enable for Realtime    | Add `web_search` to `voice.realtime.toolAllowlist`                                                                                                                                                                |
+| Host prerequisites     | `grok` on `PATH` (or `ASSISTANT_GROK_BIN`); Grok auth (`~/.grok/auth.json` and/or `XAI_API_KEY`); do not lock off `bypassPermissions` in Grok requirements; avoid untrusted Grok MCP servers for the service user |
+| Not the same as        | Plugin `search_*` tools (in-app notes/lists search)                                                                                                                                                               |
 
 Design: `docs/design/web-search-tool.md`.
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -115,6 +115,8 @@ Text agents use per-agent `toolAllowlist` / `toolDenylist` independently of this
 “we can stop now.” Add it to each text agent's `toolAllowlist` and to
 `voice.realtime.toolAllowlist` where the behavior is wanted.
 
+- Tell agents they must call the tool when the user asks to stop. A textual or spoken
+  acknowledgment alone does not end the interaction.
 - In a text-agent turn, the tool returns normally so the agent can complete its final response.
   Android correlates the tool call with that response and suppresses Auto Listen for that turn.
 - In a Realtime session, the same tool ends the live call immediately. The voice agent should say

--- a/packages/agent-server/src/builtInTools.test.ts
+++ b/packages/agent-server/src/builtInTools.test.ts
@@ -157,7 +157,7 @@ describe('registerBuiltInSessionTools', () => {
     };
   }
 
-  it('registers voice_speak and voice_ask with agent-facing descriptions', async () => {
+  it('registers the voice interaction tools with agent-facing descriptions', async () => {
     const host = createHost();
 
     const tools = await host.listTools();
@@ -173,6 +173,10 @@ describe('registerBuiltInSessionTools', () => {
         expect.objectContaining({
           name: 'voice_ask',
           description: expect.stringContaining('spoken reply is expected'),
+        }),
+        expect.objectContaining({
+          name: 'interaction_end',
+          description: expect.stringContaining('automatically listen'),
         }),
       ]),
     );
@@ -204,6 +208,24 @@ describe('registerBuiltInSessionTools', () => {
       host.callTool('voice_ask', '{"text":"What should I do next?"}', ctx),
     ).resolves.toEqual({
       accepted: true,
+    });
+  });
+
+  it('accepts interaction_end with an optional reason', async () => {
+    const host = createHost();
+    const ctx = createContext();
+
+    await expect(host.callTool('interaction_end', '{}', ctx)).resolves.toEqual({
+      ok: true,
+      ending: true,
+      reason: 'agent_end',
+    });
+    await expect(
+      host.callTool('interaction_end', '{"reason":" user_request "}', ctx),
+    ).resolves.toEqual({
+      ok: true,
+      ending: true,
+      reason: 'user_request',
     });
   });
 

--- a/packages/agent-server/src/builtInTools.test.ts
+++ b/packages/agent-server/src/builtInTools.test.ts
@@ -176,7 +176,7 @@ describe('registerBuiltInSessionTools', () => {
         }),
         expect.objectContaining({
           name: 'interaction_end',
-          description: expect.stringContaining('automatically listen'),
+          description: expect.stringContaining('A textual acknowledgment'),
         }),
       ]),
     );

--- a/packages/agent-server/src/builtInTools.ts
+++ b/packages/agent-server/src/builtInTools.ts
@@ -1231,7 +1231,7 @@ export function registerBuiltInSessionTools(options: {
   options.host.registerTool({
     name: INTERACTION_END_TOOL_NAME,
     description:
-      'End the current interactive exchange after completing the current response. Use when the user says the interaction can stop or no further reply is needed. Clients that automatically listen for another voice turn will remain idle.',
+      'End the current interaction after completing the current response. You MUST call this tool when the user indicates the conversation or voice interaction should end, including phrases such as "stop", "stop now", "you can stop", "stop our interaction", "we are done", or "that is all". A textual acknowledgment such as "Stopped" does not end the interaction. Clients that automatically listen for another voice turn will remain idle after this tool is called.',
     parameters: INTERACTION_END_TOOL_PARAMETERS,
     handler: async (args) => {
       const obj = asObject(args);

--- a/packages/agent-server/src/builtInTools.ts
+++ b/packages/agent-server/src/builtInTools.ts
@@ -33,6 +33,7 @@ import {
 } from './attachments/constants';
 import { createNotificationRecord } from '../../plugins/core/notifications/server/service';
 import { createWebSearchToolDefinition } from './tools/webSearch';
+import { INTERACTION_END_TOOL_NAME, INTERACTION_END_TOOL_PARAMETERS } from './interactionEndTool';
 
 interface AgentMessageArgs {
   agentId: string;
@@ -146,7 +147,10 @@ function parseAttachmentSendArgs(raw: unknown): AttachmentSendArgs {
   const title = parseOptionalTrimmedString(obj, 'title');
   const fileName = parseOptionalTrimmedString(obj, 'fileName');
   if (!fileName) {
-    throw createToolError('invalid_arguments', 'fileName is required and must be a non-empty string');
+    throw createToolError(
+      'invalid_arguments',
+      'fileName is required and must be a non-empty string',
+    );
   }
   const contentType = parseOptionalTrimmedString(obj, 'contentType');
 
@@ -259,10 +263,7 @@ async function materializeAttachmentBytes(
   }
 }
 
-async function resolveAttachmentPath(
-  rawPath: string,
-  ctx: ToolContext,
-): Promise<string> {
+async function resolveAttachmentPath(rawPath: string, ctx: ToolContext): Promise<string> {
   if (path.isAbsolute(rawPath)) {
     return rawPath;
   }
@@ -294,9 +295,7 @@ function buildAttachmentPreview(options: {
 
   const fullText = options.bytes.toString('utf8');
   const previewText =
-    fullText.length > options.maxChars
-      ? fullText.slice(0, options.maxChars)
-      : fullText;
+    fullText.length > options.maxChars ? fullText.slice(0, options.maxChars) : fullText;
   return {
     previewType,
     previewText,
@@ -919,28 +918,31 @@ export async function handleAgentMessage(
     agent.capabilityDenylist,
   );
 
-  const { availableTools, chatTools, agentTools, availableSkills } = await resolveAgentToolExposureForHost({
-    scopedToolHost,
-    agent,
-    sessionHub,
-    toolContext: {
-      signal: ctx.signal,
-      sessionId,
-      ...(ctx.toolCallId ? { toolCallId: ctx.toolCallId } : {}),
-      ...(ctx.turnId ? { turnId: ctx.turnId } : {}),
-      ...(ctx.requestId ? { requestId: ctx.requestId } : {}),
-      ...(ctx.responseId ? { responseId: ctx.responseId } : {}),
-      agentRegistry,
-      sessionIndex,
-      envConfig,
+  const { availableTools, chatTools, agentTools, availableSkills } =
+    await resolveAgentToolExposureForHost({
+      scopedToolHost,
+      agent,
       sessionHub,
-      baseToolHost,
-      ...(eventStore ? { eventStore } : {}),
-      ...(ctx.searchService ? { searchService: ctx.searchService } : {}),
-      ...(ctx.scheduledSessionService ? { scheduledSessionService: ctx.scheduledSessionService } : {}),
-      ...(ctx.forwardChunksTo ? { forwardChunksTo: ctx.forwardChunksTo } : {}),
-    },
-  });
+      toolContext: {
+        signal: ctx.signal,
+        sessionId,
+        ...(ctx.toolCallId ? { toolCallId: ctx.toolCallId } : {}),
+        ...(ctx.turnId ? { turnId: ctx.turnId } : {}),
+        ...(ctx.requestId ? { requestId: ctx.requestId } : {}),
+        ...(ctx.responseId ? { responseId: ctx.responseId } : {}),
+        agentRegistry,
+        sessionIndex,
+        envConfig,
+        sessionHub,
+        baseToolHost,
+        ...(eventStore ? { eventStore } : {}),
+        ...(ctx.searchService ? { searchService: ctx.searchService } : {}),
+        ...(ctx.scheduledSessionService
+          ? { scheduledSessionService: ctx.scheduledSessionService }
+          : {}),
+        ...(ctx.forwardChunksTo ? { forwardChunksTo: ctx.forwardChunksTo } : {}),
+      },
+    });
 
   // Forward tool output chunks to the caller session if we have the caller's tool call ID
   const forwardChunksTo =
@@ -1227,6 +1229,18 @@ export function registerBuiltInSessionTools(options: {
   });
 
   options.host.registerTool({
+    name: INTERACTION_END_TOOL_NAME,
+    description:
+      'End the current interactive exchange after completing the current response. Use when the user says the interaction can stop or no further reply is needed. Clients that automatically listen for another voice turn will remain idle.',
+    parameters: INTERACTION_END_TOOL_PARAMETERS,
+    handler: async (args) => {
+      const obj = asObject(args);
+      const reason = parseOptionalTrimmedString(obj, 'reason') ?? 'agent_end';
+      return { ok: true, ending: true, reason };
+    },
+  });
+
+  options.host.registerTool({
     name: 'attachment_send',
     description:
       'Send a persistent attachment bubble to the user. Stores one attachment owned by this tool call and returns replayable metadata plus download/open paths. Provide exactly one content source: text for UTF-8 text, dataBase64 for arbitrary bytes, or path for an existing readable local file.',
@@ -1243,7 +1257,8 @@ export function registerBuiltInSessionTools(options: {
         },
         contentType: {
           type: 'string',
-          description: 'Optional MIME type override. When omitted, it is inferred from fileName or path.',
+          description:
+            'Optional MIME type override. When omitted, it is inferred from fileName or path.',
         },
         text: {
           type: 'string',

--- a/packages/agent-server/src/interactionEndTool.ts
+++ b/packages/agent-server/src/interactionEndTool.ts
@@ -1,0 +1,16 @@
+export const INTERACTION_END_TOOL_NAME = 'interaction_end';
+
+export const INTERACTION_END_TOOL_PARAMETERS = {
+  type: 'object',
+  properties: {
+    reason: {
+      type: 'string',
+      description: 'Optional short reason (for example user_request or done).',
+    },
+  },
+  additionalProperties: false,
+};
+
+export function isInteractionEndTool(name: string): boolean {
+  return name === INTERACTION_END_TOOL_NAME;
+}

--- a/packages/agent-server/src/voice/listsTools.test.ts
+++ b/packages/agent-server/src/voice/listsTools.test.ts
@@ -1,14 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Tool } from '../tools';
+import { INTERACTION_END_TOOL_NAME, isInteractionEndTool } from '../interactionEndTool';
 
 import {
-  REALTIME_END_SESSION_TOOL_NAME,
-  buildRealtimeEndSessionTool,
+  buildRealtimeInteractionEndTool,
   buildRealtimeInstructions,
   buildRealtimeToolsFromHost,
   filterToolsForVoiceRealtime,
-  isRealtimeEndSessionTool,
   isToolAllowedForVoiceRealtime,
   toRealtimeFunctionTools,
 } from './listsTools';
@@ -18,6 +17,11 @@ const sampleTools: Tool[] = [
   { name: 'lists_item_move', description: 'Move item', parameters: { type: 'object' } },
   { name: 'notes_list', description: 'List notes', parameters: { type: 'object' } },
   { name: 'bash', description: 'Shell', parameters: { type: 'object' } },
+  {
+    name: INTERACTION_END_TOOL_NAME,
+    description: 'End this interaction',
+    parameters: { type: 'object' },
+  },
 ];
 
 describe('filterToolsForVoiceRealtime', () => {
@@ -35,13 +39,12 @@ describe('filterToolsForVoiceRealtime', () => {
   });
 
   it('supports exact names and star', () => {
-    expect(filterToolsForVoiceRealtime(sampleTools, ['bash'], undefined).map((t) => t.name)).toEqual([
-      'bash',
-    ]);
-    expect(filterToolsForVoiceRealtime(sampleTools, ['*'], ['bash', 'notes_*']).map((t) => t.name)).toEqual([
-      'lists_list',
-      'lists_item_move',
-    ]);
+    expect(
+      filterToolsForVoiceRealtime(sampleTools, ['bash'], undefined).map((t) => t.name),
+    ).toEqual(['bash']);
+    expect(
+      filterToolsForVoiceRealtime(sampleTools, ['*'], ['bash', 'notes_*']).map((t) => t.name),
+    ).toEqual(['lists_list', 'lists_item_move', INTERACTION_END_TOOL_NAME]);
   });
 });
 
@@ -50,12 +53,25 @@ describe('isToolAllowedForVoiceRealtime', () => {
     expect(isToolAllowedForVoiceRealtime('lists_list', undefined, undefined)).toBe(false);
   });
 
-  it('always allows the built-in end-session tool', () => {
-    expect(isRealtimeEndSessionTool(REALTIME_END_SESSION_TOOL_NAME)).toBe(true);
-    expect(isToolAllowedForVoiceRealtime(REALTIME_END_SESSION_TOOL_NAME, undefined, undefined)).toBe(
-      true,
+  it('applies the configured lists to interaction_end', () => {
+    expect(isInteractionEndTool(INTERACTION_END_TOOL_NAME)).toBe(true);
+    expect(isToolAllowedForVoiceRealtime(INTERACTION_END_TOOL_NAME, undefined, undefined)).toBe(
+      false,
     );
-    expect(isToolAllowedForVoiceRealtime(REALTIME_END_SESSION_TOOL_NAME, [], ['*'])).toBe(true);
+    expect(
+      isToolAllowedForVoiceRealtime(
+        INTERACTION_END_TOOL_NAME,
+        [INTERACTION_END_TOOL_NAME],
+        undefined,
+      ),
+    ).toBe(true);
+    expect(
+      isToolAllowedForVoiceRealtime(
+        INTERACTION_END_TOOL_NAME,
+        [INTERACTION_END_TOOL_NAME],
+        [INTERACTION_END_TOOL_NAME],
+      ),
+    ).toBe(false);
   });
 
   it('allows matching names and honors denylist', () => {
@@ -68,27 +84,27 @@ describe('isToolAllowedForVoiceRealtime', () => {
 });
 
 describe('buildRealtimeToolsFromHost', () => {
-  it('always appends realtime_end_session even with empty allowlist', async () => {
+  it('returns no tools when the allowlist is omitted', async () => {
     const tools = await buildRealtimeToolsFromHost({
       listTools: async () => sampleTools,
       toolAllowlist: undefined,
       toolDenylist: undefined,
     });
-    expect(tools.map((t) => t.name)).toEqual([REALTIME_END_SESSION_TOOL_NAME]);
-    expect(tools[0]).toEqual(buildRealtimeEndSessionTool());
+    expect(tools).toEqual([]);
   });
 
-  it('appends end session after filtered host tools', async () => {
+  it('uses the Realtime-specific interaction_end description when allowlisted', async () => {
     const tools = await buildRealtimeToolsFromHost({
       listTools: async () => sampleTools,
-      toolAllowlist: ['lists_*'],
+      toolAllowlist: ['lists_*', INTERACTION_END_TOOL_NAME],
       toolDenylist: undefined,
     });
     expect(tools.map((t) => t.name)).toEqual([
       'lists_list',
       'lists_item_move',
-      REALTIME_END_SESSION_TOOL_NAME,
+      INTERACTION_END_TOOL_NAME,
     ]);
+    expect(tools[2]).toEqual(buildRealtimeInteractionEndTool());
   });
 });
 
@@ -116,6 +132,7 @@ describe('buildRealtimeInstructions', () => {
   it('uses default prompt when override omitted', () => {
     const text = buildRealtimeInstructions('');
     expect(text).toContain('Assistant realtime voice agent');
+    expect(text).toContain('call interaction_end');
     expect(text).toContain('No prior conversation context.');
   });
 });

--- a/packages/agent-server/src/voice/listsTools.test.ts
+++ b/packages/agent-server/src/voice/listsTools.test.ts
@@ -105,6 +105,7 @@ describe('buildRealtimeToolsFromHost', () => {
       INTERACTION_END_TOOL_NAME,
     ]);
     expect(tools[2]).toEqual(buildRealtimeInteractionEndTool());
+    expect(tools[2]?.description).toContain('A spoken acknowledgment does not end the call');
   });
 });
 
@@ -132,7 +133,8 @@ describe('buildRealtimeInstructions', () => {
   it('uses default prompt when override omitted', () => {
     const text = buildRealtimeInstructions('');
     expect(text).toContain('Assistant realtime voice agent');
-    expect(text).toContain('call interaction_end');
+    expect(text).toContain('you MUST call interaction_end');
+    expect(text).toContain('A spoken acknowledgment does not end the call');
     expect(text).toContain('No prior conversation context.');
   });
 });

--- a/packages/agent-server/src/voice/listsTools.ts
+++ b/packages/agent-server/src/voice/listsTools.ts
@@ -1,31 +1,20 @@
 import type { Tool } from '../tools';
 import { matchesGlobPattern } from '../tools/scoping';
+import {
+  INTERACTION_END_TOOL_NAME,
+  INTERACTION_END_TOOL_PARAMETERS,
+  isInteractionEndTool,
+} from '../interactionEndTool';
 
 import type { RealtimeFunctionTool } from './types';
 
-/** Built-in Realtime-only hangup tool (not a plugin op; always available on Realtime sessions). */
-export const REALTIME_END_SESSION_TOOL_NAME = 'realtime_end_session';
-
-export function isRealtimeEndSessionTool(name: string): boolean {
-  return name === REALTIME_END_SESSION_TOOL_NAME;
-}
-
-export function buildRealtimeEndSessionTool(): RealtimeFunctionTool {
+export function buildRealtimeInteractionEndTool(): RealtimeFunctionTool {
   return {
     type: 'function',
-    name: REALTIME_END_SESSION_TOOL_NAME,
+    name: INTERACTION_END_TOOL_NAME,
     description:
       'End the current realtime voice call immediately. Use when the user wants to hang up, stop, or end the conversation. Prefer a brief spoken goodbye first when natural, then call this tool.',
-    parameters: {
-      type: 'object',
-      properties: {
-        reason: {
-          type: 'string',
-          description: 'Optional short reason (for example user_request or done).',
-        },
-      },
-      additionalProperties: false,
-    },
+    parameters: INTERACTION_END_TOOL_PARAMETERS,
   };
 }
 
@@ -62,10 +51,6 @@ export function isToolAllowedForVoiceRealtime(
   allowlist: string[] | undefined,
   denylist: string[] | undefined,
 ): boolean {
-  // Built-in hangup is always available on Realtime sessions.
-  if (isRealtimeEndSessionTool(name)) {
-    return true;
-  }
   if (!allowlist || allowlist.length === 0) {
     return false;
   }
@@ -109,9 +94,11 @@ export async function buildRealtimeToolsFromHost(options: {
 }): Promise<RealtimeFunctionTool[]> {
   const all = await options.listTools();
   const filtered = filterToolsForVoiceRealtime(all, options.toolAllowlist, options.toolDenylist);
-  const hostTools = toRealtimeFunctionTools(filtered);
-  // Always expose hangup, independent of plugin allowlist (including empty allowlist).
-  return [...hostTools, buildRealtimeEndSessionTool()];
+  return filtered.map((tool) =>
+    isInteractionEndTool(tool.name)
+      ? buildRealtimeInteractionEndTool()
+      : toRealtimeFunctionTools([tool])[0]!,
+  );
 }
 
 export function buildRealtimeInstructions(
@@ -126,7 +113,7 @@ export function buildRealtimeInstructions(
           'Speak concisely. Prefer short confirmations after mutations.',
           'You may only use the provided tools. Never invent tool names.',
           'Prefer title or name lookup fields when the user refers to items by name.',
-          'When the user wants to hang up, stop, or end the call, call realtime_end_session. A short goodbye first is fine; the call ends when that tool runs.',
+          'When the user wants to hang up, stop, or end the call, call interaction_end. A short goodbye first is fine; the call ends when that tool runs.',
           'Do not claim you can control Thread voice, notifications, or coding agents unless those tools are provided.',
         ].join('\n');
 

--- a/packages/agent-server/src/voice/listsTools.ts
+++ b/packages/agent-server/src/voice/listsTools.ts
@@ -13,7 +13,7 @@ export function buildRealtimeInteractionEndTool(): RealtimeFunctionTool {
     type: 'function',
     name: INTERACTION_END_TOOL_NAME,
     description:
-      'End the current realtime voice call immediately. Use when the user wants to hang up, stop, or end the conversation. Prefer a brief spoken goodbye first when natural, then call this tool.',
+      'End the current realtime voice call immediately. You MUST call this tool when the user indicates the call or conversation should end, including phrases such as "stop", "stop now", "you can stop", "stop our interaction", "we are done", or "that is all". A spoken acknowledgment does not end the call. If a brief goodbye is natural, say it before calling this tool.',
     parameters: INTERACTION_END_TOOL_PARAMETERS,
   };
 }
@@ -113,7 +113,7 @@ export function buildRealtimeInstructions(
           'Speak concisely. Prefer short confirmations after mutations.',
           'You may only use the provided tools. Never invent tool names.',
           'Prefer title or name lookup fields when the user refers to items by name.',
-          'When the user wants to hang up, stop, or end the call, call interaction_end. A short goodbye first is fine; the call ends when that tool runs.',
+          'When the user indicates that the call or conversation should end—including "stop", "stop now", "you can stop", "stop our interaction", "we are done", or "that is all"—you MUST call interaction_end. A spoken acknowledgment does not end the call. If a short goodbye is natural, say it before calling the tool.',
           'Do not claim you can control Thread voice, notifications, or coding agents unless those tools are provided.',
         ].join('\n');
 

--- a/packages/agent-server/src/voice/service.ts
+++ b/packages/agent-server/src/voice/service.ts
@@ -5,9 +5,9 @@ import { ToolError } from '../tools';
 import {
   buildRealtimeInstructions,
   buildRealtimeToolsFromHost,
-  isRealtimeEndSessionTool,
   isToolAllowedForVoiceRealtime,
 } from './listsTools';
+import { isInteractionEndTool } from '../interactionEndTool';
 import {
   hangupOpenAiRealtimeCall,
   negotiateOpenAiRealtimeCall,
@@ -68,9 +68,7 @@ export class VoiceService {
     this.store = new VoiceStore(dataDir);
     // Match T3 Realtime defaults (OpenAiVoiceProvider: gpt-realtime-2.1 + marin).
     this.model =
-      options.model?.trim() ||
-      process.env['OPENAI_REALTIME_MODEL']?.trim() ||
-      'gpt-realtime-2.1';
+      options.model?.trim() || process.env['OPENAI_REALTIME_MODEL']?.trim() || 'gpt-realtime-2.1';
     this.voice =
       options.voice?.trim() ||
       process.env['OPENAI_REALTIME_VOICE']?.trim() ||
@@ -104,10 +102,7 @@ export class VoiceService {
     };
   }
 
-  async createConversation(input: {
-    conversationId?: string | null;
-    listsInstanceId?: string;
-  }) {
+  async createConversation(input: { conversationId?: string | null; listsInstanceId?: string }) {
     return this.store.getOrCreateConversation({
       ...(input.conversationId !== undefined ? { conversationId: input.conversationId } : {}),
       ...(input.listsInstanceId !== undefined ? { listsInstanceId: input.listsInstanceId } : {}),
@@ -195,9 +190,7 @@ export class VoiceService {
       (reason) => {
         // Intentional hangups use close() first and should not fail the session as an error.
         if (reason.startsWith('sideband_closed_intentional')) {
-          console.info(
-            `[voice] sideband closed after hangup sessionId=${session.id} ${reason}`,
-          );
+          console.info(`[voice] sideband closed after hangup sessionId=${session.id} ${reason}`);
           return;
         }
         console.warn(
@@ -334,7 +327,11 @@ export class VoiceService {
       code: 'realtime_failed',
       message: reason,
     });
-    await this.store.appendEvent(sessionId, { type: 'session_state', state: 'failed', message: reason });
+    await this.store.appendEvent(sessionId, {
+      type: 'session_state',
+      state: 'failed',
+      message: reason,
+    });
   }
 
   private async handleSidebandEvent(
@@ -347,7 +344,10 @@ export class VoiceService {
       return;
     }
 
-    if (type === 'response.output_audio_transcript.done' || type === 'response.audio_transcript.done') {
+    if (
+      type === 'response.output_audio_transcript.done' ||
+      type === 'response.audio_transcript.done'
+    ) {
       const text = typeof event['transcript'] === 'string' ? event['transcript'] : '';
       if (text.trim()) {
         await this.store.appendJournal(live.conversationId, {
@@ -397,7 +397,9 @@ export class VoiceService {
 
     if (type === 'error') {
       const message =
-        typeof event['error'] === 'object' && event['error'] && 'message' in (event['error'] as object)
+        typeof event['error'] === 'object' &&
+        event['error'] &&
+        'message' in (event['error'] as object)
           ? String((event['error'] as { message?: unknown }).message ?? 'provider_error')
           : 'provider_error';
       await this.store.appendEvent(sessionId, {
@@ -464,7 +466,7 @@ export class VoiceService {
     });
 
     // Built-in hangup: acknowledge the tool, then close so the client plays the end cue.
-    if (isRealtimeEndSessionTool(name)) {
+    if (isInteractionEndTool(name)) {
       // Protocol close reason is always a success token so the client plays SUCCESS_COMPLETION.
       // Free-text model detail stays only in the tool result / journal payload.
       const detail =

--- a/packages/mobile-web/README.md
+++ b/packages/mobile-web/README.md
@@ -189,8 +189,9 @@ adb -s <device> exec-out run-as com.assistant.app cat files/voice-runtime.log
 adb -s <device> exec-out run-as com.assistant.work cat files/voice-runtime.log
 ```
 
-  For immediate live tracing, `adb logcat -d | rg 'AssistantVoice(RuntimeService|Plugin|EventLog|MicStreamer)'`
-  is still the fastest first pass.
+For immediate live tracing, `adb logcat -d | rg 'AssistantVoice(RuntimeService|Plugin|EventLog|MicStreamer)'`
+is still the fastest first pass.
+
 - The recognition start cue is an arming cue that plays with a short native media preroll, fully
   drains, then waits a brief settle delay before native mic startup begins. The completion cue is
   deferred until recording has actually stopped, capture focus has been released, and a longer
@@ -214,6 +215,10 @@ adb -s <device> exec-out run-as com.assistant.work cat files/voice-runtime.log
   notifications to autoplay through native playback. Session-attention replies are not read aloud
   in `Manual`, but when `Auto Listen` is enabled the native runtime can start recognition
   automatically after a final assistant reply arrives.
+- When a text agent calls `interaction_end`, the native runtime correlates that tool call with the
+  final response from the same request. The response can still play normally, but Auto Listen is
+  suppressed afterward. The signal is request-scoped and does not disable later manual microphone
+  starts or Auto Listen on subsequent turns.
 - Durable session-linked notifications expose `Play` and `Speak` actions both from the Android
   system notification shade and from the in-app Notifications panel cards. Manual actions
   reconstruct fresh local queue items from the stored notification, jump ahead of automatic work,

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceEventParser.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceEventParser.java
@@ -16,6 +16,7 @@ final class AssistantVoiceEventParser {
             eventId = trim(findStringField(eventJson, "id", 0));
         }
         String sessionId = trim(findStringField(eventJson, "sessionId", 0));
+        String requestId = trim(findStringField(eventJson, "requestId", 0));
         String payloadJson = extractObjectField(eventJson, "payload", 0);
         if (eventId.isEmpty() || sessionId.isEmpty() || payloadJson.isEmpty()) {
             return null;
@@ -24,6 +25,16 @@ final class AssistantVoiceEventParser {
         if ("tool_call".equals(eventType)) {
             String toolName = trim(findStringField(payloadJson, "toolName", 0));
             String toolCallId = trim(findStringField(payloadJson, "toolCallId", 0));
+            if ("interaction_end".equals(toolName) && !requestId.isEmpty()) {
+                return new AssistantVoicePromptEvent(
+                    eventId,
+                    sessionId,
+                    requestId,
+                    toolCallId,
+                    toolName,
+                    ""
+                );
+            }
             String argsJson = extractObjectField(payloadJson, "args", 0);
             String text = trim(findStringField(argsJson, "text", 0));
             if (
@@ -33,7 +44,14 @@ final class AssistantVoiceEventParser {
             ) {
                 return null;
             }
-            return new AssistantVoicePromptEvent(eventId, sessionId, toolCallId, toolName, text);
+            return new AssistantVoicePromptEvent(
+                eventId,
+                sessionId,
+                requestId,
+                toolCallId,
+                toolName,
+                text
+            );
         }
 
         if ("assistant_done".equals(eventType)) {
@@ -44,6 +62,7 @@ final class AssistantVoiceEventParser {
                 return new AssistantVoicePromptEvent(
                     eventId,
                     sessionId,
+                    requestId,
                     responseId,
                     "assistant_response",
                     text

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceInteractionEndTracker.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceInteractionEndTracker.java
@@ -1,0 +1,43 @@
+package com.assistant.mobile.voice;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+final class AssistantVoiceInteractionEndTracker {
+    private final int capacity;
+    private final Set<String> requestKeys = new LinkedHashSet<>();
+
+    AssistantVoiceInteractionEndTracker(int capacity) {
+        this.capacity = Math.max(1, capacity);
+    }
+
+    void remember(String sessionId, String requestId) {
+        String key = requestKey(sessionId, requestId);
+        if (key.isEmpty()) {
+            return;
+        }
+        requestKeys.remove(key);
+        requestKeys.add(key);
+        while (requestKeys.size() > capacity) {
+            requestKeys.remove(requestKeys.iterator().next());
+        }
+    }
+
+    boolean consume(String sessionId, String requestId) {
+        String key = requestKey(sessionId, requestId);
+        return !key.isEmpty() && requestKeys.remove(key);
+    }
+
+    private static String requestKey(String sessionId, String requestId) {
+        String normalizedSessionId = trim(sessionId);
+        String normalizedRequestId = trim(requestId);
+        if (normalizedSessionId.isEmpty() || normalizedRequestId.isEmpty()) {
+            return "";
+        }
+        return normalizedSessionId + "\n" + normalizedRequestId;
+    }
+
+    private static String trim(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoicePromptEvent.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoicePromptEvent.java
@@ -3,6 +3,7 @@ package com.assistant.mobile.voice;
 final class AssistantVoicePromptEvent {
     final String eventId;
     final String sessionId;
+    final String requestId;
     final String toolCallId;
     final String toolName;
     final String text;
@@ -14,8 +15,20 @@ final class AssistantVoicePromptEvent {
         String toolName,
         String text
     ) {
+        this(eventId, sessionId, "", toolCallId, toolName, text);
+    }
+
+    AssistantVoicePromptEvent(
+        String eventId,
+        String sessionId,
+        String requestId,
+        String toolCallId,
+        String toolName,
+        String text
+    ) {
         this.eventId = eventId;
         this.sessionId = sessionId;
+        this.requestId = requestId;
         this.toolCallId = toolCallId;
         this.toolName = toolName;
         this.text = text;
@@ -27,6 +40,10 @@ final class AssistantVoicePromptEvent {
 
     boolean isAssistantResponse() {
         return "assistant_response".equals(toolName);
+    }
+
+    boolean isInteractionEnd() {
+        return "interaction_end".equals(toolName);
     }
 
     boolean startsListeningAfterPlayback() {

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
@@ -119,6 +119,7 @@ public final class AssistantVoiceRuntimeService extends Service {
     private static final long PLAYBACK_DRAIN_TIMEOUT_MARGIN_MS = 1200L;
     private static final long MANUAL_PREEMPT_STOP_TIMEOUT_MS = 5000L;
     private static final int MAX_PENDING_QUEUE_ITEMS = 25;
+    private static final int MAX_INTERACTION_END_REQUESTS = 64;
     private static final int DURABLE_NOTIFICATION_ID_OFFSET = 24000;
     private static final long MEDIA_SESSION_PLAYBACK_ACTIONS =
         PlaybackState.ACTION_PLAY
@@ -169,6 +170,8 @@ public final class AssistantVoiceRuntimeService extends Service {
     private boolean assistantSocketConnected = false;
     private String adapterClientId = "";
     private final Set<String> assistantSubscribedSessionIds = new LinkedHashSet<>();
+    private final AssistantVoiceInteractionEndTracker interactionEndTracker =
+        new AssistantVoiceInteractionEndTracker(MAX_INTERACTION_END_REQUESTS);
     private String runtimeState = STATE_DISABLED;
 
     // The session currently owning native playback/listen/submit. This is set
@@ -1840,6 +1843,17 @@ public final class AssistantVoiceRuntimeService extends Service {
             Log.d(TAG, "handlePromptEvent skipped unwatched sessionId=" + safe(prompt.sessionId));
             return;
         }
+        if (prompt.isInteractionEnd()) {
+            interactionEndTracker.remember(prompt.sessionId, prompt.requestId);
+            Log.d(
+                TAG,
+                "interaction_end armed sessionId="
+                    + safe(prompt.sessionId)
+                    + " requestId="
+                    + safe(prompt.requestId)
+            );
+            return;
+        }
         if (config.ttsPreferredSessionOnly
             && !config.preferredVoiceSessionId.isEmpty()
             && !prompt.sessionId.equals(config.preferredVoiceSessionId)) {
@@ -1850,11 +1864,15 @@ public final class AssistantVoiceRuntimeService extends Service {
             );
             return;
         }
+        boolean suppressAutoListen =
+            prompt.isAssistantResponse()
+                && interactionEndTracker.consume(prompt.sessionId, prompt.requestId);
+        boolean autoListenForPrompt = config.autoListenEnabled && !suppressAutoListen;
         boolean idle = !hasActiveInteraction() && !isManualPreemptStopInFlight();
         boolean shouldAutoListenAfterManualAssistantMessage =
             AssistantVoiceInteractionRules.shouldAutoListenAfterManualAssistantMessage(
                 config.audioMode,
-                config.autoListenEnabled,
+                autoListenForPrompt,
                 prompt,
                 idle
             );
@@ -1867,6 +1885,7 @@ public final class AssistantVoiceRuntimeService extends Service {
             TAG,
             "handlePromptEvent decision shouldAutoplay=" + shouldAutoplay
                 + " shouldAutoListenAfterManualAssistantMessage=" + shouldAutoListenAfterManualAssistantMessage
+                + " suppressAutoListen=" + suppressAutoListen
                 + " audioMode=" + safe(config.audioMode)
                 + " autoListenEnabled=" + config.autoListenEnabled
                 + " hasActiveInteraction=" + hasActiveInteraction()
@@ -1891,7 +1910,7 @@ public final class AssistantVoiceRuntimeService extends Service {
         AssistantVoiceQueueItem item =
             AssistantVoiceQueueItem.fromPrompt(
                 prompt,
-                config.autoListenEnabled,
+                autoListenForPrompt,
                 config.notificationTitlePlaybackEnabled,
                 config.getSessionTitle(prompt.sessionId)
             );

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceSessionSocketProtocol.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceSessionSocketProtocol.java
@@ -92,7 +92,8 @@ final class AssistantVoiceSessionSocketProtocol {
         if (AssistantVoiceConfig.AUDIO_MODE_RESPONSE.equals(normalizedAudioMode)) {
             return "{"
                 + "\"serverMessageTypes\":[\"transcript_event\"],"
-                + "\"chatEventTypes\":[\"assistant_done\"],"
+                + "\"chatEventTypes\":[\"tool_call\",\"assistant_done\"],"
+                + "\"toolNames\":[\"interaction_end\"],"
                 + "\"messagePhases\":[\"final_answer\"]"
                 + "}";
         }
@@ -100,14 +101,14 @@ final class AssistantVoiceSessionSocketProtocol {
             return "{"
                 + "\"serverMessageTypes\":[\"transcript_event\"],"
                 + "\"chatEventTypes\":[\"tool_call\",\"assistant_done\"],"
-                + "\"toolNames\":[\"voice_speak\",\"voice_ask\"],"
+                + "\"toolNames\":[\"voice_speak\",\"voice_ask\",\"interaction_end\"],"
                 + "\"messagePhases\":[\"final_answer\"]"
                 + "}";
         }
         return "{"
             + "\"serverMessageTypes\":[\"transcript_event\"],"
             + "\"chatEventTypes\":[\"tool_call\"],"
-            + "\"toolNames\":[\"voice_speak\",\"voice_ask\"]"
+            + "\"toolNames\":[\"voice_speak\",\"voice_ask\",\"interaction_end\"]"
             + "}";
     }
 

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceInteractionEndTrackerTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceInteractionEndTrackerTest.java
@@ -1,0 +1,35 @@
+package com.assistant.mobile.voice;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public final class AssistantVoiceInteractionEndTrackerTest {
+    @Test
+    public void consumesOnlyTheMatchingSessionRequestOnce() {
+        AssistantVoiceInteractionEndTracker tracker = new AssistantVoiceInteractionEndTracker(4);
+
+        tracker.remember("session-1", "request-1");
+
+        assertFalse(tracker.consume("session-2", "request-1"));
+        assertFalse(tracker.consume("session-1", "request-2"));
+        assertTrue(tracker.consume("session-1", "request-1"));
+        assertFalse(tracker.consume("session-1", "request-1"));
+    }
+
+    @Test
+    public void ignoresIncompleteKeysAndEvictsTheOldestRequest() {
+        AssistantVoiceInteractionEndTracker tracker = new AssistantVoiceInteractionEndTracker(2);
+
+        tracker.remember("", "request-0");
+        tracker.remember("session-1", "");
+        tracker.remember("session-1", "request-1");
+        tracker.remember("session-1", "request-2");
+        tracker.remember("session-1", "request-3");
+
+        assertFalse(tracker.consume("session-1", "request-1"));
+        assertTrue(tracker.consume("session-1", "request-2"));
+        assertTrue(tracker.consume("session-1", "request-3"));
+    }
+}

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceSessionSocketProtocolTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceSessionSocketProtocolTest.java
@@ -19,7 +19,9 @@ public final class AssistantVoiceSessionSocketProtocolTest {
         assertTrue(payload.contains("\"subscriptions\":[{\"sessionId\":\"session-123\""));
         assertTrue(payload.contains("\"serverMessageTypes\":[\"transcript_event\"]"));
         assertTrue(payload.contains("\"chatEventTypes\":[\"tool_call\"]"));
-        assertTrue(payload.contains("\"toolNames\":[\"voice_speak\",\"voice_ask\"]"));
+        assertTrue(payload.contains(
+            "\"toolNames\":[\"voice_speak\",\"voice_ask\",\"interaction_end\"]"
+        ));
     }
 
     @Test
@@ -32,7 +34,8 @@ public final class AssistantVoiceSessionSocketProtocolTest {
         assertTrue(payload.contains("\"type\":\"subscribe\""));
         assertTrue(payload.contains("\"sessionId\":\"session-123\""));
         assertTrue(payload.contains("\"serverMessageTypes\":[\"transcript_event\"]"));
-        assertTrue(payload.contains("\"chatEventTypes\":[\"assistant_done\"]"));
+        assertTrue(payload.contains("\"chatEventTypes\":[\"tool_call\",\"assistant_done\"]"));
+        assertTrue(payload.contains("\"toolNames\":[\"interaction_end\"]"));
         assertTrue(payload.contains("\"messagePhases\":[\"final_answer\"]"));
     }
 
@@ -47,7 +50,9 @@ public final class AssistantVoiceSessionSocketProtocolTest {
         assertTrue(payload.contains("\"sessionId\":\"session-123\""));
         assertTrue(payload.contains("\"serverMessageTypes\":[\"transcript_event\"]"));
         assertTrue(payload.contains("\"chatEventTypes\":[\"tool_call\",\"assistant_done\"]"));
-        assertTrue(payload.contains("\"toolNames\":[\"voice_speak\",\"voice_ask\"]"));
+        assertTrue(payload.contains(
+            "\"toolNames\":[\"voice_speak\",\"voice_ask\",\"interaction_end\"]"
+        ));
         assertTrue(payload.contains("\"messagePhases\":[\"final_answer\"]"));
     }
 
@@ -66,6 +71,7 @@ public final class AssistantVoiceSessionSocketProtocolTest {
             + "\"event\":{"
             + "\"eventId\":\"event-1\","
             + "\"sessionId\":\"session-123\","
+            + "\"requestId\":\"request-1\","
             + "\"chatEventType\":\"tool_call\","
             + "\"payload\":{"
             + "\"toolName\":\"voice_speak\","
@@ -81,6 +87,7 @@ public final class AssistantVoiceSessionSocketProtocolTest {
         assertNotNull(prompt);
         assertTrue("event-1".equals(prompt.eventId));
         assertTrue("session-123".equals(prompt.sessionId));
+        assertTrue("request-1".equals(prompt.requestId));
         assertTrue("call-1".equals(prompt.toolCallId));
         assertTrue("voice_speak".equals(prompt.toolName));
         assertTrue("Hello from realtime".equals(prompt.text));
@@ -117,6 +124,7 @@ public final class AssistantVoiceSessionSocketProtocolTest {
             + "\"eventId\":\"event-2\","
             + "\"responseId\":\"response-2\","
             + "\"sessionId\":\"session-123\","
+            + "\"requestId\":\"request-2\","
             + "\"chatEventType\":\"assistant_done\","
             + "\"payload\":{"
             + "\"phase\":\"final_answer\","
@@ -133,5 +141,33 @@ public final class AssistantVoiceSessionSocketProtocolTest {
         assertTrue("assistant_response".equals(prompt.toolName));
         assertTrue("Final response text".equals(prompt.text));
         assertTrue("response-2".equals(prompt.toolCallId));
+        assertTrue("request-2".equals(prompt.requestId));
+    }
+
+    @Test
+    public void parsePlaybackMessageReturnsInteractionEndControl() {
+        String message = "{"
+            + "\"type\":\"transcript_event\","
+            + "\"event\":{"
+            + "\"eventId\":\"event-end\","
+            + "\"sessionId\":\"session-123\","
+            + "\"requestId\":\"request-end\","
+            + "\"chatEventType\":\"tool_call\","
+            + "\"payload\":{"
+            + "\"toolName\":\"interaction_end\","
+            + "\"toolCallId\":\"call-end\","
+            + "\"args\":{\"reason\":\"done\"}"
+            + "}"
+            + "}"
+            + "}";
+
+        AssistantVoicePromptEvent prompt = AssistantVoiceSessionSocketProtocol.parsePlaybackMessage(
+            message
+        );
+
+        assertNotNull(prompt);
+        assertTrue(prompt.isInteractionEnd());
+        assertTrue("request-end".equals(prompt.requestId));
+        assertTrue("call-end".equals(prompt.toolCallId));
     }
 }


### PR DESCRIPTION
## Summary

- add a shared `interaction_end` tool for text and Realtime agents
- suppress Android Auto Listen for the completed turn when the tool is called
- require the tool for explicit stop/end requests and document configuration

## Testing

- `npm test -- packages/agent-server/src/builtInTools.test.ts packages/agent-server/src/voice/listsTools.test.ts`
- Android unit tests
- `npm run build`
- deployed build and systemd restart verification
