### PR TITLE
Add Android voice notification controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Added promoted Android voice notifications with persistent Start/Stop controls and distinct Skip/Stop actions during TTS so users can either advance into Auto Listen or suppress that follow-up. ([#122](https://github.com/kcosr/assistant/pull/122))
 - Added native Pi steering for messages submitted during an active run, with silent context persistence and a transient client acknowledgement instead of Assistant-side queue rendering. ([#120](https://github.com/kcosr/assistant/pull/120))
 - Added a unified `interaction_end` tool for text and Realtime agents, including Android Auto Listen suppression for the completed turn when an agent ends the interaction. ([#118](https://github.com/kcosr/assistant/pull/118))
 - Added a Realtime mic mute toggle FAB stacked above the floating microphone control so uplink audio can be muted while keeping the duplex call active. ([#116](https://github.com/kcosr/assistant/pull/116))

--- a/docs/design/mobile-voice-tool-mode-android-contract.md
+++ b/docs/design/mobile-voice-tool-mode-android-contract.md
@@ -203,6 +203,19 @@ v1 requirements:
   on the lock screen
 - notification title should surface the runtime state directly, e.g. `Voice (Listening)`
 - notification body should show the resolved preferred or active session title when available
+- while voice controls are enabled and a Thread session or Realtime start action is available,
+  keep a promoted-ongoing standard notification visible with state-dependent actions:
+  `Start` while idle, `Stop` during Thread recognition or a Realtime call, and `Skip` plus `Stop`
+  during Thread playback that has a pending recognition follow-up
+- promoted voice notifications should provide short `Voice` critical text so Android renders a
+  visibly expanded status chip rather than an icon-only compact representation
+- promoted notifications should use only the current state as their title and omit session/body
+  text, leaving Android's app header, the state, and the state-dependent action
+- during Thread playback, `Skip` stops TTS and preserves the current item's pending recognition
+  transition, while `Stop` stops TTS and suppresses that transition without disabling Auto Listen
+  globally; `Stop` still cancels active recognition or ends the active Realtime call according to
+  native ownership
+- disabled, connecting, or otherwise unavailable Start states remain ordinary notifications
 - automatic reconnect while enabled
 - service may start immediately when voice mode is enabled
 - service should not arm prompt playback until it has valid selected-session state

--- a/packages/mobile-web/README.md
+++ b/packages/mobile-web/README.md
@@ -219,6 +219,9 @@ is still the fastest first pass.
   final response from the same request. The response can still play normally, but Auto Listen is
   suppressed afterward. The signal is request-scoped and does not disable later manual microphone
   starts or Auto Listen on subsequent turns.
+- During TTS that has a pending Auto Listen follow-up, the promoted foreground notification shows
+  `Skip` and `Stop`: `Skip` ends playback and advances into recognition, while `Stop` ends playback
+  and suppresses that item's recognition transition without disabling Auto Listen globally.
 - Durable session-linked notifications expose `Play` and `Speak` actions both from the Android
   system notification shade and from the in-app Notifications panel cards. Manual actions
   reconstruct fresh local queue items from the stored notification, jump ahead of automatic work,

--- a/packages/mobile-web/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile-web/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
@@ -59,6 +59,7 @@ public final class AssistantVoiceRuntimeService extends Service {
     static final String ACTION_APPLY_CONFIG = "com.assistant.mobile.voice.APPLY_CONFIG";
     static final String ACTION_STOP_SERVICE = "com.assistant.mobile.voice.STOP_SERVICE";
     static final String ACTION_STOP_CURRENT_INTERACTION = "com.assistant.mobile.voice.STOP_CURRENT_INTERACTION";
+    static final String ACTION_SKIP_CURRENT_PLAYBACK = "com.assistant.mobile.voice.SKIP_CURRENT_PLAYBACK";
     static final String ACTION_START_MANUAL_LISTEN = "com.assistant.mobile.voice.START_MANUAL_LISTEN";
     static final String ACTION_RETARGET_ACTIVE_RECOGNITION =
         "com.assistant.mobile.voice.RETARGET_ACTIVE_RECOGNITION";
@@ -234,6 +235,11 @@ public final class AssistantVoiceRuntimeService extends Service {
     public static Intent stopCurrentInteractionIntent(Context context) {
         return new Intent(context, AssistantVoiceRuntimeService.class)
             .setAction(ACTION_STOP_CURRENT_INTERACTION);
+    }
+
+    public static Intent skipCurrentPlaybackIntent(Context context) {
+        return new Intent(context, AssistantVoiceRuntimeService.class)
+            .setAction(ACTION_SKIP_CURRENT_PLAYBACK);
     }
 
     public static Intent startManualListenIntent(Context context, String sessionId) {
@@ -471,7 +477,12 @@ public final class AssistantVoiceRuntimeService extends Service {
         }
         if (ACTION_STOP_CURRENT_INTERACTION.equals(action)) {
             recordVoiceEvent("service_action_stop_current_interaction", null);
-            handleUserStopRequest("notification_stop");
+            handleUserStopAndSuppressRequest("notification_stop");
+            return START_STICKY;
+        }
+        if (ACTION_SKIP_CURRENT_PLAYBACK.equals(action)) {
+            recordVoiceEvent("service_action_skip_current_playback", null);
+            handleUserSkipRequest("notification_skip");
             return START_STICKY;
         }
         if (ACTION_START_MANUAL_LISTEN.equals(action)) {
@@ -803,7 +814,7 @@ public final class AssistantVoiceRuntimeService extends Service {
             Log.d(TAG, "handleMediaSessionStop ignored: media buttons disabled");
             return;
         }
-        handleUserStopRequest("media_button");
+        handleUserSkipRequest("media_button");
     }
 
     /**
@@ -824,14 +835,21 @@ public final class AssistantVoiceRuntimeService extends Service {
         startManualListen(sessionId == null ? "" : sessionId);
     }
 
-    /**
-     * Shared stop entry for headset media buttons and the notification Stop action.
-     */
-    private void handleUserStopRequest(String reason) {
+    private void handleUserSkipRequest(String reason) {
+        handleUserInteractionControl(true, reason);
+    }
+
+    private void handleUserStopAndSuppressRequest(String reason) {
+        handleUserInteractionControl(false, reason);
+    }
+
+    private void handleUserInteractionControl(boolean continueToRecognition, String reason) {
         Log.d(
             TAG,
-            "handleUserStopRequest reason="
+            "handleUserInteractionControl reason="
                 + safe(reason)
+                + " continueToRecognition="
+                + continueToRecognition
                 + " runtimeState="
                 + runtimeState
                 + " runtimeMode="
@@ -847,7 +865,20 @@ public final class AssistantVoiceRuntimeService extends Service {
             stopRealtimeCall(reason);
             return;
         }
-        stopCurrentInteraction(isPromptPlaybackActive(), "manual_stop");
+        stopCurrentInteraction(
+            shouldContinueToRecognitionAfterInteractionControl(
+                continueToRecognition,
+                isPromptPlaybackActive()
+            ),
+            "manual_stop"
+        );
+    }
+
+    static boolean shouldContinueToRecognitionAfterInteractionControl(
+        boolean continueRequested,
+        boolean promptPlaybackActive
+    ) {
+        return continueRequested && promptPlaybackActive;
     }
 
     private boolean isRealtimeMediaInteractionActive() {
@@ -1017,6 +1048,18 @@ public final class AssistantVoiceRuntimeService extends Service {
             launchIntent,
             PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT
         );
+        PendingIntent stopInteractionPendingIntent = PendingIntent.getService(
+            this,
+            2,
+            stopCurrentInteractionIntent(this),
+            PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT
+        );
+        PendingIntent skipPlaybackPendingIntent = PendingIntent.getService(
+            this,
+            5,
+            skipCurrentPlaybackIntent(this),
+            PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT
+        );
 
         // Realtime preference: Realtime chrome whether idle or in a call (not Thread speak/mode).
         // Exception: Thread SPEAKING/LISTENING (e.g. notification replay) still needs Stop chrome.
@@ -1033,18 +1076,12 @@ public final class AssistantVoiceRuntimeService extends Service {
                 PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT
             );
             if (callActive) {
-                PendingIntent endCallPendingIntent = PendingIntent.getService(
-                    this,
-                    5,
-                    stopRealtimeIntent(this),
-                    PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT
-                );
                 return buildRealtimeNotification(
                     this,
                     state,
                     launchPendingIntent,
                     muteTogglePendingIntent,
-                    endCallPendingIntent,
+                    stopInteractionPendingIntent,
                     null,
                     true,
                     mutedForUi
@@ -1075,12 +1112,6 @@ public final class AssistantVoiceRuntimeService extends Service {
             startManualListenIntent(this, null),
             PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT
         );
-        PendingIntent stopInteractionPendingIntent = PendingIntent.getService(
-            this,
-            2,
-            stopCurrentInteractionIntent(this),
-            PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT
-        );
         PendingIntent cycleAudioModePendingIntent = PendingIntent.getService(
             this,
             3,
@@ -1109,6 +1140,15 @@ public final class AssistantVoiceRuntimeService extends Service {
             !activeSttRequestId.isEmpty(),
             realtimeActive
         );
+        boolean showSkipAction =
+            isPromptPlaybackActive()
+                && !activeVoiceSessionId.isEmpty()
+                && (activeQueueItem != null
+                    ? activeQueueItem.startsListeningAfterPlayback()
+                    : AssistantVoiceInteractionRules.shouldStartRecognitionAfterPlayback(
+                        activePromptToolName,
+                        config.autoListenEnabled
+                    ));
         String notificationSessionTitle = resolveNotificationSessionTitle();
 
         return buildNotification(
@@ -1118,10 +1158,12 @@ public final class AssistantVoiceRuntimeService extends Service {
             launchPendingIntent,
             startListenPendingIntent,
             stopInteractionPendingIntent,
+            skipPlaybackPendingIntent,
             cycleAudioModePendingIntent,
             toggleMediaButtonsPendingIntent,
             showSpeakAction,
             showStopAction,
+            showSkipAction,
             displayedAudioMode,
             config.mediaButtonsEnabled
         );
@@ -1129,7 +1171,7 @@ public final class AssistantVoiceRuntimeService extends Service {
 
     /**
      * Realtime-mode foreground notification (preference is Realtime, not only while a call is live).
-     * Idle: Start call + Mute/Unmute (mute-on-start). Active: Mute/Unmute + End call.
+     * Idle: Start. Active: Stop.
      * Thread speak / audio-mode / media-button actions are omitted in this mode.
      */
     static Notification buildRealtimeNotification(
@@ -1137,45 +1179,60 @@ public final class AssistantVoiceRuntimeService extends Service {
         String state,
         PendingIntent launchPendingIntent,
         PendingIntent muteTogglePendingIntent,
-        PendingIntent endCallPendingIntent,
+        PendingIntent stopInteractionPendingIntent,
         PendingIntent startCallPendingIntent,
         boolean callActive,
         boolean muted
     ) {
+        String stateLabel = formatNotificationStateLabel(context, state, muted, true, callActive);
+        boolean showPromotedControl = callActive || startCallPendingIntent != null;
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
             .setSmallIcon(android.R.drawable.ic_btn_speak_now)
             .setContentTitle(
-                context.getString(
-                    R.string.assistant_voice_notification_title,
-                    formatNotificationStateLabel(context, state, muted, true, callActive)
-                )
-            )
-            .setContentText(
-                context.getString(
-                    callActive
-                        ? (muted
-                            ? R.string.assistant_voice_notification_realtime_body_muted
-                            : R.string.assistant_voice_notification_realtime_body)
-                        : (muted
-                            ? R.string.assistant_voice_notification_realtime_body_muted
-                            : R.string.assistant_voice_notification_realtime_body_idle)
-                )
+                showPromotedControl
+                    ? stateLabel
+                    : context.getString(R.string.assistant_voice_notification_title, stateLabel)
             )
             .setContentIntent(launchPendingIntent)
             .setPriority(NOTIFICATION_PRIORITY)
             .setVisibility(NOTIFICATION_VISIBILITY)
             .setCategory(NOTIFICATION_CATEGORY)
+            .setOnlyAlertOnce(true)
             .setOngoing(true);
 
-        int compactCount = 0;
-        if (!callActive && startCallPendingIntent != null) {
+        if (callActive && stopInteractionPendingIntent != null) {
+            builder.addAction(
+                R.drawable.ic_notification_stop,
+                context.getString(R.string.assistant_voice_notification_action_stop),
+                stopInteractionPendingIntent
+            );
+            builder.setShortCriticalText(
+                context.getString(R.string.assistant_voice_notification_chip_text)
+            );
+            builder.setRequestPromotedOngoing(true);
+            return builder.build();
+        }
+
+        if (startCallPendingIntent != null) {
             builder.addAction(
                 android.R.drawable.ic_btn_speak_now,
-                context.getString(R.string.assistant_voice_notification_action_start_call),
+                context.getString(R.string.assistant_voice_notification_action_start),
                 startCallPendingIntent
             );
-            compactCount += 1;
+            builder.setShortCriticalText(
+                context.getString(R.string.assistant_voice_notification_chip_text)
+            );
+            builder.setRequestPromotedOngoing(true);
+            return builder.build();
         }
+
+        builder.setContentText(
+            context.getString(
+                muted
+                    ? R.string.assistant_voice_notification_realtime_body_muted
+                    : R.string.assistant_voice_notification_realtime_body_idle
+            )
+        );
         // Icon reflects current state (muted → mic-off), matching the in-app mute FAB.
         // Label still describes the action taken on tap (Mute / Unmute).
         builder.addAction(
@@ -1187,20 +1244,7 @@ public final class AssistantVoiceRuntimeService extends Service {
             ),
             muteTogglePendingIntent
         );
-        compactCount += 1;
-        if (callActive && endCallPendingIntent != null) {
-            builder.addAction(
-                R.drawable.ic_notification_stop,
-                context.getString(R.string.assistant_voice_notification_action_end_call),
-                endCallPendingIntent
-            );
-            compactCount += 1;
-        }
-        builder.setStyle(
-            compactCount >= 3
-                ? new MediaStyle().setShowActionsInCompactView(0, 1, 2)
-                : new MediaStyle().setShowActionsInCompactView(0, 1)
-        );
+        builder.setStyle(new MediaStyle().setShowActionsInCompactView(0));
         return builder.build();
     }
 
@@ -1211,46 +1255,66 @@ public final class AssistantVoiceRuntimeService extends Service {
         PendingIntent launchPendingIntent,
         PendingIntent startListenPendingIntent,
         PendingIntent stopInteractionPendingIntent,
+        PendingIntent skipPlaybackPendingIntent,
         PendingIntent cycleAudioModePendingIntent,
         PendingIntent toggleMediaButtonsPendingIntent,
         boolean showSpeakAction,
         boolean showStopAction,
+        boolean showSkipAction,
         String audioMode,
         boolean mediaButtonsEnabled
     ) {
+        String stateLabel = formatNotificationStateLabel(context, state);
+        boolean showPromotedControl = showStopAction || showSpeakAction;
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
             .setSmallIcon(android.R.drawable.ic_btn_speak_now)
             .setContentTitle(
-                context.getString(
-                    R.string.assistant_voice_notification_title,
-                    formatNotificationStateLabel(context, state)
-                )
+                showPromotedControl
+                    ? stateLabel
+                    : context.getString(R.string.assistant_voice_notification_title, stateLabel)
             )
             .setContentIntent(launchPendingIntent)
             .setPriority(NOTIFICATION_PRIORITY)
             .setVisibility(NOTIFICATION_VISIBILITY)
             .setCategory(NOTIFICATION_CATEGORY)
+            .setOnlyAlertOnce(true)
             .setOngoing(true);
         String normalizedSessionTitle = trim(sessionTitle);
-        if (!normalizedSessionTitle.isEmpty()) {
+        if (!showPromotedControl && !normalizedSessionTitle.isEmpty()) {
             builder.setContentText(normalizedSessionTitle);
         }
         String displayedAudioMode = resolveDisplayedNotificationAudioMode(state, audioMode);
         int compactActionCount = 0;
         if (showStopAction) {
+            if (showSkipAction) {
+                builder.addAction(
+                    R.drawable.ic_notification_skip,
+                    context.getString(R.string.assistant_voice_notification_action_skip),
+                    skipPlaybackPendingIntent
+                );
+            }
             builder.addAction(
                 R.drawable.ic_notification_stop,
                 context.getString(R.string.assistant_voice_notification_action_stop),
                 stopInteractionPendingIntent
             );
-            compactActionCount += 1;
-        } else if (showSpeakAction) {
+            builder.setShortCriticalText(
+                context.getString(R.string.assistant_voice_notification_chip_text)
+            );
+            builder.setRequestPromotedOngoing(true);
+            return builder.build();
+        }
+        if (showSpeakAction) {
             builder.addAction(
                 android.R.drawable.ic_btn_speak_now,
-                context.getString(R.string.assistant_voice_notification_action_speak),
+                context.getString(R.string.assistant_voice_notification_action_start),
                 startListenPendingIntent
             );
-            compactActionCount += 1;
+            builder.setShortCriticalText(
+                context.getString(R.string.assistant_voice_notification_chip_text)
+            );
+            builder.setRequestPromotedOngoing(true);
+            return builder.build();
         }
         builder.addAction(
             resolveNotificationMediaButtonsActionIcon(mediaButtonsEnabled),

--- a/packages/mobile-web/android/app/src/main/res/drawable/ic_notification_skip.xml
+++ b/packages/mobile-web/android/app/src/main/res/drawable/ic_notification_skip.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M6,5v14l11,-7zM18,5h2v14h-2z" />
+</vector>

--- a/packages/mobile-web/android/app/src/main/res/values/strings.xml
+++ b/packages/mobile-web/android/app/src/main/res/values/strings.xml
@@ -25,13 +25,14 @@
     <string name="assistant_voice_notification_state_realtime_idle">Realtime · Idle</string>
     <string name="assistant_voice_notification_state_realtime_connecting">Realtime · Connecting</string>
     <string name="assistant_voice_notification_state_realtime_muted">Realtime · Muted</string>
-    <string name="assistant_voice_notification_action_start_call">Start call</string>
     <string name="assistant_voice_notification_realtime_body_idle">Tap Start call for duplex voice</string>
     <string name="assistant_voice_notification_channel_name">Assistant voice controls</string>
-    <string name="assistant_voice_notification_channel_description">Persistent Assistant voice playback and listening with Speak and Stop controls, including lock-screen visibility when allowed.</string>
+    <string name="assistant_voice_notification_channel_description">Persistent Assistant voice playback and listening with Start, Skip, and Stop controls, including lock-screen visibility when allowed.</string>
+    <string name="assistant_voice_notification_chip_text">Voice</string>
+    <string name="assistant_voice_notification_action_start">Start</string>
     <string name="assistant_voice_notification_action_speak">Speak</string>
+    <string name="assistant_voice_notification_action_skip">Skip</string>
     <string name="assistant_voice_notification_action_stop">Stop</string>
-    <string name="assistant_voice_notification_action_end_call">End call</string>
     <string name="assistant_voice_notification_action_mute">Mute</string>
     <string name="assistant_voice_notification_action_unmute">Unmute</string>
     <string name="assistant_voice_notification_realtime_body">Duplex call active</string>

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRuntimeServiceTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRuntimeServiceTest.java
@@ -10,6 +10,8 @@ import android.os.Build;
 import android.os.Bundle;
 import android.view.KeyEvent;
 
+import androidx.core.app.NotificationCompat;
+
 import com.assistant.mobile.R;
 
 import org.junit.Test;
@@ -219,20 +221,22 @@ public final class AssistantVoiceRuntimeServiceTest {
 
     @Test
     @Config(sdk = Build.VERSION_CODES.N)
-    public void buildNotificationUsesPublicVisibilityDefaultPriorityAndServiceCategory() {
+    public void buildActiveThreadNotificationIsPromotedWithOnlyStop() {
         Context context = RuntimeEnvironment.getApplication();
 
         Notification notification = AssistantVoiceRuntimeService.buildNotification(
             context,
-            AssistantVoiceRuntimeService.STATE_IDLE,
+            AssistantVoiceRuntimeService.STATE_LISTENING,
             "Daily Assistant",
             createActivityPendingIntent(context, "launch"),
             createServicePendingIntent(context, "listen"),
             createServicePendingIntent(context, "stop"),
+            createServicePendingIntent(context, "skip"),
             createServicePendingIntent(context, "cycle-mode"),
             createServicePendingIntent(context, "toggle"),
+            false,
             true,
-            true,
+            false,
             AssistantVoiceConfig.AUDIO_MODE_TOOL,
             false
         );
@@ -241,24 +245,57 @@ public final class AssistantVoiceRuntimeServiceTest {
         assertEquals(AssistantVoiceRuntimeService.NOTIFICATION_PRIORITY, notification.priority);
         assertEquals(AssistantVoiceRuntimeService.NOTIFICATION_VISIBILITY, notification.visibility);
         assertEquals(AssistantVoiceRuntimeService.NOTIFICATION_CATEGORY, notification.category);
-        assertEquals("Voice (Idle)", String.valueOf(extras.getCharSequence(Notification.EXTRA_TITLE)));
         assertEquals(
-            "Daily Assistant",
-            String.valueOf(extras.getCharSequence(Notification.EXTRA_TEXT))
+            "Listening",
+            String.valueOf(extras.getCharSequence(Notification.EXTRA_TITLE))
         );
+        assertNull(extras.getCharSequence(Notification.EXTRA_TEXT));
+        assertTrue(NotificationCompat.isRequestPromotedOngoing(notification));
+        assertEquals(
+            context.getString(R.string.assistant_voice_notification_chip_text),
+            NotificationCompat.getShortCriticalText(notification)
+        );
+        assertNull(extras.getString(Notification.EXTRA_TEMPLATE));
         assertNotNull(notification.actions);
-        assertEquals(3, notification.actions.length);
+        assertEquals(1, notification.actions.length);
         assertEquals(
             context.getString(R.string.assistant_voice_notification_action_stop),
             notification.actions[0].title
         );
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.N)
+    public void buildSpeakingNotificationShowsSkipAndStopForPendingAutoListen() {
+        Context context = RuntimeEnvironment.getApplication();
+
+        Notification notification = AssistantVoiceRuntimeService.buildNotification(
+            context,
+            AssistantVoiceRuntimeService.STATE_SPEAKING,
+            "Daily Assistant",
+            createActivityPendingIntent(context, "launch"),
+            createServicePendingIntent(context, "listen"),
+            createServicePendingIntent(context, "stop"),
+            createServicePendingIntent(context, "skip"),
+            createServicePendingIntent(context, "cycle-mode"),
+            createServicePendingIntent(context, "toggle"),
+            false,
+            true,
+            true,
+            AssistantVoiceConfig.AUDIO_MODE_RESPONSE,
+            false
+        );
+
+        assertTrue(NotificationCompat.isRequestPromotedOngoing(notification));
+        assertNotNull(notification.actions);
+        assertEquals(2, notification.actions.length);
         assertEquals(
-            R.drawable.ic_notification_media_buttons_disabled,
-            notification.actions[1].icon
+            context.getString(R.string.assistant_voice_notification_action_skip),
+            notification.actions[0].title
         );
         assertEquals(
-            R.drawable.ic_notification_mode_tool,
-            notification.actions[2].icon
+            context.getString(R.string.assistant_voice_notification_action_stop),
+            notification.actions[1].title
         );
     }
 
@@ -300,41 +337,41 @@ public final class AssistantVoiceRuntimeServiceTest {
 
     @Test
     @Config(sdk = Build.VERSION_CODES.N)
-    public void buildNotificationOmitsBodyWhenThereIsNoSessionTitle() {
+    public void buildIdleThreadNotificationIsPromotedWithOnlyStart() {
         Context context = RuntimeEnvironment.getApplication();
 
         Notification notification = AssistantVoiceRuntimeService.buildNotification(
             context,
-            AssistantVoiceRuntimeService.STATE_LISTENING,
+            AssistantVoiceRuntimeService.STATE_IDLE,
             "",
             createActivityPendingIntent(context, "launch"),
             createServicePendingIntent(context, "listen"),
             createServicePendingIntent(context, "stop"),
+            createServicePendingIntent(context, "skip"),
             createServicePendingIntent(context, "cycle-mode"),
             createServicePendingIntent(context, "toggle"),
             true,
+            false,
             false,
             AssistantVoiceConfig.AUDIO_MODE_RESPONSE,
             true
         );
 
         assertEquals(
-            "Voice (Listening)",
+            "Idle",
             String.valueOf(notification.extras.getCharSequence(Notification.EXTRA_TITLE))
         );
         assertNull(notification.extras.getCharSequence(Notification.EXTRA_TEXT));
-        assertEquals(3, notification.actions.length);
+        assertTrue(NotificationCompat.isRequestPromotedOngoing(notification));
         assertEquals(
-            context.getString(R.string.assistant_voice_notification_action_speak),
+            context.getString(R.string.assistant_voice_notification_chip_text),
+            NotificationCompat.getShortCriticalText(notification)
+        );
+        assertNull(notification.extras.getString(Notification.EXTRA_TEMPLATE));
+        assertEquals(1, notification.actions.length);
+        assertEquals(
+            context.getString(R.string.assistant_voice_notification_action_start),
             notification.actions[0].title
-        );
-        assertEquals(
-            R.drawable.ic_notification_media_buttons_enabled,
-            notification.actions[1].icon
-        );
-        assertEquals(
-            R.drawable.ic_notification_mode_response,
-            notification.actions[2].icon
         );
     }
 
@@ -422,7 +459,7 @@ public final class AssistantVoiceRuntimeServiceTest {
 
     @Test
     @Config(sdk = Build.VERSION_CODES.N)
-    public void buildRealtimeNotificationShowsMuteAndEndCallWhenActive() {
+    public void buildActiveRealtimeNotificationIsPromotedWithOnlyStop() {
         Context context = RuntimeEnvironment.getApplication();
 
         Notification unmuted = AssistantVoiceRuntimeService.buildRealtimeNotification(
@@ -436,22 +473,21 @@ public final class AssistantVoiceRuntimeServiceTest {
             false
         );
         assertEquals(
-            "Voice (Realtime)",
+            "Realtime",
             String.valueOf(unmuted.extras.getCharSequence(Notification.EXTRA_TITLE))
         );
+        assertNull(unmuted.extras.getCharSequence(Notification.EXTRA_TEXT));
+        assertTrue(NotificationCompat.isRequestPromotedOngoing(unmuted));
         assertEquals(
-            context.getString(R.string.assistant_voice_notification_realtime_body),
-            String.valueOf(unmuted.extras.getCharSequence(Notification.EXTRA_TEXT))
+            context.getString(R.string.assistant_voice_notification_chip_text),
+            NotificationCompat.getShortCriticalText(unmuted)
         );
+        assertNull(unmuted.extras.getString(Notification.EXTRA_TEMPLATE));
         assertNotNull(unmuted.actions);
-        assertEquals(2, unmuted.actions.length);
+        assertEquals(1, unmuted.actions.length);
         assertEquals(
-            context.getString(R.string.assistant_voice_notification_action_mute),
+            context.getString(R.string.assistant_voice_notification_action_stop),
             unmuted.actions[0].title
-        );
-        assertEquals(
-            context.getString(R.string.assistant_voice_notification_action_end_call),
-            unmuted.actions[1].title
         );
 
         Notification muted = AssistantVoiceRuntimeService.buildRealtimeNotification(
@@ -465,22 +501,19 @@ public final class AssistantVoiceRuntimeServiceTest {
             true
         );
         assertEquals(
-            "Voice (Realtime · Muted)",
+            "Realtime · Muted",
             String.valueOf(muted.extras.getCharSequence(Notification.EXTRA_TITLE))
         );
         assertEquals(
-            context.getString(R.string.assistant_voice_notification_action_unmute),
+            context.getString(R.string.assistant_voice_notification_action_stop),
             muted.actions[0].title
         );
-        assertEquals(
-            context.getString(R.string.assistant_voice_notification_realtime_body_muted),
-            String.valueOf(muted.extras.getCharSequence(Notification.EXTRA_TEXT))
-        );
+        assertNull(muted.extras.getCharSequence(Notification.EXTRA_TEXT));
     }
 
     @Test
     @Config(sdk = Build.VERSION_CODES.N)
-    public void buildRealtimeNotificationShowsStartAndMuteWhenIdle() {
+    public void buildIdleRealtimeNotificationIsPromotedWithOnlyStart() {
         Context context = RuntimeEnvironment.getApplication();
 
         Notification idle = AssistantVoiceRuntimeService.buildRealtimeNotification(
@@ -494,17 +527,20 @@ public final class AssistantVoiceRuntimeServiceTest {
             false
         );
         assertEquals(
-            "Voice (Realtime · Idle)",
+            "Realtime · Idle",
             String.valueOf(idle.extras.getCharSequence(Notification.EXTRA_TITLE))
         );
-        assertEquals(2, idle.actions.length);
+        assertNull(idle.extras.getCharSequence(Notification.EXTRA_TEXT));
+        assertTrue(NotificationCompat.isRequestPromotedOngoing(idle));
         assertEquals(
-            context.getString(R.string.assistant_voice_notification_action_start_call),
-            idle.actions[0].title
+            context.getString(R.string.assistant_voice_notification_chip_text),
+            NotificationCompat.getShortCriticalText(idle)
         );
+        assertNull(idle.extras.getString(Notification.EXTRA_TEMPLATE));
+        assertEquals(1, idle.actions.length);
         assertEquals(
-            context.getString(R.string.assistant_voice_notification_action_mute),
-            idle.actions[1].title
+            context.getString(R.string.assistant_voice_notification_action_start),
+            idle.actions[0].title
         );
     }
 
@@ -559,14 +595,17 @@ public final class AssistantVoiceRuntimeServiceTest {
             createActivityPendingIntent(context, "launch"),
             createServicePendingIntent(context, "listen"),
             createServicePendingIntent(context, "stop"),
+            createServicePendingIntent(context, "skip"),
             createServicePendingIntent(context, "cycle-mode"),
             createServicePendingIntent(context, "toggle"),
+            false,
             false,
             false,
             AssistantVoiceConfig.AUDIO_MODE_RESPONSE,
             false
         );
 
+        assertFalse(NotificationCompat.isRequestPromotedOngoing(notification));
         assertEquals(2, notification.actions.length);
         assertEquals(
             R.drawable.ic_notification_media_buttons_disabled,
@@ -1109,6 +1148,29 @@ public final class AssistantVoiceRuntimeServiceTest {
         );
         assertFalse(
             AssistantVoiceRuntimeService.shouldDrainQueueAfterStop("voice_mode_disabled")
+        );
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.N)
+    public void skipContinuesToRecognitionWhileStopSuppressesTheFollowup() {
+        assertTrue(
+            AssistantVoiceRuntimeService.shouldContinueToRecognitionAfterInteractionControl(
+                true,
+                true
+            )
+        );
+        assertFalse(
+            AssistantVoiceRuntimeService.shouldContinueToRecognitionAfterInteractionControl(
+                false,
+                true
+            )
+        );
+        assertFalse(
+            AssistantVoiceRuntimeService.shouldContinueToRecognitionAfterInteractionControl(
+                true,
+                false
+            )
         );
     }
 


### PR DESCRIPTION
## Summary

- promote the Android foreground voice notification with persistent Start/Stop controls
- show Skip and Stop side-by-side during TTS with a pending Auto Listen follow-up
- make Skip advance into recognition while Stop suppresses only that follow-up
- document and test Thread and Realtime notification states

## Testing

- `npm run android:test`
- `npm run android:build`
- verified debug APK package metadata, permissions, contents, and v2 signature
