### PR TITLE
Auto-listen after silent settled turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Added settlement-driven Android Auto Listen for successful local-origin turns with no final speakable output, while suppressing queued, stale, interrupted, error, and voice-control-completed turns. ([#125](https://github.com/kcosr/assistant/pull/125))
 - Added locally bundled UI and code font catalogs with consistent form-control and terminal rendering, plus unified mobile, Electron, and Tauri app artwork generation. ([#124](https://github.com/kcosr/assistant/pull/124))
 - Added default-on Android response ownership so automatic assistant TTS and Auto Listen only run for turns started by the current app process, while tool prompts, external notifications, and manual voice actions remain available. ([#123](https://github.com/kcosr/assistant/pull/123))
 - Added promoted Android voice notifications with persistent Start/Stop controls and distinct Skip/Stop actions during TTS so users can either advance into Auto Listen or suppress that follow-up. ([#122](https://github.com/kcosr/assistant/pull/122))

--- a/docs/design/mobile-voice-tool-mode-android-contract.md
+++ b/docs/design/mobile-voice-tool-mode-android-contract.md
@@ -129,6 +129,12 @@ For any item that could transition into recognition:
   queued item still passes pre-listen validation
 - if the user manually interrupts playback, start recognition immediately only when
   `Auto-listen` is enabled
+- when a successful local-origin turn produces no final speakable response, admit the server's
+  ephemeral `turn_settled` signal as a `listen_only` queue item after the run is released and only
+  if no queued continuation remains
+- suppress settlement-driven Auto Listen after a same-request `voice_ask` or `interaction_end`,
+  for server-origin/interrupted/error turns, and when a newer `turn_start` makes a pending
+  settlement stale
 - while listening, manual stop cancels recognition
 
 ### `assistant_response`

--- a/packages/agent-server/src/chatProcessor.test.ts
+++ b/packages/agent-server/src/chatProcessor.test.ts
@@ -496,6 +496,17 @@ describe('processUserMessage stream event emission', () => {
     );
 
     expect(broadcast.some((message) => message.type === 'text_done')).toBe(true);
+    expect(broadcast).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'turn_settled',
+          sessionId: 's1',
+          status: 'completed',
+          hasSpeakableOutput: true,
+          turnOriginId: 'android-process-1',
+        }),
+      ]),
+    );
   });
 
   it('emits user_audio events for spoken submits while keeping user text in model state', async () => {

--- a/packages/agent-server/src/chatProcessor.ts
+++ b/packages/agent-server/src/chatProcessor.ts
@@ -46,6 +46,11 @@ import { buildMessagesForPiSync } from './history/piSessionSync';
 import { publishFinalResponseNotification } from './notificationProducers';
 import { DEFAULT_PI_COMPACTION_SETTINGS, shouldCompactPiContext } from './history/piCompaction';
 import { calculateContextTokens } from './contextUsage';
+import {
+  broadcastTurnSettledIfIdle,
+  hasSpeakableAssistantOutput,
+  type TurnSettlementCandidate,
+} from './turnSettlement';
 
 function buildAssistantDoneEvents(options: {
   sessionId: string;
@@ -605,6 +610,7 @@ export async function processUserMessage(
 
   let fullText = '';
   let thinkingText = '';
+  let turnSettlement: TurnSettlementCandidate | null = null;
 
   const toolCallMetrics: ChatToolCallMetric[] = [];
 
@@ -698,6 +704,13 @@ export async function processUserMessage(
           : {}),
         ...(runResult.provider === 'pi' ? { piTurnEndStatus: 'interrupted' as const } : {}),
       });
+      turnSettlement = {
+        requestId: turnId ?? requestId,
+        responseId,
+        status: 'interrupted',
+        hasSpeakableOutput: false,
+        ...(turnOriginId ? { turnOriginId } : {}),
+      };
       if (timedOut) {
         throw new ChatRunError('upstream_timeout', 'Chat backend request timed out', {
           retryable: true,
@@ -750,6 +763,13 @@ export async function processUserMessage(
           piSdkMessage: runResult.piSdkMessage,
           ...(turnOriginId ? { turnOriginId } : {}),
         }) as Array<Extract<ChatEvent, { type: 'assistant_done' }>>;
+        turnSettlement = {
+          requestId: turnId ?? requestId,
+          responseId,
+          status: 'completed',
+          hasSpeakableOutput: hasSpeakableAssistantOutput(assistantDoneEvents),
+          ...(turnOriginId ? { turnOriginId } : {}),
+        };
         for (const event of assistantDoneEvents) {
           logDebugChatEventRecord({
             enabled: envConfig.debugChatCompletions,
@@ -856,6 +876,13 @@ export async function processUserMessage(
       ...(eventStore ? { eventStore } : {}),
       ...(chatProvider === 'pi' ? { piTurnEndStatus: 'completed' as const } : {}),
     });
+    turnSettlement ??= {
+      requestId: turnId ?? requestId,
+      responseId,
+      status: 'completed',
+      hasSpeakableOutput: false,
+      ...(turnOriginId ? { turnOriginId } : {}),
+    };
 
     if (runResult.provider === 'pi' && runResult.piSdkMessage?.role === 'assistant') {
       const piConfig = agent?.chat?.config as PiSdkChatConfig | undefined;
@@ -950,6 +977,13 @@ export async function processUserMessage(
         prependEvents: buildInterruptedAssistantEvents(),
         ...(chatProvider === 'pi' ? { piTurnEndStatus: 'interrupted' as const } : {}),
       });
+      turnSettlement ??= {
+        requestId: turnId ?? requestId,
+        responseId,
+        status: timedOut ? 'interrupted' : 'error',
+        hasSpeakableOutput: false,
+        ...(turnOriginId ? { turnOriginId } : {}),
+      };
     }
 
     if (timedOut) {
@@ -971,6 +1005,12 @@ export async function processUserMessage(
     if (state.activeChatRun && state.activeChatRun.responseId === responseId) {
       state.activeChatRun = undefined;
     }
+    broadcastTurnSettledIfIdle({
+      sessionId,
+      state,
+      sessionHub,
+      candidate: turnSettlement,
+    });
     void sessionHub.processNextQueuedMessage(sessionId);
   }
 }

--- a/packages/agent-server/src/sessionConnectionRegistry.test.ts
+++ b/packages/agent-server/src/sessionConnectionRegistry.test.ts
@@ -398,6 +398,38 @@ describe('SessionConnectionRegistry', () => {
     });
   });
 
+  it('delivers turn settlement through a filtered voice subscription', () => {
+    const registry = new SessionConnectionRegistry();
+    const { connection, sendServerMessageFromHub } = createTestConnection();
+
+    registry.subscribe('session-a', connection, {
+      serverMessageTypes: ['transcript_event', 'turn_settled'],
+      chatEventTypes: ['turn_start', 'tool_call', 'assistant_done'],
+      toolNames: ['voice_ask', 'interaction_end'],
+      messagePhases: ['final_answer'],
+    });
+
+    registry.broadcastToSession('session-a', {
+      type: 'turn_settled',
+      sessionId: 'session-a',
+      requestId: 'turn-1',
+      responseId: 'response-1',
+      status: 'completed',
+      hasSpeakableOutput: false,
+      turnOriginId: 'android-process-1',
+    });
+
+    expect(sendServerMessageFromHub).toHaveBeenCalledWith({
+      type: 'turn_settled',
+      sessionId: 'session-a',
+      requestId: 'turn-1',
+      responseId: 'response-1',
+      status: 'completed',
+      hasSpeakableOutput: false,
+      turnOriginId: 'android-process-1',
+    });
+  });
+
   it('lets non-tool messages pass through when only toolNames filtering is present', () => {
     const registry = new SessionConnectionRegistry();
     const { connection, sendServerMessageFromHub } = createTestConnection();

--- a/packages/agent-server/src/turnSettlement.test.ts
+++ b/packages/agent-server/src/turnSettlement.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ChatEvent, ServerMessage } from '@assistant/shared';
+
+import type { LogicalSessionState, SessionHub } from './sessionHub';
+import { broadcastTurnSettledIfIdle, hasSpeakableAssistantOutput } from './turnSettlement';
+
+function createState(overrides: Partial<LogicalSessionState> = {}): LogicalSessionState {
+  return {
+    summary: {
+      sessionId: 'session-1',
+      createdAt: '',
+      updatedAt: '',
+    },
+    chatMessages: [],
+    messageQueue: [],
+    ...overrides,
+  } as LogicalSessionState;
+}
+
+describe('turn settlement', () => {
+  it('broadcasts a completed tool-only settlement after the run is released', () => {
+    const broadcast: ServerMessage[] = [];
+    const sessionHub = {
+      broadcastToSession: (_sessionId: string, message: ServerMessage) => {
+        broadcast.push(message);
+      },
+    } as SessionHub;
+
+    expect(
+      broadcastTurnSettledIfIdle({
+        sessionId: 'session-1',
+        state: createState(),
+        sessionHub,
+        candidate: {
+          requestId: 'turn-1',
+          responseId: 'response-1',
+          status: 'completed',
+          hasSpeakableOutput: false,
+          turnOriginId: 'android-process-1',
+        },
+      }),
+    ).toBe(true);
+    expect(broadcast).toEqual([
+      {
+        type: 'turn_settled',
+        sessionId: 'session-1',
+        requestId: 'turn-1',
+        responseId: 'response-1',
+        status: 'completed',
+        hasSpeakableOutput: false,
+        turnOriginId: 'android-process-1',
+      },
+    ]);
+  });
+
+  it('does not settle while a run or queued continuation remains', () => {
+    const broadcastToSession = vi.fn();
+    const sessionHub = { broadcastToSession } as unknown as SessionHub;
+    const candidate = {
+      requestId: 'turn-1',
+      responseId: 'response-1',
+      status: 'completed' as const,
+      hasSpeakableOutput: false,
+    };
+
+    expect(
+      broadcastTurnSettledIfIdle({
+        sessionId: 'session-1',
+        state: createState({
+          activeChatRun: {
+            requestId: 'request-1',
+            responseId: 'response-1',
+            abortController: new AbortController(),
+            accumulatedText: '',
+          },
+        }),
+        sessionHub,
+        candidate,
+      }),
+    ).toBe(false);
+    expect(
+      broadcastTurnSettledIfIdle({
+        sessionId: 'session-1',
+        state: createState({
+          messageQueue: [
+            {
+              id: 'queued-1',
+              text: 'next',
+              queuedAt: '',
+              source: 'user',
+            },
+          ],
+        }),
+        sessionHub,
+        candidate,
+      }),
+    ).toBe(false);
+    expect(broadcastToSession).not.toHaveBeenCalled();
+  });
+
+  it('recognizes only final-answer assistant output as speakable', () => {
+    const event = (phase: 'commentary' | 'final_answer'): ChatEvent => ({
+      id: phase,
+      timestamp: 1,
+      sessionId: 'session-1',
+      type: 'assistant_done',
+      payload: { text: 'text', phase },
+    });
+
+    expect(hasSpeakableAssistantOutput([event('commentary')])).toBe(false);
+    expect(hasSpeakableAssistantOutput([event('final_answer')])).toBe(true);
+  });
+});

--- a/packages/agent-server/src/turnSettlement.ts
+++ b/packages/agent-server/src/turnSettlement.ts
@@ -1,0 +1,51 @@
+import type { ChatEvent, ServerTurnSettledMessage, TurnSettlementStatus } from '@assistant/shared';
+
+import type { LogicalSessionState, SessionHub } from './sessionHub';
+
+export interface TurnSettlementCandidate {
+  requestId: string;
+  responseId: string;
+  status: TurnSettlementStatus;
+  hasSpeakableOutput: boolean;
+  turnOriginId?: string;
+}
+
+export function hasSpeakableAssistantOutput(events: readonly ChatEvent[]): boolean {
+  return events.some(
+    (event) =>
+      event.type === 'assistant_done' &&
+      event.payload.text.trim().length > 0 &&
+      (!event.payload.phase || event.payload.phase === 'final_answer'),
+  );
+}
+
+export function broadcastTurnSettledIfIdle(options: {
+  sessionId: string;
+  state: LogicalSessionState;
+  sessionHub: SessionHub;
+  candidate: TurnSettlementCandidate | null;
+  additionalState?: LogicalSessionState;
+}): boolean {
+  const { sessionId, state, sessionHub, candidate, additionalState } = options;
+  if (
+    !candidate ||
+    state.activeChatRun ||
+    additionalState?.activeChatRun ||
+    (state.messageQueue?.length ?? 0) > 0 ||
+    (additionalState?.messageQueue?.length ?? 0) > 0
+  ) {
+    return false;
+  }
+
+  const message: ServerTurnSettledMessage = {
+    type: 'turn_settled',
+    sessionId,
+    requestId: candidate.requestId,
+    responseId: candidate.responseId,
+    status: candidate.status,
+    hasSpeakableOutput: candidate.hasSpeakableOutput,
+    ...(candidate.turnOriginId ? { turnOriginId: candidate.turnOriginId } : {}),
+  };
+  sessionHub.broadcastToSession(sessionId, message);
+  return true;
+}

--- a/packages/agent-server/src/ws/chatRunLifecycle.ts
+++ b/packages/agent-server/src/ws/chatRunLifecycle.ts
@@ -45,6 +45,11 @@ import { resolveSessionModelForRun, resolveSessionThinkingForRun } from '../sess
 import { buildMessagesForPiSync, resolveInterruptedPiSyncMessages } from '../history/piSessionSync';
 import type { AgentTool } from '../tools';
 import { publishFinalResponseNotification } from '../notificationProducers';
+import {
+  broadcastTurnSettledIfIdle,
+  hasSpeakableAssistantOutput,
+  type TurnSettlementCandidate,
+} from '../turnSettlement';
 
 const LATE_PROVIDER_TAIL_CUSTOM_TYPE = 'assistant.late_provider_tail';
 
@@ -541,6 +546,7 @@ export async function handleTextInputWithChatCompletions(options: {
 
   let fullText = '';
   let thinkingText = '';
+  let turnSettlement: TurnSettlementCandidate | null = null;
   const buildInterruptedAssistantEvents = (): ChatEvent[] => {
     const run = state.activeChatRun;
     const partialText = run?.accumulatedText?.trim() ?? '';
@@ -627,6 +633,13 @@ export async function handleTextInputWithChatCompletions(options: {
           : {}),
         ...(runResult.provider === 'pi' ? { piTurnEndStatus: 'interrupted' as const } : {}),
       });
+      turnSettlement = {
+        requestId: turnId ?? requestId,
+        responseId,
+        status: 'interrupted',
+        hasSpeakableOutput: false,
+        ...(turnOriginId ? { turnOriginId } : {}),
+      };
       if (timedOut) {
         sendError('upstream_timeout', 'Chat backend request timed out', undefined, {
           retryable: true,
@@ -670,6 +683,13 @@ export async function handleTextInputWithChatCompletions(options: {
           piSdkMessage: runResult.piSdkMessage,
           ...(turnOriginId ? { turnOriginId } : {}),
         }) as Array<Extract<ChatEvent, { type: 'assistant_done' }>>;
+        turnSettlement = {
+          requestId: turnId ?? requestId,
+          responseId,
+          status: 'completed',
+          hasSpeakableOutput: hasSpeakableAssistantOutput(events),
+          ...(turnOriginId ? { turnOriginId } : {}),
+        };
         for (const event of events) {
           logDebugChatEventRecord({
             enabled: envConfig.debugChatCompletions,
@@ -778,6 +798,13 @@ export async function handleTextInputWithChatCompletions(options: {
       eventStore,
       ...(chatProvider === 'pi' ? { piTurnEndStatus: 'completed' as const } : {}),
     });
+    turnSettlement ??= {
+      requestId: turnId ?? requestId,
+      responseId,
+      status: 'completed',
+      hasSpeakableOutput: false,
+      ...(turnOriginId ? { turnOriginId } : {}),
+    };
   } catch (err) {
     const timedOut = abortController.signal.reason === 'timeout';
     if (state.activeChatRun?.outputCancelled === true) {
@@ -802,6 +829,13 @@ export async function handleTextInputWithChatCompletions(options: {
       prependEvents: buildInterruptedAssistantEvents(),
       ...(chatProvider === 'pi' ? { piTurnEndStatus: 'interrupted' as const } : {}),
     });
+    turnSettlement ??= {
+      requestId: turnId ?? requestId,
+      responseId,
+      status: timedOut ? 'interrupted' : 'error',
+      hasSpeakableOutput: false,
+      ...(turnOriginId ? { turnOriginId } : {}),
+    };
     if (timedOut) {
       sendError('upstream_timeout', 'Chat backend request timed out', undefined, {
         retryable: true,
@@ -834,6 +868,13 @@ export async function handleTextInputWithChatCompletions(options: {
       currentState.activeChatRun = undefined;
     }
     clearActiveRunState(activeRunState);
+    broadcastTurnSettledIfIdle({
+      sessionId,
+      state,
+      sessionHub,
+      candidate: turnSettlement,
+      ...(currentState && currentState !== state ? { additionalState: currentState } : {}),
+    });
     void sessionHub.processNextQueuedMessage(sessionId);
   }
 }

--- a/packages/mobile-web/README.md
+++ b/packages/mobile-web/README.md
@@ -210,6 +210,12 @@ is still the fastest first pass.
 - Session-linked voice notifications now drive a one-at-a-time Android-local queue. If the runtime
   is already alive, automatic `voice_speak`, `voice_ask`, and response-mode final replies queue
   behind the active local interaction instead of being dropped solely because the runtime was busy.
+- Completed turns also publish an ephemeral `turn_settled` websocket message after the active run
+  is released and only when no queued continuation remains. In Response and Manual modes, Android
+  uses a successful local-origin settlement with no final speakable text to start Auto Listen
+  without manufacturing an empty assistant response. A same-request `voice_ask` or
+  `interaction_end`, a server-origin turn, an interrupted/error result, or a subsequent
+  `turn_start` suppresses that automatic listen.
 - Final assistant replies are persisted as one durable `session_attention` item per session, while
   `voice_speak` and `voice_ask` remain append-only notifications with explicit `voiceMode`
   metadata. Auto-listen-capable items carry a server-generated session activity sequence so stale

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceEventParser.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceEventParser.java
@@ -22,6 +22,18 @@ final class AssistantVoiceEventParser {
             return null;
         }
 
+        if ("turn_start".equals(eventType) && !requestId.isEmpty()) {
+            return new AssistantVoicePromptEvent(
+                eventId,
+                sessionId,
+                requestId,
+                "",
+                "turn_start",
+                "",
+                ""
+            );
+        }
+
         if ("tool_call".equals(eventType)) {
             String toolName = trim(findStringField(payloadJson, "toolName", 0));
             String toolCallId = trim(findStringField(payloadJson, "toolCallId", 0));

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceInteractionRules.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceInteractionRules.java
@@ -41,6 +41,28 @@ final class AssistantVoiceInteractionRules {
         return trim(responseTurnOriginId).isEmpty();
     }
 
+    static boolean shouldAutoListenForSettledTurn(
+        boolean autoListenEnabled,
+        boolean localResponseVoiceOnlyEnabled,
+        String localTurnOriginId,
+        AssistantVoiceTurnSettledEvent event,
+        boolean interactionEnded,
+        boolean voiceAskStarted
+    ) {
+        return autoListenEnabled
+            && event != null
+            && "completed".equals(event.status)
+            && !event.hasSpeakableOutput
+            && !interactionEnded
+            && !voiceAskStarted
+            && !shouldSuppressAutoListenForAutomaticResponse(event.turnOriginId)
+            && shouldAdmitAutomaticResponse(
+                localResponseVoiceOnlyEnabled,
+                localTurnOriginId,
+                event.turnOriginId
+            );
+    }
+
     static boolean shouldAdmitAutomaticNotification(
         boolean localResponseVoiceOnlyEnabled,
         String localTurnOriginId,

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoicePromptEvent.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoicePromptEvent.java
@@ -50,6 +50,10 @@ final class AssistantVoicePromptEvent {
         return "interaction_end".equals(toolName);
     }
 
+    boolean isTurnStart() {
+        return "turn_start".equals(toolName);
+    }
+
     boolean startsListeningAfterPlayback() {
         return "voice_ask".equals(toolName);
     }

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceQueueItem.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceQueueItem.java
@@ -68,6 +68,10 @@ final class AssistantVoiceQueueItem {
         return "session_attention".equals(notificationKind);
     }
 
+    boolean isTurnSettledAutoListen() {
+        return "turn_settled_auto_listen".equals(notificationKind);
+    }
+
     String dedupKey() {
         if (!sourceEventId.isEmpty()) {
             return sourceEventId;
@@ -169,6 +173,35 @@ final class AssistantVoiceQueueItem {
             "system",
             dedupId,
             sessionId,
+            normalizedSessionTitle,
+            normalizedSessionTitle,
+            "",
+            "listen_only",
+            null,
+            false,
+            true
+        );
+    }
+
+    static AssistantVoiceQueueItem fromTurnSettled(
+        AssistantVoiceTurnSettledEvent event,
+        String sessionTitle
+    ) {
+        if (
+            event == null
+                || !"completed".equals(event.status)
+                || event.hasSpeakableOutput
+                || event.sessionId.isEmpty()
+        ) {
+            return null;
+        }
+        String normalizedSessionTitle = trim(sessionTitle);
+        return new AssistantVoiceQueueItem(
+            "",
+            "turn_settled_auto_listen",
+            "system",
+            event.responseId,
+            event.sessionId,
             normalizedSessionTitle,
             normalizedSessionTitle,
             "",

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRequestTracker.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRequestTracker.java
@@ -3,11 +3,11 @@ package com.assistant.mobile.voice;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-final class AssistantVoiceInteractionEndTracker {
+final class AssistantVoiceRequestTracker {
     private final int capacity;
     private final Set<String> requestKeys = new LinkedHashSet<>();
 
-    AssistantVoiceInteractionEndTracker(int capacity) {
+    AssistantVoiceRequestTracker(int capacity) {
         this.capacity = Math.max(1, capacity);
     }
 

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
@@ -182,8 +182,10 @@ public final class AssistantVoiceRuntimeService extends Service {
     private boolean assistantSocketConnected = false;
     private String adapterClientId = "";
     private final Set<String> assistantSubscribedSessionIds = new LinkedHashSet<>();
-    private final AssistantVoiceInteractionEndTracker interactionEndTracker =
-        new AssistantVoiceInteractionEndTracker(MAX_INTERACTION_END_REQUESTS);
+    private final AssistantVoiceRequestTracker interactionEndTracker =
+        new AssistantVoiceRequestTracker(MAX_INTERACTION_END_REQUESTS);
+    private final AssistantVoiceRequestTracker voiceAskTracker =
+        new AssistantVoiceRequestTracker(MAX_INTERACTION_END_REQUESTS);
     private String runtimeState = STATE_DISABLED;
 
     // The session currently owning native playback/listen/submit. This is set
@@ -1821,6 +1823,13 @@ public final class AssistantVoiceRuntimeService extends Service {
             return;
         }
 
+        AssistantVoiceTurnSettledEvent turnSettled =
+            AssistantVoiceTurnSettledEvent.parse(rawText);
+        if (turnSettled != null) {
+            handleTurnSettledEvent(turnSettled);
+            return;
+        }
+
         if (!messageType.isEmpty()) {
             Log.d(TAG, "assistant socket unhandled message type=" + messageType);
         }
@@ -1919,6 +1928,10 @@ public final class AssistantVoiceRuntimeService extends Service {
             Log.d(TAG, "handlePromptEvent skipped unwatched sessionId=" + safe(prompt.sessionId));
             return;
         }
+        if (prompt.isTurnStart()) {
+            cancelTurnSettledAutoListen(prompt.sessionId);
+            return;
+        }
         if (prompt.isInteractionEnd()) {
             interactionEndTracker.remember(prompt.sessionId, prompt.requestId);
             Log.d(
@@ -1930,9 +1943,13 @@ public final class AssistantVoiceRuntimeService extends Service {
             );
             return;
         }
+        if (prompt.startsListeningAfterPlayback()) {
+            voiceAskTracker.remember(prompt.sessionId, prompt.requestId);
+        }
         AssistantResponseAdmission responseAdmission = evaluateAssistantResponseAdmission(
             prompt,
             interactionEndTracker,
+            voiceAskTracker,
             config.localResponseVoiceOnlyEnabled,
             AssistantVoiceTurnOrigin.get()
         );
@@ -2011,7 +2028,8 @@ public final class AssistantVoiceRuntimeService extends Service {
 
     static AssistantResponseAdmission evaluateAssistantResponseAdmission(
         AssistantVoicePromptEvent prompt,
-        AssistantVoiceInteractionEndTracker interactionEndTracker,
+        AssistantVoiceRequestTracker interactionEndTracker,
+        AssistantVoiceRequestTracker voiceAskTracker,
         boolean localResponseVoiceOnlyEnabled,
         String localTurnOriginId
     ) {
@@ -2021,8 +2039,12 @@ public final class AssistantVoiceRuntimeService extends Service {
         boolean interactionEnded =
             interactionEndTracker != null
                 && interactionEndTracker.consume(prompt.sessionId, prompt.requestId);
+        boolean voiceAskStarted =
+            voiceAskTracker != null
+                && voiceAskTracker.consume(prompt.sessionId, prompt.requestId);
         boolean suppressAutoListen =
             interactionEnded
+                || voiceAskStarted
                 || AssistantVoiceInteractionRules.shouldSuppressAutoListenForAutomaticResponse(
                     prompt.turnOriginId
                 );
@@ -2032,6 +2054,60 @@ public final class AssistantVoiceRuntimeService extends Service {
             prompt.turnOriginId
         );
         return new AssistantResponseAdmission(admitted, suppressAutoListen);
+    }
+
+    private void handleTurnSettledEvent(AssistantVoiceTurnSettledEvent event) {
+        if (event == null || !isWatchedSessionId(event.sessionId)) {
+            return;
+        }
+        boolean interactionEnded = interactionEndTracker.consume(event.sessionId, event.requestId);
+        boolean voiceAskStarted = voiceAskTracker.consume(event.sessionId, event.requestId);
+        boolean shouldAutoListen =
+            AssistantVoiceInteractionRules.shouldAutoListenForSettledTurn(
+                config.autoListenEnabled,
+                config.localResponseVoiceOnlyEnabled,
+                AssistantVoiceTurnOrigin.get(),
+                event,
+                interactionEnded,
+                voiceAskStarted
+            );
+        if (
+            !shouldAutoListen
+                || (!AssistantVoiceConfig.AUDIO_MODE_RESPONSE.equals(config.audioMode)
+                    && !AssistantVoiceConfig.AUDIO_MODE_MANUAL.equals(config.audioMode))
+                || (config.ttsPreferredSessionOnly
+                    && !config.preferredVoiceSessionId.isEmpty()
+                    && !event.sessionId.equals(config.preferredVoiceSessionId))
+        ) {
+            return;
+        }
+        AssistantVoiceQueueItem item = AssistantVoiceQueueItem.fromTurnSettled(
+            event,
+            config.getSessionTitle(event.sessionId)
+        );
+        if (item != null) {
+            enqueueQueueItem(item, false);
+        }
+    }
+
+    private void cancelTurnSettledAutoListen(String sessionId) {
+        String normalizedSessionId = trim(sessionId);
+        for (int index = queuedVoiceItems.size() - 1; index >= 0; index -= 1) {
+            AssistantVoiceQueueItem item = queuedVoiceItems.get(index);
+            if (
+                item.isTurnSettledAutoListen()
+                    && normalizedSessionId.equals(item.sessionId)
+            ) {
+                queuedVoiceItems.remove(index);
+            }
+        }
+        if (
+            activeQueueItem != null
+                && activeQueueItem.isTurnSettledAutoListen()
+                && normalizedSessionId.equals(activeQueueItem.sessionId)
+        ) {
+            stopCurrentInteraction(false, "new_turn_started");
+        }
     }
 
     private void applyDurableNotificationSnapshot(List<AssistantVoiceNotificationRecord> notifications) {
@@ -3772,7 +3848,11 @@ public final class AssistantVoiceRuntimeService extends Service {
         return item != null
             && item.isListenOnly()
             && !item.manual
-            && ("manual_auto_listen".equals(item.notificationKind) || item.isSessionAttention());
+            && (
+                "manual_auto_listen".equals(item.notificationKind)
+                    || item.isSessionAttention()
+                    || item.isTurnSettledAutoListen()
+            );
     }
 
     static boolean shouldDedupManualAutoListenQueueItem(

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceSessionSocketProtocol.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceSessionSocketProtocol.java
@@ -91,16 +91,16 @@ final class AssistantVoiceSessionSocketProtocol {
         String normalizedAudioMode = trim(audioMode);
         if (AssistantVoiceConfig.AUDIO_MODE_RESPONSE.equals(normalizedAudioMode)) {
             return "{"
-                + "\"serverMessageTypes\":[\"transcript_event\"],"
-                + "\"chatEventTypes\":[\"tool_call\",\"assistant_done\"],"
-                + "\"toolNames\":[\"interaction_end\"],"
+                + "\"serverMessageTypes\":[\"transcript_event\",\"turn_settled\"],"
+                + "\"chatEventTypes\":[\"turn_start\",\"tool_call\",\"assistant_done\"],"
+                + "\"toolNames\":[\"voice_ask\",\"interaction_end\"],"
                 + "\"messagePhases\":[\"final_answer\"]"
                 + "}";
         }
         if (AssistantVoiceConfig.AUDIO_MODE_MANUAL.equals(normalizedAudioMode)) {
             return "{"
-                + "\"serverMessageTypes\":[\"transcript_event\"],"
-                + "\"chatEventTypes\":[\"tool_call\",\"assistant_done\"],"
+                + "\"serverMessageTypes\":[\"transcript_event\",\"turn_settled\"],"
+                + "\"chatEventTypes\":[\"turn_start\",\"tool_call\",\"assistant_done\"],"
                 + "\"toolNames\":[\"voice_speak\",\"voice_ask\",\"interaction_end\"],"
                 + "\"messagePhases\":[\"final_answer\"]"
                 + "}";

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceTurnSettledEvent.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceTurnSettledEvent.java
@@ -1,0 +1,63 @@
+package com.assistant.mobile.voice;
+
+import org.json.JSONObject;
+
+final class AssistantVoiceTurnSettledEvent {
+    final String sessionId;
+    final String requestId;
+    final String responseId;
+    final String status;
+    final boolean hasSpeakableOutput;
+    final String turnOriginId;
+
+    AssistantVoiceTurnSettledEvent(
+        String sessionId,
+        String requestId,
+        String responseId,
+        String status,
+        boolean hasSpeakableOutput,
+        String turnOriginId
+    ) {
+        this.sessionId = trim(sessionId);
+        this.requestId = trim(requestId);
+        this.responseId = trim(responseId);
+        this.status = trim(status);
+        this.hasSpeakableOutput = hasSpeakableOutput;
+        this.turnOriginId = trim(turnOriginId);
+    }
+
+    static AssistantVoiceTurnSettledEvent parse(String rawMessage) {
+        if (rawMessage == null || rawMessage.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            JSONObject message = new JSONObject(rawMessage);
+            if (!"turn_settled".equals(trim(message.optString("type")))) {
+                return null;
+            }
+            AssistantVoiceTurnSettledEvent event = new AssistantVoiceTurnSettledEvent(
+                message.optString("sessionId"),
+                message.optString("requestId"),
+                message.optString("responseId"),
+                message.optString("status"),
+                message.optBoolean("hasSpeakableOutput", false),
+                message.optString("turnOriginId")
+            );
+            if (
+                event.sessionId.isEmpty()
+                    || event.requestId.isEmpty()
+                    || event.responseId.isEmpty()
+                    || event.status.isEmpty()
+            ) {
+                return null;
+            }
+            return event;
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private static String trim(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceInteractionRulesTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceInteractionRulesTest.java
@@ -53,6 +53,68 @@ public final class AssistantVoiceInteractionRulesTest {
     }
 
     @Test
+    public void settledLocalToolOnlyTurnAutoListens() {
+        AssistantVoiceTurnSettledEvent event = new AssistantVoiceTurnSettledEvent(
+            "session-1",
+            "request-1",
+            "response-1",
+            "completed",
+            false,
+            "android-process-1"
+        );
+
+        assertTrue(AssistantVoiceInteractionRules.shouldAutoListenForSettledTurn(
+            true,
+            true,
+            "android-process-1",
+            event,
+            false,
+            false
+        ));
+    }
+
+    @Test
+    public void settledTurnAutoListenRejectsOutputServerOriginAndVoiceControls() {
+        AssistantVoiceTurnSettledEvent speakable = new AssistantVoiceTurnSettledEvent(
+            "session-1",
+            "request-1",
+            "response-1",
+            "completed",
+            true,
+            "android-process-1"
+        );
+        AssistantVoiceTurnSettledEvent server = new AssistantVoiceTurnSettledEvent(
+            "session-1",
+            "request-2",
+            "response-2",
+            "completed",
+            false,
+            ""
+        );
+        AssistantVoiceTurnSettledEvent toolOnly = new AssistantVoiceTurnSettledEvent(
+            "session-1",
+            "request-3",
+            "response-3",
+            "completed",
+            false,
+            "android-process-1"
+        );
+
+        assertFalse(AssistantVoiceInteractionRules.shouldAutoListenForSettledTurn(
+            true, true, "android-process-1", speakable, false, false
+        ));
+        assertFalse(AssistantVoiceInteractionRules.shouldAutoListenForSettledTurn(
+            true, true, "android-process-1", server, false, false
+        ));
+        assertFalse(AssistantVoiceInteractionRules.shouldAutoListenForSettledTurn(
+            true, true, "android-process-1", toolOnly, true, false
+        ));
+        assertFalse(AssistantVoiceInteractionRules.shouldAutoListenForSettledTurn(
+            true, true, "android-process-1", toolOnly, false, true
+        ));
+    }
+
+    @Test
     public void identifiesOnlySystemSessionAttentionAsAssistantResponseNotification() {
         AssistantVoiceNotificationRecord responseNotification =
             new AssistantVoiceNotificationRecord(

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceQueueItemTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceQueueItemTest.java
@@ -165,6 +165,42 @@ public final class AssistantVoiceQueueItemTest {
     }
 
     @Test
+    public void fromTurnSettledBuildsListenOnlyQueueItem() {
+        AssistantVoiceQueueItem item = AssistantVoiceQueueItem.fromTurnSettled(
+            new AssistantVoiceTurnSettledEvent(
+                "session-1",
+                "request-1",
+                "response-1",
+                "completed",
+                false,
+                "android-process-1"
+            ),
+            "Session 1"
+        );
+
+        assertNotNull(item);
+        assertTrue(item.isListenOnly());
+        assertTrue(item.isTurnSettledAutoListen());
+        assertTrue("response-1".equals(item.sourceEventId));
+        assertTrue("session-1".equals(item.sessionId));
+    }
+
+    @Test
+    public void fromTurnSettledIgnoresSpeakableResponse() {
+        assertNull(AssistantVoiceQueueItem.fromTurnSettled(
+            new AssistantVoiceTurnSettledEvent(
+                "session-1",
+                "request-1",
+                "response-1",
+                "completed",
+                true,
+                "android-process-1"
+            ),
+            "Session 1"
+        ));
+    }
+
+    @Test
     public void manualNotificationMicSkipsPlaybackAndStartsListeningImmediately() {
         AssistantVoiceNotificationRecord notification = new AssistantVoiceNotificationRecord(
             "notif-1",

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRequestTrackerTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRequestTrackerTest.java
@@ -5,10 +5,10 @@ import org.junit.Test;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public final class AssistantVoiceInteractionEndTrackerTest {
+public final class AssistantVoiceRequestTrackerTest {
     @Test
     public void consumesOnlyTheMatchingSessionRequestOnce() {
-        AssistantVoiceInteractionEndTracker tracker = new AssistantVoiceInteractionEndTracker(4);
+        AssistantVoiceRequestTracker tracker = new AssistantVoiceRequestTracker(4);
 
         tracker.remember("session-1", "request-1");
 
@@ -20,7 +20,7 @@ public final class AssistantVoiceInteractionEndTrackerTest {
 
     @Test
     public void ignoresIncompleteKeysAndEvictsTheOldestRequest() {
-        AssistantVoiceInteractionEndTracker tracker = new AssistantVoiceInteractionEndTracker(2);
+        AssistantVoiceRequestTracker tracker = new AssistantVoiceRequestTracker(2);
 
         tracker.remember("", "request-0");
         tracker.remember("session-1", "");

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRuntimeServiceTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRuntimeServiceTest.java
@@ -38,7 +38,7 @@ public final class AssistantVoiceRuntimeServiceTest {
     @Test
     @Config(sdk = Build.VERSION_CODES.N)
     public void foreignResponseConsumesInteractionEndBeforeOriginRejection() {
-        AssistantVoiceInteractionEndTracker tracker = new AssistantVoiceInteractionEndTracker(4);
+        AssistantVoiceRequestTracker tracker = new AssistantVoiceRequestTracker(4);
         tracker.remember("session-1", "request-1");
         AssistantVoicePromptEvent foreignResponse = new AssistantVoicePromptEvent(
             "event-1",
@@ -54,6 +54,7 @@ public final class AssistantVoiceRuntimeServiceTest {
             AssistantVoiceRuntimeService.evaluateAssistantResponseAdmission(
                 foreignResponse,
                 tracker,
+                new AssistantVoiceRequestTracker(4),
                 true,
                 "this-device"
             );
@@ -79,13 +80,43 @@ public final class AssistantVoiceRuntimeServiceTest {
         AssistantVoiceRuntimeService.AssistantResponseAdmission admission =
             AssistantVoiceRuntimeService.evaluateAssistantResponseAdmission(
                 serverResponse,
-                new AssistantVoiceInteractionEndTracker(4),
+                new AssistantVoiceRequestTracker(4),
+                new AssistantVoiceRequestTracker(4),
                 true,
                 "this-device"
             );
 
         assertTrue(admission.admitted);
         assertTrue(admission.suppressAutoListen);
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.N)
+    public void voiceAskSuppressesAssistantResponseAutoListenForSameRequest() {
+        AssistantVoiceRequestTracker voiceAskTracker = new AssistantVoiceRequestTracker(4);
+        voiceAskTracker.remember("session-1", "request-1");
+        AssistantVoicePromptEvent response = new AssistantVoicePromptEvent(
+            "event-1",
+            "session-1",
+            "request-1",
+            "response-1",
+            "assistant_response",
+            "Answer",
+            "this-device"
+        );
+
+        AssistantVoiceRuntimeService.AssistantResponseAdmission admission =
+            AssistantVoiceRuntimeService.evaluateAssistantResponseAdmission(
+                response,
+                new AssistantVoiceRequestTracker(4),
+                voiceAskTracker,
+                true,
+                "this-device"
+            );
+
+        assertTrue(admission.admitted);
+        assertTrue(admission.suppressAutoListen);
+        assertFalse(voiceAskTracker.consume("session-1", "request-1"));
     }
 
     @Test

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceSessionSocketProtocolTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceSessionSocketProtocolTest.java
@@ -33,9 +33,9 @@ public final class AssistantVoiceSessionSocketProtocolTest {
 
         assertTrue(payload.contains("\"type\":\"subscribe\""));
         assertTrue(payload.contains("\"sessionId\":\"session-123\""));
-        assertTrue(payload.contains("\"serverMessageTypes\":[\"transcript_event\"]"));
-        assertTrue(payload.contains("\"chatEventTypes\":[\"tool_call\",\"assistant_done\"]"));
-        assertTrue(payload.contains("\"toolNames\":[\"interaction_end\"]"));
+        assertTrue(payload.contains("\"serverMessageTypes\":[\"transcript_event\",\"turn_settled\"]"));
+        assertTrue(payload.contains("\"chatEventTypes\":[\"turn_start\",\"tool_call\",\"assistant_done\"]"));
+        assertTrue(payload.contains("\"toolNames\":[\"voice_ask\",\"interaction_end\"]"));
         assertTrue(payload.contains("\"messagePhases\":[\"final_answer\"]"));
     }
 
@@ -48,8 +48,8 @@ public final class AssistantVoiceSessionSocketProtocolTest {
 
         assertTrue(payload.contains("\"type\":\"subscribe\""));
         assertTrue(payload.contains("\"sessionId\":\"session-123\""));
-        assertTrue(payload.contains("\"serverMessageTypes\":[\"transcript_event\"]"));
-        assertTrue(payload.contains("\"chatEventTypes\":[\"tool_call\",\"assistant_done\"]"));
+        assertTrue(payload.contains("\"serverMessageTypes\":[\"transcript_event\",\"turn_settled\"]"));
+        assertTrue(payload.contains("\"chatEventTypes\":[\"turn_start\",\"tool_call\",\"assistant_done\"]"));
         assertTrue(payload.contains(
             "\"toolNames\":[\"voice_speak\",\"voice_ask\",\"interaction_end\"]"
         ));
@@ -171,5 +171,27 @@ public final class AssistantVoiceSessionSocketProtocolTest {
         assertTrue(prompt.isInteractionEnd());
         assertTrue("request-end".equals(prompt.requestId));
         assertTrue("call-end".equals(prompt.toolCallId));
+    }
+
+    @Test
+    public void parsePlaybackMessageReturnsTurnStartControl() {
+        String message = "{"
+            + "\"type\":\"transcript_event\","
+            + "\"event\":{"
+            + "\"eventId\":\"event-start\","
+            + "\"sessionId\":\"session-123\","
+            + "\"requestId\":\"request-start\","
+            + "\"chatEventType\":\"turn_start\","
+            + "\"payload\":{\"trigger\":\"user\"}"
+            + "}"
+            + "}";
+
+        AssistantVoicePromptEvent prompt = AssistantVoiceSessionSocketProtocol.parsePlaybackMessage(
+            message
+        );
+
+        assertNotNull(prompt);
+        assertTrue(prompt.isTurnStart());
+        assertTrue("request-start".equals(prompt.requestId));
     }
 }

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceTurnSettledEventTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceTurnSettledEventTest.java
@@ -1,0 +1,40 @@
+package com.assistant.mobile.voice;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public final class AssistantVoiceTurnSettledEventTest {
+    @Test
+    public void parsesCompletedToolOnlyTurn() {
+        AssistantVoiceTurnSettledEvent event = AssistantVoiceTurnSettledEvent.parse(
+            "{"
+                + "\"type\":\"turn_settled\","
+                + "\"sessionId\":\"session-1\","
+                + "\"requestId\":\"request-1\","
+                + "\"responseId\":\"response-1\","
+                + "\"status\":\"completed\","
+                + "\"hasSpeakableOutput\":false,"
+                + "\"turnOriginId\":\"android-process-1\""
+                + "}"
+        );
+
+        assertNotNull(event);
+        assertTrue("session-1".equals(event.sessionId));
+        assertTrue("request-1".equals(event.requestId));
+        assertTrue("response-1".equals(event.responseId));
+        assertTrue("completed".equals(event.status));
+        assertFalse(event.hasSpeakableOutput);
+        assertTrue("android-process-1".equals(event.turnOriginId));
+    }
+
+    @Test
+    public void rejectsIncompleteSettlementMessage() {
+        assertNull(AssistantVoiceTurnSettledEvent.parse(
+            "{\"type\":\"turn_settled\",\"sessionId\":\"session-1\"}"
+        ));
+    }
+}

--- a/packages/shared/src/protocol.test.ts
+++ b/packages/shared/src/protocol.test.ts
@@ -304,6 +304,20 @@ describe('server message validation', () => {
     expect(parsed).toEqual(message);
   });
 
+  it('accepts a turn_settled message', () => {
+    const message: ServerMessage = {
+      type: 'turn_settled',
+      sessionId: 'session-1',
+      requestId: 'turn-1',
+      responseId: 'response-1',
+      status: 'completed',
+      hasSpeakableOutput: false,
+      turnOriginId: 'android-process-1',
+    };
+
+    expect(validateServerMessage(message)).toEqual(message);
+  });
+
   it('accepts a session_updated message with attributes', () => {
     const message: ServerMessage = {
       type: 'session_updated',

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -32,6 +32,7 @@ const SERVER_MESSAGE_TYPE_VALUES = [
   'tool_call_start',
   'tool_output_delta',
   'tool_result',
+  'turn_settled',
   'transcript_event',
   'agent_callback_result',
   'modes_updated',
@@ -734,6 +735,19 @@ export const ServerTranscriptEventMessageSchema = z.object({
   event: ProjectedTranscriptEventSchema,
 });
 
+export const TurnSettlementStatusSchema = z.enum(['completed', 'interrupted', 'error']);
+export type TurnSettlementStatus = z.infer<typeof TurnSettlementStatusSchema>;
+
+export const ServerTurnSettledMessageSchema = z.object({
+  type: z.literal('turn_settled'),
+  sessionId: z.string().trim().min(1),
+  requestId: z.string().trim().min(1),
+  responseId: z.string().trim().min(1),
+  status: TurnSettlementStatusSchema,
+  hasSpeakableOutput: z.boolean(),
+  turnOriginId: z.string().trim().min(1).max(128).optional(),
+});
+
 export const ServerAgentCallbackResultMessageSchema = z.object({
   type: z.literal('agent_callback_result'),
   /**
@@ -918,6 +932,7 @@ export const ServerMessageSchema = z.discriminatedUnion('type', [
   ServerToolCallStartMessageSchema,
   ServerToolOutputDeltaMessageSchema,
   ServerToolResultMessageSchema,
+  ServerTurnSettledMessageSchema,
   ServerTranscriptEventMessageSchema,
   ServerAgentCallbackResultMessageSchema,
   ServerModesUpdatedMessageSchema,
@@ -951,6 +966,7 @@ export type ServerToolCallMessage = z.infer<typeof ServerToolCallMessageSchema>;
 export type ServerToolCallStartMessage = z.infer<typeof ServerToolCallStartMessageSchema>;
 export type ServerToolOutputDeltaMessage = z.infer<typeof ServerToolOutputDeltaMessageSchema>;
 export type ServerToolResultMessage = z.infer<typeof ServerToolResultMessageSchema>;
+export type ServerTurnSettledMessage = z.infer<typeof ServerTurnSettledMessageSchema>;
 export type ServerTranscriptEventMessage = z.infer<typeof ServerTranscriptEventMessageSchema>;
 export type ServerAgentCallbackResultMessage = z.infer<
   typeof ServerAgentCallbackResultMessageSchema


### PR DESCRIPTION
## Summary
- add an ephemeral `turn_settled` server message emitted only after a run is released and no continuation is queued
- let Android Response and Manual voice modes auto-listen after successful local-origin turns with no speakable output
- suppress stale or duplicate listens for voice controls, new turns, non-local origins, and unsuccessful settlements
- document the behavior and cover the protocol, server lifecycle, subscriptions, and Android rules

## Testing
- `npx vitest --run turnSettlement.test.ts chatProcessor.test.ts ws/chatRunLifecycle.pi.test.ts sessionConnectionRegistry.test.ts shared/protocol.test.ts`
- `cd packages/mobile-web/android && ./gradlew testDebugUnitTest`
- full production `npm run build`
- `npm run android:build`