### PR TITLE
Fix Android back panel navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 
 ### Fixed
 
+- Fixed Android Back navigation so closed pinned Sessions/Agents panels are never opened, while an otherwise unhandled Back press swaps between the two most recently active regular workspace panels. ([#121](https://github.com/kcosr/assistant/pull/121))
 - Added Realtime OpenAI sideband WebSocket ping + TCP keepalive (60s) to reduce idle NAT drops, and log ping/pong counts on close; Android logs WebRTC ice/connection state when a session fails so phone↔OpenAI can be correlated with server sideband closes. ([#116](https://github.com/kcosr/assistant/pull/116))
 - Improved Realtime sideband logging so unexpected WebSocket closes record code, wasClean, reason text, and intentional vs peer/network drop (helps distinguish OpenAI hangup from path failures). ([#116](https://github.com/kcosr/assistant/pull/116))
 - Fixed Realtime mode preference persistence across app restarts so WebView localStorage defaults do not overwrite native `voiceRuntimeMode` on cold start. ([#116](https://github.com/kcosr/assistant/pull/116))

--- a/packages/web-client/README.md
+++ b/packages/web-client/README.md
@@ -15,6 +15,7 @@ Browser-based chat client for the AI Assistant.
 
 - Autosizing multiline text input with streaming response display
 - Pi steering for messages submitted while the agent is active, acknowledged with a transient toast
+- Android Back dismisses open UI first, then swaps between the two most recently active workspace panels
 - Voice input via Web Speech API (browser speech recognition)
 - Audio output via server-generated TTS
 - Session management (create, switch, delete)

--- a/packages/web-client/src/controllers/panelWorkspaceController.focusHistory.test.ts
+++ b/packages/web-client/src/controllers/panelWorkspaceController.focusHistory.test.ts
@@ -88,6 +88,99 @@ describe('PanelWorkspaceController focus history', () => {
     expect(workspace.getActivePanelId()).toBe('time-1');
   });
 
+  it('swaps between the two most recently focused workspace panels', () => {
+    const registry = new PanelRegistry();
+    registry.register({ type: 'time-tracker', title: 'Time Tracker' }, createStubPanel);
+    registry.register({ type: 'notes', title: 'Notes' }, createStubPanel);
+
+    const host = new PanelHostController({ registry });
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+
+    const workspace = new PanelWorkspaceController({
+      root,
+      registry,
+      host,
+      loadLayout: () => buildLayout(),
+    });
+    host.setPanelWorkspace(workspace);
+    workspace.attach();
+
+    workspace.focusPanel('time-1');
+    workspace.focusPanel('notes-1');
+
+    expect(workspace.navigateToPreviousPanel()).toBe(true);
+    expect(workspace.getActivePanelId()).toBe('time-1');
+
+    expect(workspace.navigateToPreviousPanel()).toBe(true);
+    expect(workspace.getActivePanelId()).toBe('notes-1');
+  });
+
+  it('excludes pinned header panels from previous-panel navigation', () => {
+    const registry = new PanelRegistry();
+    registry.register({ type: 'time-tracker', title: 'Time Tracker' }, createStubPanel);
+    registry.register({ type: 'notes', title: 'Notes' }, createStubPanel);
+    registry.register({ type: 'sessions', title: 'Sessions' }, createStubPanel);
+
+    const host = new PanelHostController({ registry });
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+
+    const layout: LayoutPersistence = {
+      layout: pane('pane-1', ['time-1', 'notes-1'], 'notes-1'),
+      panels: {
+        'time-1': { panelId: 'time-1', panelType: 'time-tracker' },
+        'notes-1': { panelId: 'notes-1', panelType: 'notes' },
+        'sessions-1': { panelId: 'sessions-1', panelType: 'sessions' },
+      },
+      headerPanels: ['sessions-1'],
+      headerPanelSizes: {},
+    };
+    const workspace = new PanelWorkspaceController({
+      root,
+      registry,
+      host,
+      loadLayout: () => layout,
+    });
+    host.setPanelWorkspace(workspace);
+    workspace.attach();
+
+    workspace.focusPanel('time-1');
+    workspace.focusPanel('notes-1');
+    workspace.focusPanel('sessions-1');
+
+    expect(workspace.navigateToPreviousPanel()).toBe(true);
+    expect(workspace.getActivePanelId()).toBe('time-1');
+    expect(workspace.getOpenHeaderPanelId()).toBeNull();
+  });
+
+  it('returns false when there is no previous regular workspace panel', () => {
+    const registry = new PanelRegistry();
+    registry.register({ type: 'notes', title: 'Notes' }, createStubPanel);
+
+    const host = new PanelHostController({ registry });
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+
+    const layout: LayoutPersistence = {
+      layout: pane('pane-1', ['notes-1']),
+      panels: { 'notes-1': { panelId: 'notes-1', panelType: 'notes' } },
+      headerPanels: [],
+      headerPanelSizes: {},
+    };
+    const workspace = new PanelWorkspaceController({
+      root,
+      registry,
+      host,
+      loadLayout: () => layout,
+    });
+    host.setPanelWorkspace(workspace);
+    workspace.attach();
+
+    expect(workspace.navigateToPreviousPanel()).toBe(false);
+    expect(workspace.getActivePanelId()).toBe('notes-1');
+  });
+
   it('adds newly created panels to focus history', () => {
     const registry = new PanelRegistry();
     registry.register({ type: 'time-tracker', title: 'Time Tracker' }, createStubPanel);

--- a/packages/web-client/src/controllers/panelWorkspaceController.ts
+++ b/packages/web-client/src/controllers/panelWorkspaceController.ts
@@ -262,6 +262,26 @@ export class PanelWorkspaceController {
     return true;
   }
 
+  navigateToPreviousPanel(): boolean {
+    this.pruneFocusHistory();
+    const isEligible = (panelId: string): boolean =>
+      !!this.layout.panels[panelId] &&
+      containsPanelId(this.layout.layout, panelId) &&
+      !this.modalPanelIds.has(panelId) &&
+      !this.isPanelPinned(panelId);
+    const regularHistory = this.focusHistory.filter(isEligible);
+    const currentPanelId =
+      this.activePanelId && isEligible(this.activePanelId)
+        ? this.activePanelId
+        : (regularHistory[0] ?? null);
+    const previousPanelId = regularHistory.find((panelId) => panelId !== currentPanelId) ?? null;
+    if (!previousPanelId) {
+      return false;
+    }
+    this.activatePanel(previousPanelId);
+    return true;
+  }
+
   applyLayoutPreset(preset: PanelLayoutPreset): void {
     const nextRoot = buildPanelLayoutPreset(this.layout.layout, preset);
     const normalized = this.normalizeLayout({ ...this.layout, layout: nextRoot });

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -5718,15 +5718,10 @@ async function main(): Promise<void> {
     if (closeModalPanel()) {
       return true;
     }
-    if (panelWorkspace && isMobileViewport() && panelWorkspace.isPanelTypeOpen('sessions')) {
-      panelWorkspace.togglePanel('sessions');
-      return true;
-    }
     if (keyboardNavigationController?.cancelNavigationModes()) {
       return true;
     }
-    if (commandPaletteController) {
-      commandPaletteController.open();
+    if (panelWorkspace && isMobileViewport() && panelWorkspace.navigateToPreviousPanel()) {
       return true;
     }
     return false;


### PR DESCRIPTION
## Summary
- prevent Android Back from opening the closed pinned Sessions/Agents panel
- make Android Back switch to the previously active regular workspace panel after dismissible UI is exhausted
- exclude pinned and modal panels while preserving repeated two-panel flip-flop behavior
- fall through to native Android back/exit behavior when no previous panel exists

## Verification
- `npx vitest --run packages/web-client/src/controllers/panelWorkspaceController.focusHistory.test.ts` (9 tests passed)
- `npm run build -w @assistant/web-client`
- full deploy-checkout `npm run build`
- default Android debug flavor build
