### PR TITLE
Add native Pi steering messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Added native Pi steering for messages submitted during an active run, with silent context persistence and a transient client acknowledgement instead of Assistant-side queue rendering. ([#120](https://github.com/kcosr/assistant/pull/120))
 - Added a unified `interaction_end` tool for text and Realtime agents, including Android Auto Listen suppression for the completed turn when an agent ends the interaction. ([#118](https://github.com/kcosr/assistant/pull/118))
 - Added a Realtime mic mute toggle FAB stacked above the floating microphone control so uplink audio can be muted while keeping the duplex call active. ([#116](https://github.com/kcosr/assistant/pull/116))
 - Added Realtime-specific persistent notification controls for Realtime mode (Start call + Mute/Unmute when idle; Mute/Unmute + End call when live) instead of Thread speak/mode/media-button actions. ([#116](https://github.com/kcosr/assistant/pull/116))

--- a/packages/agent-server/src/chatRunCore.ts
+++ b/packages/agent-server/src/chatRunCore.ts
@@ -1644,6 +1644,21 @@ export async function runChatCompletionCore(
           } else if (event.message.role === 'toolResult') {
             appendToolResultMessage(piReplayAccumulator, event.message);
             appendToolResultMessage(state.chatMessages, event.message);
+          } else if (event.message.role === 'user' && event.message !== promptMessage) {
+            const content =
+              typeof event.message.content === 'string'
+                ? event.message.content
+                : event.message.content
+                    .filter((block) => block.type === 'text')
+                    .map((block) => block.text)
+                    .join('');
+            const replayMessage: ChatCompletionMessage = {
+              role: 'user',
+              content,
+              historyTimestampMs: event.message.timestamp,
+            };
+            piReplayAccumulator.push(replayMessage);
+            state.chatMessages.push(replayMessage);
           }
           return;
         }

--- a/packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts
+++ b/packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts
@@ -450,6 +450,189 @@ describe('handleTextInputWithChatCompletions (pi)', () => {
     });
   });
 
+  it('sends input directly to Pi steering while a Pi run is active', async () => {
+    const steer = vi.fn();
+    const queueMessage = vi.fn();
+    const sendServerMessageFromHub = vi.fn();
+    const agentRegistry = new AgentRegistry([
+      {
+        agentId: 'pi-agent',
+        displayName: 'Pi',
+        description: 'Pi',
+        chat: { provider: 'pi', models: ['openai-codex/gpt-5.4'] },
+      },
+    ]);
+    const sessionHub: SessionHub = {
+      getAgentRegistry: () => agentRegistry,
+      queueMessage,
+    } as unknown as SessionHub;
+    const state: LogicalSessionState = {
+      summary: {
+        sessionId: 's1',
+        agentId: 'pi-agent',
+        createdAt: '',
+        updatedAt: '',
+        deleted: false,
+      },
+      chatMessages: [],
+      messageQueue: [],
+      activeChatRun: {
+        responseId: 'r1',
+        abortController: new AbortController(),
+        accumulatedText: '',
+      },
+      piAgentRuntime: {
+        agent: { steer } as never,
+        requestConfig: {},
+      },
+    };
+
+    await handleTextInputWithChatCompletions({
+      message: {
+        type: 'text_input',
+        text: 'Change direction',
+        sessionId: 's1',
+        clientMessageId: 'client-1',
+      },
+      state,
+      sessionId: 's1',
+      connection: { sendServerMessageFromHub } as never,
+      sessionHub,
+      config: createEnvConfig(),
+      chatCompletionTools: [],
+      outputMode: 'text',
+      clientAudioCapabilities: undefined,
+      ttsBackendFactory: null,
+      handleChatToolCalls: async () => undefined,
+      setActiveRunState: () => undefined,
+      clearActiveRunState: () => undefined,
+      sendError: vi.fn(),
+      log: () => undefined,
+      eventStore: createTestEventStore(),
+    });
+
+    expect(steer).toHaveBeenCalledWith({
+      role: 'user',
+      content: 'Change direction',
+      timestamp: expect.any(Number),
+    });
+    expect(queueMessage).not.toHaveBeenCalled();
+    expect(sendServerMessageFromHub).toHaveBeenCalledWith({
+      type: 'message_steered',
+      sessionId: 's1',
+      clientMessageId: 'client-1',
+    });
+  });
+
+  it('keeps a Pi-consumed steering message in canonical history without broadcasting it', async () => {
+    vi.mocked(resolvePiSdkModel).mockResolvedValue({
+      model: { id: 'gpt-5.4', provider: 'openai-codex', api: 'openai-responses' } as never,
+      providerId: 'openai-codex',
+      modelId: 'gpt-5.4',
+    });
+
+    const steeringMessage = {
+      role: 'user' as const,
+      content: 'Focus on permissions',
+      timestamp: 1234,
+    };
+    const assistantMessage = createAssistantMessage({ text: 'Redirected result' });
+    mockPiAgentPrompt.mockImplementationOnce(async ({ emit }) => {
+      await emit({ type: 'message_start', message: steeringMessage });
+      await emit({ type: 'message_end', message: steeringMessage });
+      await emit({
+        type: 'message_update',
+        message: assistantMessage,
+        assistantMessageEvent: {
+          type: 'text_delta',
+          contentIndex: 0,
+          delta: 'Redirected result',
+          partial: assistantMessage,
+        },
+      });
+      await emit({ type: 'message_end', message: assistantMessage });
+      await emit({ type: 'turn_end', message: assistantMessage, toolResults: [] });
+    });
+
+    const broadcast: ServerMessage[] = [];
+    const agentRegistry = new AgentRegistry([
+      {
+        agentId: 'pi',
+        displayName: 'Pi',
+        description: 'Pi',
+        chat: { provider: 'pi', models: ['openai-codex/gpt-5.4'] },
+      },
+    ]);
+    const sessionHub: SessionHub = {
+      getAgentRegistry: () => agentRegistry,
+      broadcastToSession: (_sessionId: string, message: ServerMessage) => {
+        broadcast.push(message);
+      },
+      broadcastToSessionExcluding: () => undefined,
+      updateSessionAttributes: async () => undefined,
+      recordSessionActivity: async () => undefined,
+      queueMessage: async () => {
+        throw new Error('queueMessage should not be called in this test');
+      },
+      dequeueMessageById: async () => undefined,
+      processNextQueuedMessage: async () => false,
+      getPiSessionWriter: () => undefined,
+    } as unknown as SessionHub;
+    const state: LogicalSessionState = {
+      summary: {
+        sessionId: 's1',
+        agentId: 'pi',
+        createdAt: '',
+        updatedAt: '',
+        deleted: false,
+      },
+      chatMessages: [{ role: 'system', content: 'System prompt' }],
+      messageQueue: [],
+    };
+
+    await handleTextInputWithChatCompletions({
+      message: { type: 'text_input', text: 'Initial request', sessionId: 's1' },
+      state,
+      sessionId: 's1',
+      connection: {} as never,
+      sessionHub,
+      config: createEnvConfig(),
+      chatCompletionTools: [],
+      outputMode: 'text',
+      clientAudioCapabilities: undefined,
+      ttsBackendFactory: null,
+      handleChatToolCalls: async () => undefined,
+      setActiveRunState: () => undefined,
+      clearActiveRunState: () => undefined,
+      sendError: () => undefined,
+      log: () => undefined,
+      eventStore: createTestEventStore(),
+    });
+
+    expect(state.chatMessages).toEqual(
+      expect.arrayContaining([
+        {
+          role: 'user',
+          content: 'Focus on permissions',
+          historyTimestampMs: 1234,
+        },
+      ]),
+    );
+    expect(
+      broadcast.some(
+        (message) => message.type === 'user_message' && message.text === 'Focus on permissions',
+      ),
+    ).toBe(false);
+    expect(
+      broadcast.some(
+        (message) =>
+          message.type === 'transcript_event' &&
+          message.event.chatEventType === 'user_message' &&
+          message.event.payload['text'] === 'Focus on permissions',
+      ),
+    ).toBe(false);
+  });
+
   it('uses the canonical Pi transcript for replay and records only the final answer text', async () => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'assistant-pi-replay-'));
     const baseDir = path.join(os.homedir(), '.pi', 'agent', 'sessions', encodePiCwd(cwd));

--- a/packages/agent-server/src/ws/chatRunLifecycle.ts
+++ b/packages/agent-server/src/ws/chatRunLifecycle.ts
@@ -330,6 +330,25 @@ export async function handleTextInputWithChatCompletions(options: {
   const requestId = randomUUID();
 
   if (state.activeChatRun) {
+    const activeAgentId = state.summary.agentId;
+    const activeAgent = activeAgentId
+      ? sessionHub.getAgentRegistry().getAgent(activeAgentId)
+      : undefined;
+    const { provider: activeProvider } = resolveChatProvider(activeAgent);
+    if (activeProvider === 'pi' && state.piAgentRuntime) {
+      state.piAgentRuntime.agent.steer({
+        role: 'user',
+        content: text,
+        timestamp: Date.now(),
+      });
+      connection.sendServerMessageFromHub({
+        type: 'message_steered',
+        sessionId,
+        ...(message.clientMessageId ? { clientMessageId: message.clientMessageId } : {}),
+      });
+      return;
+    }
+
     const queuedMessage: ClientTextInputMessage = { ...message, text };
     try {
       await sessionHub.queueMessage({

--- a/packages/shared/src/protocol.test.ts
+++ b/packages/shared/src/protocol.test.ts
@@ -234,6 +234,16 @@ describe('server message validation', () => {
     expect(parsed).toEqual(message);
   });
 
+  it('accepts a message_steered acknowledgement', () => {
+    const message: ServerMessage = {
+      type: 'message_steered',
+      sessionId: 'session-1',
+      clientMessageId: 'client-1',
+    };
+
+    expect(validateServerMessage(message)).toEqual(message);
+  });
+
   it('accepts a transcript_event message', () => {
     const message: ServerMessage = {
       type: 'transcript_event',

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -39,6 +39,7 @@ const SERVER_MESSAGE_TYPE_VALUES = [
   'error',
   'message_queued',
   'message_dequeued',
+  'message_steered',
   'output_cancelled',
   'open_url',
   'subscribed',
@@ -790,6 +791,12 @@ export const ServerMessageDequeuedMessageSchema = z.object({
   sessionId: z.string().optional(),
 });
 
+export const ServerMessageSteeredMessageSchema = z.object({
+  type: z.literal('message_steered'),
+  sessionId: z.string(),
+  clientMessageId: z.string().optional(),
+});
+
 export const ServerOutputCancelledMessageSchema = z.object({
   type: z.literal('output_cancelled'),
   sessionId: z.string().optional(),
@@ -916,6 +923,7 @@ export const ServerMessageSchema = z.discriminatedUnion('type', [
   ServerErrorMessageSchema,
   ServerMessageQueuedMessageSchema,
   ServerMessageDequeuedMessageSchema,
+  ServerMessageSteeredMessageSchema,
   ServerOutputCancelledMessageSchema,
   ServerOpenUrlMessageSchema,
   ServerSubscribedMessageSchema,
@@ -950,6 +958,7 @@ export type ServerPongMessage = z.infer<typeof ServerPongMessageSchema>;
 export type ServerErrorMessage = z.infer<typeof ServerErrorMessageSchema>;
 export type ServerMessageQueuedMessage = z.infer<typeof ServerMessageQueuedMessageSchema>;
 export type ServerMessageDequeuedMessage = z.infer<typeof ServerMessageDequeuedMessageSchema>;
+export type ServerMessageSteeredMessage = z.infer<typeof ServerMessageSteeredMessageSchema>;
 export type ServerOutputCancelledMessage = z.infer<typeof ServerOutputCancelledMessageSchema>;
 export type ServerOpenUrlMessage = z.infer<typeof ServerOpenUrlMessageSchema>;
 export type ServerPanelEventMessage = z.infer<typeof PanelEventEnvelopeSchema>;

--- a/packages/web-client/README.md
+++ b/packages/web-client/README.md
@@ -14,6 +14,7 @@ Browser-based chat client for the AI Assistant.
 ## Features
 
 - Autosizing multiline text input with streaming response display
+- Pi steering for messages submitted while the agent is active, acknowledged with a transient toast
 - Voice input via Web Speech API (browser speech recognition)
 - Audio output via server-generated TTS
 - Session management (create, switch, delete)
@@ -127,6 +128,7 @@ All session-specific messages include `sessionId` field.
 | `tool_call_start`   | Tool call started                      |
 | `tool_output_delta` | Tool output streaming                  |
 | `tool_result`       | Tool call complete                     |
+| `message_steered`   | Pi accepted mid-run steering input     |
 | `modes_updated`     | Acknowledge mode change                |
 | `error`             | Error with code and message            |
 | `output_cancelled`  | Confirm output cancellation            |

--- a/packages/web-client/public/styles.css
+++ b/packages/web-client/public/styles.css
@@ -7201,3 +7201,29 @@ textarea.interaction-input {
 .share-list-confirm:hover {
   background-color: var(--color-accent-hover);
 }
+
+.app-toast {
+  position: fixed;
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 8rem);
+  left: 50%;
+  z-index: 10000;
+  max-width: min(90vw, 420px);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-full);
+  background-color: var(--color-bg-elevated);
+  color: var(--color-text-primary);
+  box-shadow: var(--shadow-lg);
+  font-size: var(--font-size-sm);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 8px);
+  transition:
+    opacity var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.app-toast.is-visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}

--- a/packages/web-client/src/controllers/serverMessageHandler.agentCallbackResult.test.ts
+++ b/packages/web-client/src/controllers/serverMessageHandler.agentCallbackResult.test.ts
@@ -53,6 +53,7 @@ function makeHandler(overrides: Partial<ServerMessageHandlerOptions> = {}) {
       sessionRequestActivity.set(normalized, hasActiveRequest);
     },
     setStatus: () => {},
+    showToast: () => {},
     setTtsStatus: () => {},
     focusInputForSession: () => {},
     isMobileViewport: () => false,
@@ -82,6 +83,19 @@ function makeHandler(overrides: Partial<ServerMessageHandlerOptions> = {}) {
 }
 
 describe('ServerMessageHandler typing indicator', () => {
+  it('shows a transient acknowledgement for accepted steering messages', async () => {
+    const showToast = vi.fn();
+    const { handler } = makeHandler({ showToast });
+
+    await handler.handle({
+      type: 'message_steered',
+      sessionId: 's-1',
+      clientMessageId: 'client-1',
+    });
+
+    expect(showToast).toHaveBeenCalledWith('Steering message sent');
+  });
+
   it('resets active turn state on reconnect cleanup', async () => {
     const { handler, typingIndicators } = makeHandler();
 

--- a/packages/web-client/src/controllers/serverMessageHandler.ts
+++ b/packages/web-client/src/controllers/serverMessageHandler.ts
@@ -62,6 +62,7 @@ export interface ServerMessageHandlerOptions {
   scrollMessageIntoView: (container: HTMLElement, element: HTMLElement) => void;
   syncSessionRequestActivityUi: (sessionId: string, hasActiveRequest: boolean) => void;
   setStatus: (element: HTMLElement, text: string) => void;
+  showToast: (text: string) => void;
   setTtsStatus: (text: string) => void;
   focusInputForSession: (sessionId: string) => void;
   isMobileViewport: () => boolean;
@@ -431,6 +432,10 @@ export class ServerMessageHandler {
         if (indicator) {
           indicator.remove();
         }
+        break;
+      }
+      case 'message_steered': {
+        this.options.showToast('Steering message sent');
         break;
       }
       case 'session_ready': {

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -138,6 +138,7 @@ import { ToolOutputPreferencesClient } from './utils/toolOutputPreferences';
 import { ThinkingPreferencesClient } from './utils/thinkingPreferences';
 import { PluginSettingsClient } from './utils/pluginSettingsClient';
 import { PluginBundleLoader } from './utils/pluginBundleLoader';
+import { showToast } from './utils/toast';
 import { ICONS } from './utils/icons';
 import {
   formatSessionLabel,
@@ -5429,6 +5430,7 @@ async function main(): Promise<void> {
       syncSessionContext();
     },
     setStatus,
+    showToast,
     setTtsStatus,
     focusInputForSession: (sessionId) => {
       const runtime = getChatInputRuntimeForSession(sessionId);

--- a/packages/web-client/src/utils/toast.test.ts
+++ b/packages/web-client/src/utils/toast.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { showToast } from './toast';
+
+describe('showToast', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('shows and then hides a transient status message', () => {
+    vi.useFakeTimers();
+
+    showToast('Steering accepted', 1000);
+
+    const toast = document.querySelector<HTMLElement>('[data-role="app-toast"]');
+    expect(toast?.textContent).toBe('Steering accepted');
+    expect(toast?.classList.contains('is-visible')).toBe(true);
+    expect(toast?.getAttribute('role')).toBe('status');
+
+    vi.advanceTimersByTime(1000);
+
+    expect(toast?.classList.contains('is-visible')).toBe(false);
+  });
+});

--- a/packages/web-client/src/utils/toast.ts
+++ b/packages/web-client/src/utils/toast.ts
@@ -1,0 +1,35 @@
+let hideTimer: ReturnType<typeof setTimeout> | null = null;
+
+function getToastElement(): HTMLDivElement {
+  const existing = document.querySelector<HTMLDivElement>('[data-role="app-toast"]');
+  if (existing) {
+    return existing;
+  }
+
+  const element = document.createElement('div');
+  element.className = 'app-toast';
+  element.dataset['role'] = 'app-toast';
+  element.setAttribute('role', 'status');
+  element.setAttribute('aria-live', 'polite');
+  document.body.appendChild(element);
+  return element;
+}
+
+export function showToast(message: string, durationMs = 2400): void {
+  const text = message.trim();
+  if (!text) {
+    return;
+  }
+
+  const element = getToastElement();
+  element.textContent = text;
+  element.classList.add('is-visible');
+
+  if (hideTimer) {
+    clearTimeout(hideTimer);
+  }
+  hideTimer = setTimeout(() => {
+    element.classList.remove('is-visible');
+    hideTimer = null;
+  }, durationMs);
+}


### PR DESCRIPTION
## Summary
- route messages submitted during active Pi runs through Pi native steering instead of the Assistant FIFO
- retain consumed steering messages in canonical Pi context without rendering user bubbles
- acknowledge accepted steering with a bottom-centered web toast
- preserve existing queued-message behavior for non-Pi providers

## Verification
- `npx vitest --run packages/agent-server/src/ws/chatRunLifecycle.pi.test.ts packages/web-client/src/controllers/serverMessageHandler.agentCallbackResult.test.ts packages/web-client/src/utils/toast.test.ts packages/shared/src/protocol.test.ts` (67 tests passed)
- full build passed before deployment; no rebuild was run for the final toast-only wording/position adjustment
