### PR TITLE
Add bounded Codex Threads agent tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Added bounded Codex Threads tools for thread discovery, status, transcripts, messaging, steering, creation, and renaming, with server/capability scoping and exact-turn response retrieval for asynchronous relay workflows. ([#126](https://github.com/kcosr/assistant/pull/126))
 - Added settlement-driven Android Auto Listen for successful local-origin turns with no final speakable output, while suppressing queued, stale, interrupted, error, and voice-control-completed turns. ([#125](https://github.com/kcosr/assistant/pull/125))
 - Added locally bundled UI and code font catalogs with consistent form-control and terminal rendering, plus unified mobile, Electron, and Tauri app artwork generation. ([#124](https://github.com/kcosr/assistant/pull/124))
 - Added default-on Android response ownership so automatic assistant TTS and Auto Listen only run for turns started by the current app process, while tool prompts, external notifications, and manual voice actions remain available. ([#123](https://github.com/kcosr/assistant/pull/123))

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -18,6 +18,7 @@ This document describes the application configuration file used by the agent ser
   - [Location and Loading](#location-and-loading)
   - [Environment Variable Substitution](#environment-variable-substitution)
   - [Top-Level Keys](#top-level-keys)
+  - [Codex Threads](#codex-threads)
   - [Agents](#agents)
 - [Security Notes](#security-notes)
 - [Full Example](#full-example)
@@ -94,7 +95,15 @@ Realtime tool exposure is **explicit opt-in**. Configure under `voice.realtime`:
 {
   "voice": {
     "realtime": {
-      "toolAllowlist": ["interaction_end", "lists_*", "web_search"],
+      "toolAllowlist": [
+        "interaction_end",
+        "lists_*",
+        "web_search",
+        "codex_threads_list",
+        "codex_threads_find",
+        "codex_threads_status",
+        "codex_threads_messages"
+      ],
       "toolDenylist": []
     }
   }
@@ -136,6 +145,27 @@ Text agents use per-agent `toolAllowlist` / `toolDenylist` independently of this
 | Not the same as        | Plugin `search_*` tools (in-app notes/lists search)                                                                                                                                                               |
 
 Design: `docs/design/web-search-tool.md`.
+
+#### Built-in Codex Threads tools
+
+The `codex_threads_*` built-in tools use the local `codex-threads` CLI to inspect
+and interact with a configured Codex app-server. They are individually
+allowlisted for text agents and Realtime voice.
+
+| Tool                     | Purpose                                                                                                    |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| `codex_threads_list`     | List bounded recently updated threads, including cwd/project and status.                                   |
+| `codex_threads_find`     | Match a bounded recent candidate set by name, preview, and cwd metadata. It is not full transcript search. |
+| `codex_threads_status`   | Load and inspect one thread and its active-turn state.                                                     |
+| `codex_threads_messages` | Read a bounded recent user/assistant transcript.                                                           |
+| `codex_threads_send`     | Start or queue a turn; optionally wait up to 120 seconds for bounded final text.                           |
+| `codex_threads_steer`    | Add guidance to the exact currently active turn.                                                          |
+| `codex_threads_create`   | Create, optionally name, and start a thread in an allowed cwd.                                             |
+| `codex_threads_rename`   | Set a non-empty thread name.                                                                               |
+
+The Realtime example exposes only read operations. Add write operation names
+explicitly when voice-driven mutations are desired; Realtime does not apply
+per-agent capability rules.
 
 ### ElevenLabs TTS
 
@@ -241,13 +271,14 @@ Examples:
 
 ### Top-Level Keys
 
-| Key          | Type   | Description                                                     |
-| ------------ | ------ | --------------------------------------------------------------- |
-| `sessions`   | object | Session cache settings.                                         |
-| `agents`     | array  | Agent persona definitions and chat provider config.             |
-| `profiles`   | array  | Shared profile (instance) definitions for cross-plugin scoping. |
-| `plugins`    | object | Plugin enablement and per-plugin config.                        |
-| `mcpServers` | array  | External MCP servers launched over stdio.                       |
+| Key            | Type   | Description                                                     |
+| -------------- | ------ | --------------------------------------------------------------- |
+| `sessions`     | object | Session cache settings.                                         |
+| `agents`       | array  | Agent persona definitions and chat provider config.             |
+| `profiles`     | array  | Shared profile (instance) definitions for cross-plugin scoping. |
+| `plugins`      | object | Plugin enablement and per-plugin config.                        |
+| `mcpServers`   | array  | External MCP servers launched over stdio.                       |
+| `codexThreads` | object | Host configuration for built-in `codex_threads_*` tools.        |
 
 #### `sessions`
 
@@ -258,6 +289,38 @@ Controls session cache behavior.
 ```
 
 - `maxCached`: maximum number of sessions cached in memory
+
+#### Codex Threads
+
+```json
+{
+  "codexThreads": {
+    "allowedServers": ["main", "work"],
+    "binary": "codex-threads",
+    "permissionMode": "app-server-default",
+    "allowedCwdRoots": ["/home/kevin/worktrees"]
+  }
+}
+```
+
+| Field             | Default              | Description                                                                                                                                                    |
+| ----------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `allowedServers`  | required             | Nonempty list of aliases from the host user's `codex-threads` config. Every tool call must select one of these aliases through its required `server` argument. |
+| `binary`          | `codex-threads`      | Executable name or trusted host-configured path.                                                                                                               |
+| `permissionMode`  | `app-server-default` | `app-server-default` passes `--no-yolo`; `full-access` deliberately uses the CLI's approval-policy-never/full-access behavior. Agents cannot override it.      |
+| `allowedCwdRoots` | `[]`                 | Absolute roots permitted for `codex_threads_create`. With no roots, create is unavailable while other operations still work.                                   |
+
+The host service user must have a working `codex-threads` configuration and a
+reachable app-server for each allowed alias. Every operation requires a
+model-visible `server` argument constrained to `allowedServers`. Calls use JSON output,
+argument-array subprocess execution, hard time/output limits, and compact
+result projections. Full-text CLI search is intentionally not exposed because
+its time filtering can scan unbounded history; `codex_threads_find` searches a
+fixed recent metadata candidate set instead.
+
+Text agents opt in through `toolAllowlist` and may additionally scope
+`codex_threads.read` versus `codex_threads.write` capabilities. Realtime opts in
+independently through exact names or globs under `voice.realtime.toolAllowlist`.
 
 #### `agents`
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -159,7 +159,7 @@ allowlisted for text agents and Realtime voice.
 | `codex_threads_status`   | Load and inspect one thread and its active-turn state.                                                     |
 | `codex_threads_messages` | Read a bounded recent user/assistant transcript.                                                           |
 | `codex_threads_send`     | Start or queue a turn; optionally wait up to 120 seconds for bounded final text.                           |
-| `codex_threads_steer`    | Add guidance to the exact currently active turn.                                                          |
+| `codex_threads_steer`    | Add guidance to the exact currently active turn.                                                           |
 | `codex_threads_create`   | Create, optionally name, and start a thread in an allowed cwd.                                             |
 | `codex_threads_rename`   | Set a non-empty thread name.                                                                               |
 
@@ -317,6 +317,12 @@ argument-array subprocess execution, hard time/output limits, and compact
 result projections. Full-text CLI search is intentionally not exposed because
 its time filtering can scan unbounded history; `codex_threads_find` searches a
 fixed recent metadata candidate set instead.
+
+`codex_threads_messages` accepts an optional exact `turnId` returned by
+`codex_threads_send`. When present, the server scans the bounded recent-turn
+window, filters to that turn, and only then applies the final message limit.
+This lets asynchronous relay agents retrieve the response for the turn they
+submitted without confusing it with newer thread activity.
 
 Text agents opt in through `toolAllowlist` and may additionally scope
 `codex_threads.read` versus `codex_threads.write` capabilities. Realtime opts in

--- a/packages/agent-server/data/config.example.json
+++ b/packages/agent-server/data/config.example.json
@@ -5,6 +5,16 @@
   "sessions": {
     "maxCached": 100
   },
+  "codexThreads": {
+    "allowedServers": [
+      "main"
+    ],
+    "binary": "codex-threads",
+    "permissionMode": "app-server-default",
+    "allowedCwdRoots": [
+      "/path/to/workspaces"
+    ]
+  },
   "agents": [
     {
       "agentId": "lists",
@@ -295,7 +305,11 @@
     "realtime": {
       "toolAllowlist": [
         "lists_*",
-        "web_search"
+        "web_search",
+        "codex_threads_list",
+        "codex_threads_find",
+        "codex_threads_status",
+        "codex_threads_messages"
       ]
     }
   }

--- a/packages/agent-server/src/builtInTools.test.ts
+++ b/packages/agent-server/src/builtInTools.test.ts
@@ -182,6 +182,24 @@ describe('registerBuiltInSessionTools', () => {
     );
   });
 
+  it('registers the Codex Threads built-in tool family', async () => {
+    const host = createHost();
+    const tools = await host.listTools();
+
+    expect(tools.map((tool) => tool.name)).toEqual(
+      expect.arrayContaining([
+        'codex_threads_list',
+        'codex_threads_find',
+        'codex_threads_status',
+        'codex_threads_messages',
+        'codex_threads_send',
+        'codex_threads_steer',
+        'codex_threads_create',
+        'codex_threads_rename',
+      ]),
+    );
+  });
+
   it('registers attachment_send', async () => {
     const host = createHost();
 

--- a/packages/agent-server/src/builtInTools.ts
+++ b/packages/agent-server/src/builtInTools.ts
@@ -6,7 +6,13 @@ import path from 'node:path';
 import type { SessionHub, SessionIndex } from './index';
 import type { EnvConfig } from './envConfig';
 import type { AgentDefinition, AgentRegistry } from './agents';
-import type { AgentTool, BuiltInToolDefinition, ToolContext, ToolHost } from './tools';
+import type {
+  AgentTool,
+  BuiltInToolDefinition,
+  CodexThreadsToolConfig,
+  ToolContext,
+  ToolHost,
+} from './tools';
 import { processUserMessage, isSessionBusy } from './chatProcessor';
 import { createScopedToolHost } from './tools';
 import { resolveSessionWorkingDir } from './tools/sessionWorkingDir';
@@ -33,6 +39,7 @@ import {
 } from './attachments/constants';
 import { createNotificationRecord } from '../../plugins/core/notifications/server/service';
 import { createWebSearchToolDefinition } from './tools/webSearch';
+import { createCodexThreadsToolDefinitions } from './tools/codexThreads';
 import { INTERACTION_END_TOOL_NAME, INTERACTION_END_TOOL_PARAMETERS } from './interactionEndTool';
 
 interface AgentMessageArgs {
@@ -1187,6 +1194,7 @@ export function registerBuiltInSessionTools(options: {
   host: { registerTool(definition: BuiltInToolDefinition): void };
   sessionHub: SessionHub;
   attachmentPreviewChars?: number;
+  codexThreadsConfig?: CodexThreadsToolConfig;
 }): void {
   const attachmentPreviewChars =
     typeof options.attachmentPreviewChars === 'number'
@@ -1284,4 +1292,7 @@ export function registerBuiltInSessionTools(options: {
   });
 
   options.host.registerTool(createWebSearchToolDefinition());
+  for (const definition of createCodexThreadsToolDefinitions(options.codexThreadsConfig)) {
+    options.host.registerTool(definition);
+  }
 }

--- a/packages/agent-server/src/config.test.ts
+++ b/packages/agent-server/src/config.test.ts
@@ -122,6 +122,64 @@ describe('loadConfig', () => {
     expect(server.env?.['COMPLEX']).toBe('prefix-one-two-suffix');
   });
 
+  it('loads bounded Codex Threads host configuration', async () => {
+    const filePath = createTempFile('config-codex-threads');
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({
+        codexThreads: {
+          allowedServers: ['main', 'work'],
+          allowedCwdRoots: ['/home/kevin/worktrees'],
+        },
+      }),
+      'utf8',
+    );
+
+    const config = loadConfig(filePath);
+    expect(config.codexThreads).toEqual({
+      allowedServers: ['main', 'work'],
+      binary: 'codex-threads',
+      permissionMode: 'app-server-default',
+      allowedCwdRoots: ['/home/kevin/worktrees'],
+    });
+  });
+
+  it('rejects invalid Codex Threads configuration', async () => {
+    const relativeRootPath = createTempFile('config-codex-threads-relative');
+    await fs.writeFile(
+      relativeRootPath,
+      JSON.stringify({
+        codexThreads: {
+          allowedServers: ['main'],
+          allowedCwdRoots: ['relative/path'],
+        },
+      }),
+      'utf8',
+    );
+    expect(() => loadConfig(relativeRootPath)).toThrow(/absolute path/i);
+
+    const unknownModePath = createTempFile('config-codex-threads-mode');
+    await fs.writeFile(
+      unknownModePath,
+      JSON.stringify({
+        codexThreads: {
+          allowedServers: ['main'],
+          permissionMode: 'yolo',
+        },
+      }),
+      'utf8',
+    );
+    expect(() => loadConfig(unknownModePath)).toThrow();
+
+    const invalidServersPath = createTempFile('config-codex-threads-servers');
+    await fs.writeFile(
+      invalidServersPath,
+      JSON.stringify({ codexThreads: { allowedServers: ['main', 'main'] } }),
+      'utf8',
+    );
+    expect(() => loadConfig(invalidServersPath)).toThrow(/unique/i);
+  });
+
   it('parses coding plugin configuration with local workspace root', async () => {
     const filePath = createTempFile('config-coding-plugin');
     const configJson = {

--- a/packages/agent-server/src/config.ts
+++ b/packages/agent-server/src/config.ts
@@ -832,6 +832,32 @@ export const VoiceConfigSchema = z
 
 export type VoiceConfig = z.infer<typeof VoiceConfigSchema>;
 
+export const CodexThreadsConfigSchema = z
+  .object({
+    allowedServers: z
+      .array(
+        z
+          .string()
+          .trim()
+          .min(1)
+          .max(100)
+          .regex(
+            /^[A-Za-z0-9][A-Za-z0-9._-]*$/,
+            'Codex Threads server aliases may contain letters, numbers, dots, underscores, and hyphens',
+          ),
+      )
+      .min(1)
+      .refine((servers) => new Set(servers).size === servers.length, {
+        message: 'Codex Threads server aliases must be unique',
+      }),
+    binary: NonEmptyTrimmedStringSchema.default('codex-threads'),
+    permissionMode: z.enum(['app-server-default', 'full-access']).default('app-server-default'),
+    allowedCwdRoots: z.array(AbsolutePathSchema).default([]),
+  })
+  .strict();
+
+export type CodexThreadsConfig = z.infer<typeof CodexThreadsConfigSchema>;
+
 export const AppConfigSchema = z
   .object({
     agents: z
@@ -850,6 +876,7 @@ export const AppConfigSchema = z
     sessions: SessionsConfigSchema.optional(),
     attachments: AttachmentsConfigSchema.default({}),
     voice: VoiceConfigSchema,
+    codexThreads: CodexThreadsConfigSchema.optional(),
   })
   .superRefine((value, ctx) => {
     const profileIds = new Set<string>();

--- a/packages/agent-server/src/index.ts
+++ b/packages/agent-server/src/index.ts
@@ -112,6 +112,7 @@ export async function startServer(
       ...(typeof appConfig?.attachments.previewSnippetChars === 'number'
         ? { attachmentPreviewChars: appConfig.attachments.previewSnippetChars }
         : {}),
+      ...(appConfig?.codexThreads ? { codexThreadsConfig: appConfig.codexThreads } : {}),
     },
   );
 

--- a/packages/agent-server/src/tools.ts
+++ b/packages/agent-server/src/tools.ts
@@ -6,6 +6,7 @@ export type {
   AgentToolResult,
   AgentToolUpdateCallback,
   BuiltInToolDefinition,
+  CodexThreadsToolConfig,
   CreateToolHostDeps,
   McpServerConfig,
   Tool,
@@ -352,6 +353,7 @@ export function createToolHost(config: ToolHostConfig, deps?: CreateToolHostDeps
       ...(typeof deps.attachmentPreviewChars === 'number'
         ? { attachmentPreviewChars: deps.attachmentPreviewChars }
         : {}),
+      ...(deps.codexThreadsConfig ? { codexThreadsConfig: deps.codexThreadsConfig } : {}),
     });
   }
 

--- a/packages/agent-server/src/tools/codexThreads.test.ts
+++ b/packages/agent-server/src/tools/codexThreads.test.ts
@@ -1,0 +1,554 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ToolError } from './errors';
+import type { CodexThreadsToolConfig, ToolContext } from './types';
+import {
+  CODEX_THREADS_BOUNDS,
+  CODEX_THREADS_TOOL_NAMES,
+  createCodexThreadsToolDefinitions,
+  type CodexThreadsRunner,
+} from './codexThreads';
+
+const tempDirs: string[] = [];
+
+function makeConfig(overrides: Partial<CodexThreadsToolConfig> = {}): CodexThreadsToolConfig {
+  return {
+    allowedServers: ['main'],
+    binary: 'codex-threads',
+    permissionMode: 'app-server-default',
+    allowedCwdRoots: [],
+    ...overrides,
+  };
+}
+
+function makeContext(): ToolContext {
+  return {
+    sessionId: 'session-1',
+    signal: new AbortController().signal,
+  };
+}
+
+function success(output: unknown) {
+  return {
+    exitCode: 0,
+    stdout: JSON.stringify(output),
+    stderr: '',
+    timedOut: false,
+    aborted: false,
+    outputTooLarge: false,
+  };
+}
+
+function queuedRunner(outputs: unknown[]) {
+  const queue = [...outputs];
+  const runner = vi.fn<CodexThreadsRunner>(async () => success(queue.shift()));
+  return runner;
+}
+
+function definitions(config: CodexThreadsToolConfig | undefined, runner: CodexThreadsRunner) {
+  return new Map(
+    createCodexThreadsToolDefinitions(config, runner).map((tool) => [tool.name, tool]),
+  );
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map(async (dir) => {
+      await fs.rm(dir, { recursive: true, force: true });
+    }),
+  );
+});
+
+describe('Codex Threads tool definitions', () => {
+  it('uses expanded bounded transcript and process output ceilings', () => {
+    expect(CODEX_THREADS_BOUNDS).toMatchObject({
+      maxMessageChars: 64_000,
+      maxTranscriptChars: 256_000,
+      maxFinalResponseChars: 64_000,
+      maxStdoutBytes: 4_000_000,
+    });
+  });
+
+  it('registers a stable bounded read/write tool family', () => {
+    const tools = createCodexThreadsToolDefinitions(undefined, queuedRunner([]));
+    expect(tools.map((tool) => tool.name)).toEqual(Object.values(CODEX_THREADS_TOOL_NAMES));
+    expect(tools.filter((tool) => tool.capabilities?.includes('codex_threads.read'))).toHaveLength(
+      4,
+    );
+    expect(tools.filter((tool) => tool.capabilities?.includes('codex_threads.write'))).toHaveLength(
+      4,
+    );
+  });
+
+  it('requires a host-allowed server on every tool schema', () => {
+    const tools = createCodexThreadsToolDefinitions(makeConfig(), queuedRunner([]));
+    for (const tool of tools) {
+      const schema = tool.parameters as {
+        properties?: Record<string, { enum?: string[] }>;
+        required?: string[];
+      };
+      expect(schema.required).toContain('server');
+      expect(schema.properties?.['server']?.enum).toEqual(['main']);
+    }
+  });
+
+  it('keeps tools registered but returns a clear error when unconfigured', async () => {
+    const tool = definitions(undefined, queuedRunner([])).get(CODEX_THREADS_TOOL_NAMES.list)!;
+    await expect(tool.handler({}, makeContext())).rejects.toMatchObject({
+      code: 'not_configured',
+    });
+  });
+});
+
+describe('Codex Threads read tools', () => {
+  it('lists recent updated-desc threads and projects status plus cwd', async () => {
+    const runner = queuedRunner([
+      {
+        threads: [
+          {
+            id: 'thread-1',
+            name: 'Tool design',
+            cwd: '/home/kevin/worktrees/assistant',
+            preview: 'Build a bounded integration',
+            status: { type: 'active', activeFlags: ['waiting'] },
+            updatedAt: 1_784_670_402,
+            path: '/secret/rollout.jsonl',
+            gitInfo: { originUrl: 'private' },
+          },
+        ],
+        nextCursor: 'more',
+      },
+    ]);
+    const tool = definitions(makeConfig(), runner).get(CODEX_THREADS_TOOL_NAMES.list)!;
+    const result = (await tool.handler(
+      { server: 'main', updatedWithinHours: 48, limit: 1 },
+      makeContext(),
+    )) as Record<string, unknown>;
+
+    const invocation = runner.mock.calls[0]![0];
+    expect(invocation.args).toEqual([
+      '--no-yolo',
+      'list',
+      '--limit',
+      '1',
+      '--since',
+      '48h',
+      '--sort',
+      'updated',
+      '--desc',
+      '--server',
+      'main',
+      '--json',
+    ]);
+    expect(result).toMatchObject({
+      server: 'main',
+      updatedWithinHours: 48,
+      truncated: true,
+      threads: [
+        {
+          threadId: 'thread-1',
+          cwd: '/home/kevin/worktrees/assistant',
+          project: 'assistant',
+          status: 'active',
+          activeFlags: ['waiting'],
+        },
+      ],
+    });
+    expect(JSON.stringify(result)).not.toContain('rollout');
+    expect(JSON.stringify(result)).not.toContain('originUrl');
+  });
+
+  it('finds bounded recent metadata without invoking CLI full-text search', async () => {
+    const runner = queuedRunner([
+      {
+        threads: [
+          {
+            id: 'a',
+            cwd: '/work/assistant',
+            name: 'Codex thread tools',
+            preview: 'Implement recent metadata lookup',
+            status: { type: 'idle' },
+            updatedAt: 200,
+          },
+          {
+            id: 'b',
+            cwd: '/work/other',
+            preview: 'Unrelated task',
+            status: { type: 'idle' },
+            updatedAt: 100,
+          },
+        ],
+        nextCursor: null,
+      },
+    ]);
+    const tool = definitions(makeConfig(), runner).get(CODEX_THREADS_TOOL_NAMES.find)!;
+    const result = await tool.handler({ server: 'main', query: 'codex tools' }, makeContext());
+
+    expect(runner.mock.calls[0]![0].args).toContain('list');
+    expect(runner.mock.calls[0]![0].args).not.toContain('search');
+    expect(result).toMatchObject({
+      server: 'main',
+      matches: [{ threadId: 'a', matchedFields: expect.arrayContaining(['name']) }],
+      truncated: false,
+    });
+  });
+
+  it('loads focused status and reports the active turn', async () => {
+    const runner = queuedRunner([
+      {
+        thread: {
+          id: 'thread-1',
+          cwd: '/work/a',
+          status: { type: 'active' },
+          updatedAt: 100,
+        },
+        activeTurnId: 'turn-1',
+        truncated: false,
+      },
+    ]);
+    const tool = definitions(makeConfig(), runner).get(CODEX_THREADS_TOOL_NAMES.status)!;
+    const result = await tool.handler({ server: 'main', threadId: 'thread-1' }, makeContext());
+    expect(runner.mock.calls[0]![0].args).toEqual([
+      '--no-yolo',
+      'status',
+      'thread-1',
+      '--load',
+      '--server',
+      'main',
+      '--json',
+    ]);
+    expect(result).toMatchObject({ server: 'main', active: true, activeTurnId: 'turn-1' });
+  });
+
+  it('bounds transcript scan, final messages, and returned text', async () => {
+    const longText = 'x'.repeat(CODEX_THREADS_BOUNDS.maxMessageChars + 500);
+    const runner = queuedRunner([
+      {
+        messages: Array.from({ length: 12 }, (_, index) => ({
+          role: index % 2 === 0 ? 'user' : 'assistant',
+          text: longText,
+          turnId: `turn-${index}`,
+          turnStartedAt: 100 + index,
+        })),
+        truncated: true,
+      },
+    ]);
+    const tool = definitions(makeConfig(), runner).get(CODEX_THREADS_TOOL_NAMES.messages)!;
+    const result = (await tool.handler(
+      { server: 'main', threadId: 'thread-1', last: 12, role: 'assistant' },
+      makeContext(),
+    )) as { messages: Array<{ text: string }>; textTruncated: boolean };
+    const args = runner.mock.calls[0]![0].args;
+    expect(args).toContain('--last');
+    expect(args[args.indexOf('--last') + 1]).toBe('12');
+    expect(args).toContain('--max-turns');
+    expect(args[args.indexOf('--max-turns') + 1]).toBe('50');
+    expect(args).toContain('--role');
+    expect(result.textTruncated).toBe(true);
+    expect(
+      result.messages.reduce((sum, message) => sum + message.text.length, 0),
+    ).toBeLessThanOrEqual(CODEX_THREADS_BOUNDS.maxTranscriptChars);
+    expect(
+      result.messages.every(
+        (message) => message.text.length <= CODEX_THREADS_BOUNDS.maxMessageChars,
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects missing or disallowed server selection before invoking the CLI', async () => {
+    const runner = queuedRunner([]);
+    const tool = definitions(makeConfig(), runner).get(CODEX_THREADS_TOOL_NAMES.status)!;
+
+    await expect(tool.handler({ threadId: 'thread-1' }, makeContext())).rejects.toMatchObject({
+      code: 'invalid_arguments',
+    });
+    await expect(
+      tool.handler({ server: 'work', threadId: 'thread-1' }, makeContext()),
+    ).rejects.toMatchObject({ code: 'server_not_allowed' });
+    expect(runner).not.toHaveBeenCalled();
+  });
+});
+
+describe('Codex Threads write tools', () => {
+  it('queues a send without prechecking or rejecting an active thread', async () => {
+    const runner = queuedRunner([
+      { threadId: 'thread-1', turnId: 'turn-queued', status: 'accepted' },
+    ]);
+    const tool = definitions(makeConfig(), runner).get(CODEX_THREADS_TOOL_NAMES.send)!;
+    const result = await tool.handler(
+      { server: 'main', threadId: 'thread-1', message: 'Queue this' },
+      makeContext(),
+    );
+
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(runner.mock.calls[0]![0].args).toContain('--no-wait');
+    expect(result).toMatchObject({ status: 'accepted', turnId: 'turn-queued' });
+  });
+
+  it('sends without waiting by default', async () => {
+    const runner = queuedRunner([{ threadId: 'thread-1', turnId: 'turn-new', status: 'accepted' }]);
+    const tool = definitions(makeConfig(), runner).get(CODEX_THREADS_TOOL_NAMES.send)!;
+    const result = await tool.handler(
+      { server: 'main', threadId: 'thread-1', message: 'Follow up' },
+      makeContext(),
+    );
+    expect(runner.mock.calls[0]![0].args).toEqual([
+      '--no-yolo',
+      'send',
+      'thread-1',
+      'Follow up',
+      '--no-wait',
+      '--server',
+      'main',
+      '--json',
+    ]);
+    expect(result).toEqual({
+      server: 'main',
+      status: 'accepted',
+      threadId: 'thread-1',
+      turnId: 'turn-new',
+    });
+  });
+
+  it('rejects a send response that does not confirm an accepted turn', async () => {
+    const runner = queuedRunner([{ threadId: 'thread-1', status: 'accepted' }]);
+    const tool = definitions(makeConfig(), runner).get(CODEX_THREADS_TOOL_NAMES.send)!;
+
+    await expect(
+      tool.handler({ server: 'main', threadId: 'thread-1', message: 'Follow up' }, makeContext()),
+    ).rejects.toMatchObject({ code: 'execution_failed' });
+  });
+
+  it('waits up to 120 seconds and projects bounded terminal assistant text', async () => {
+    const longText = 'x'.repeat(CODEX_THREADS_BOUNDS.maxFinalResponseChars + 100);
+    const runner = vi.fn<CodexThreadsRunner>(async () => ({
+      exitCode: 0,
+      stdout: [
+        JSON.stringify({
+          type: 'accepted',
+          server: 'main',
+          threadId: 'thread-1',
+          turnId: 'turn-wait',
+          status: 'accepted',
+        }),
+        JSON.stringify({
+          server: 'main',
+          threadId: 'thread-1',
+          turnId: 'turn-wait',
+          status: 'completed',
+          finalAssistantText: longText,
+        }),
+      ].join('\n'),
+      stderr: '',
+      timedOut: false,
+      aborted: false,
+      outputTooLarge: false,
+    }));
+    const tool = definitions(makeConfig(), runner).get(CODEX_THREADS_TOOL_NAMES.send)!;
+    const result = (await tool.handler(
+      { server: 'main', threadId: 'thread-1', message: 'Wait for this', wait: true },
+      makeContext(),
+    )) as { finalAssistantText: string; textTruncated: boolean };
+
+    expect(runner.mock.calls[0]![0]).toMatchObject({ timeoutMs: 120_000 });
+    expect(runner.mock.calls[0]![0].args).toContain('--stream');
+    expect(runner.mock.calls[0]![0].args).not.toContain('--no-wait');
+    expect(result.finalAssistantText.length).toBe(CODEX_THREADS_BOUNDS.maxFinalResponseChars);
+    expect(result.textTruncated).toBe(true);
+  });
+
+  it('returns pending identifiers when the 120-second local wait expires', async () => {
+    const runner = vi.fn<CodexThreadsRunner>(async () => ({
+      exitCode: null,
+      stdout: `${JSON.stringify({
+        type: 'accepted',
+        threadId: 'thread-1',
+        turnId: 'turn-pending',
+        status: 'accepted',
+      })}\n`,
+      stderr: '',
+      timedOut: true,
+      aborted: false,
+      outputTooLarge: false,
+    }));
+    const tool = definitions(makeConfig(), runner).get(CODEX_THREADS_TOOL_NAMES.send)!;
+
+    await expect(
+      tool.handler(
+        { server: 'main', threadId: 'thread-1', message: 'Long task', wait: true },
+        makeContext(),
+      ),
+    ).resolves.toMatchObject({
+      server: 'main',
+      status: 'pending',
+      threadId: 'thread-1',
+      turnId: 'turn-pending',
+      waitTimedOut: true,
+    });
+  });
+
+  it('keeps accepted identifiers when the bounded stream ends on a partial line', async () => {
+    const runner = vi.fn<CodexThreadsRunner>(async () => ({
+      exitCode: null,
+      stdout: `${JSON.stringify({
+        type: 'accepted',
+        threadId: 'thread-1',
+        turnId: 'turn-limited',
+        status: 'accepted',
+      })}\n{"type":"progress"`,
+      stderr: '',
+      timedOut: false,
+      aborted: false,
+      outputTooLarge: true,
+    }));
+    const tool = definitions(makeConfig(), runner).get(CODEX_THREADS_TOOL_NAMES.send)!;
+
+    await expect(
+      tool.handler(
+        { server: 'main', threadId: 'thread-1', message: 'Verbose task', wait: true },
+        makeContext(),
+      ),
+    ).resolves.toMatchObject({
+      status: 'pending',
+      turnId: 'turn-limited',
+      outputLimitReached: true,
+    });
+  });
+
+  it('steers the exact active turn', async () => {
+    const runner = queuedRunner([
+      { threadId: 'thread-1', turnId: 'turn-active', status: 'accepted' },
+    ]);
+    const tool = definitions(makeConfig(), runner).get(CODEX_THREADS_TOOL_NAMES.steer)!;
+    const result = await tool.handler(
+      {
+        server: 'main',
+        threadId: 'thread-1',
+        turnId: 'turn-active',
+        message: 'Focus on the tests',
+      },
+      makeContext(),
+    );
+
+    expect(runner.mock.calls[0]![0].args).toEqual([
+      '--no-yolo',
+      'steer',
+      'thread-1',
+      'turn-active',
+      'Focus on the tests',
+      '--server',
+      'main',
+      '--json',
+    ]);
+    expect(result).toEqual({
+      server: 'main',
+      status: 'accepted',
+      threadId: 'thread-1',
+      turnId: 'turn-active',
+    });
+  });
+
+  it('creates, names, and starts a thread inside an allowed root', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-threads-root-'));
+    tempDirs.push(root);
+    const cwd = path.join(root, 'project');
+    await fs.mkdir(cwd);
+    const runner = queuedRunner([
+      { threadId: 'thread-new' },
+      { threadId: 'thread-new', name: 'Readable', status: 'accepted' },
+      { threadId: 'thread-new', turnId: 'turn-new', status: 'accepted' },
+    ]);
+    const tool = definitions(makeConfig({ allowedCwdRoots: [root] }), runner).get(
+      CODEX_THREADS_TOOL_NAMES.create,
+    )!;
+    const result = await tool.handler(
+      { server: 'main', cwd, prompt: 'Implement the task', name: 'Readable' },
+      makeContext(),
+    );
+
+    expect(runner.mock.calls.map((call) => call[0].args[1])).toEqual(['new', 'name', 'send']);
+    expect(runner.mock.calls[2]![0].args).toContain('--no-wait');
+    expect(result).toEqual({
+      server: 'main',
+      status: 'accepted',
+      threadId: 'thread-new',
+      turnId: 'turn-new',
+      nameRequested: true,
+      nameSet: true,
+      promptAccepted: true,
+    });
+  });
+
+  it('returns the created id when naming partially fails', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-threads-partial-'));
+    tempDirs.push(root);
+    const runner = vi.fn<CodexThreadsRunner>(async (options) => {
+      if (options.args.includes('name')) {
+        return {
+          ...success({}),
+          exitCode: 3,
+          stderr: 'name failed',
+        };
+      }
+      if (options.args.includes('new')) {
+        return success({ threadId: 'thread-partial' });
+      }
+      return success({ threadId: 'thread-partial', turnId: 'turn-1', status: 'accepted' });
+    });
+    const tool = definitions(makeConfig({ allowedCwdRoots: [root] }), runner).get(
+      CODEX_THREADS_TOOL_NAMES.create,
+    )!;
+    const result = await tool.handler(
+      { server: 'main', cwd: root, prompt: 'Start anyway', name: 'Name' },
+      makeContext(),
+    );
+
+    expect(result).toMatchObject({
+      server: 'main',
+      status: 'partial',
+      threadId: 'thread-partial',
+      nameSet: false,
+      promptAccepted: true,
+      errors: [{ step: 'name', code: 'execution_failed' }],
+    });
+  });
+
+  it('rejects create outside configured roots and rejects empty rename', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-threads-allowed-'));
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-threads-outside-'));
+    tempDirs.push(root, outside);
+    const runner = queuedRunner([]);
+    const tools = definitions(makeConfig({ allowedCwdRoots: [root] }), runner);
+
+    await expect(
+      tools
+        .get(CODEX_THREADS_TOOL_NAMES.create)!
+        .handler({ server: 'main', cwd: outside, prompt: 'No' }, makeContext()),
+    ).rejects.toMatchObject({ code: 'cwd_not_allowed' });
+    await expect(
+      tools
+        .get(CODEX_THREADS_TOOL_NAMES.rename)!
+        .handler({ server: 'main', threadId: 'thread-1', name: '  ' }, makeContext()),
+    ).rejects.toBeInstanceOf(ToolError);
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('uses CLI full-access behavior only when host configuration opts in', async () => {
+    const runner = queuedRunner([
+      {
+        thread: { id: 'thread-1', status: { type: 'idle' }, updatedAt: 100 },
+        activeTurnId: null,
+        truncated: false,
+      },
+    ]);
+    const tool = definitions(makeConfig({ permissionMode: 'full-access' }), runner).get(
+      CODEX_THREADS_TOOL_NAMES.status,
+    )!;
+    await tool.handler({ server: 'main', threadId: 'thread-1' }, makeContext());
+    expect(runner.mock.calls[0]![0].args).not.toContain('--no-yolo');
+  });
+});

--- a/packages/agent-server/src/tools/codexThreads.test.ts
+++ b/packages/agent-server/src/tools/codexThreads.test.ts
@@ -259,6 +259,63 @@ describe('Codex Threads read tools', () => {
     ).toBe(true);
   });
 
+  it('filters an exact turn before applying the final message limit', async () => {
+    const runner = queuedRunner([
+      {
+        messages: [
+          {
+            role: 'assistant',
+            text: 'Unrelated newer response',
+            turnId: 'turn-other',
+            turnCompletedAt: 400,
+          },
+          {
+            role: 'assistant',
+            text: 'Target response part one',
+            turnId: 'turn-target',
+            turnCompletedAt: 300,
+          },
+          {
+            role: 'assistant',
+            text: 'Target response part two',
+            turnId: 'turn-target',
+            turnCompletedAt: 301,
+          },
+        ],
+        truncated: false,
+      },
+    ]);
+    const tool = definitions(makeConfig(), runner).get(CODEX_THREADS_TOOL_NAMES.messages)!;
+    const result = await tool.handler(
+      {
+        server: 'main',
+        threadId: 'thread-1',
+        turnId: 'turn-target',
+        last: 1,
+        role: 'assistant',
+      },
+      makeContext(),
+    );
+
+    const args = runner.mock.calls[0]![0].args;
+    expect(args).not.toContain('--last');
+    expect(args).toContain('--max-turns');
+    expect(result).toMatchObject({
+      server: 'main',
+      threadId: 'thread-1',
+      turnId: 'turn-target',
+      turnFound: true,
+      historyTruncated: true,
+      messages: [
+        {
+          role: 'assistant',
+          text: 'Target response part two',
+          turnId: 'turn-target',
+        },
+      ],
+    });
+  });
+
   it('rejects missing or disallowed server selection before invoking the CLI', async () => {
     const runner = queuedRunner([]);
     const tool = definitions(makeConfig(), runner).get(CODEX_THREADS_TOOL_NAMES.status)!;

--- a/packages/agent-server/src/tools/codexThreads.ts
+++ b/packages/agent-server/src/tools/codexThreads.ts
@@ -685,16 +685,19 @@ function parseMessagesArgs(
   server: string;
   threadId: string;
   last: number;
+  turnId?: string;
   role?: 'user' | 'assistant';
 } {
-  const args = asObject(raw, ['server', 'threadId', 'last', 'role']);
+  const args = asObject(raw, ['server', 'threadId', 'turnId', 'last', 'role']);
   const roleRaw = args['role'];
   if (roleRaw !== undefined && roleRaw !== 'user' && roleRaw !== 'assistant') {
     throw new ToolError('invalid_arguments', 'role must be user or assistant');
   }
+  const turnId = optionalString(args['turnId'], 'turnId', CODEX_THREADS_BOUNDS.maxThreadIdChars);
   return {
     server: requireServer(args['server'], config),
     threadId: requireThreadId(args['threadId']),
+    ...(turnId ? { turnId } : {}),
     last: boundedInteger(
       args['last'],
       'last',
@@ -1030,12 +1033,18 @@ export function createCodexThreadsToolDefinitions(
     {
       name: CODEX_THREADS_TOOL_NAMES.messages,
       description:
-        'Read a compact recent user/assistant transcript from one Codex thread. Defaults to 6 messages and never returns more than 12.',
+        'Read a compact recent user/assistant transcript from one Codex thread, optionally restricted to an exact turn id returned by a send. Defaults to 6 messages and never returns more than 12.',
       capabilities: readCapability,
       parameters: objectSchema(
         {
           server: serverProperty,
           threadId: threadIdProperty,
+          turnId: {
+            type: 'string',
+            maxLength: CODEX_THREADS_BOUNDS.maxThreadIdChars,
+            description:
+              'Optional exact turn id. Filtering occurs inside the bounded recent turn scan before the final message limit.',
+          },
           last: {
             type: 'integer',
             minimum: 1,
@@ -1060,8 +1069,7 @@ export function createCodexThreadsToolDefinitions(
           [
             'messages',
             input.threadId,
-            '--last',
-            String(input.last),
+            ...(input.turnId ? [] : ['--last', String(input.last)]),
             '--max-turns',
             String(CODEX_THREADS_BOUNDS.messageTurnScan),
             ...(input.role ? ['--role', input.role] : []),
@@ -1070,12 +1078,29 @@ export function createCodexThreadsToolDefinitions(
           READ_TIMEOUT_MS,
         );
         const rawMessages = Array.isArray(output['messages']) ? output['messages'] : [];
-        const projected = projectMessages(rawMessages);
+        const matchingMessages = input.turnId
+          ? rawMessages.filter(
+              (message) =>
+                message !== null &&
+                typeof message === 'object' &&
+                !Array.isArray(message) &&
+                (message as Record<string, unknown>)['turnId'] === input.turnId,
+            )
+          : rawMessages;
+        const selectedMessages = matchingMessages.slice(-input.last);
+        const projected = projectMessages(selectedMessages);
         return {
           server: input.server,
           threadId: input.threadId,
+          ...(input.turnId
+            ? {
+                turnId: input.turnId,
+                turnFound: projected.messages.length > 0,
+              }
+            : {}),
           ...projected,
-          historyTruncated: output['truncated'] === true,
+          historyTruncated:
+            output['truncated'] === true || matchingMessages.length > selectedMessages.length,
           scannedTurns: CODEX_THREADS_BOUNDS.messageTurnScan,
         };
       },

--- a/packages/agent-server/src/tools/codexThreads.ts
+++ b/packages/agent-server/src/tools/codexThreads.ts
@@ -1,0 +1,1283 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { ToolError } from './errors';
+import type { BuiltInToolDefinition, CodexThreadsToolConfig, ToolContext } from './types';
+
+export const CODEX_THREADS_TOOL_NAMES = {
+  list: 'codex_threads_list',
+  find: 'codex_threads_find',
+  status: 'codex_threads_status',
+  messages: 'codex_threads_messages',
+  send: 'codex_threads_send',
+  steer: 'codex_threads_steer',
+  create: 'codex_threads_create',
+  rename: 'codex_threads_rename',
+} as const;
+
+export const CODEX_THREADS_BOUNDS = {
+  defaultLookbackHours: 24,
+  maxLookbackHours: 720,
+  defaultListLimit: 10,
+  maxListLimit: 25,
+  findCandidateLimit: 100,
+  defaultFindLimit: 5,
+  maxFindLimit: 10,
+  maxFindQueryChars: 200,
+  defaultMessageLimit: 6,
+  maxMessageLimit: 12,
+  messageTurnScan: 50,
+  maxMessageChars: 64_000,
+  maxTranscriptChars: 256_000,
+  maxPromptChars: 8_000,
+  maxFinalResponseChars: 64_000,
+  maxStdoutBytes: 4_000_000,
+  maxNameChars: 100,
+  maxServerNameChars: 100,
+  maxThreadIdChars: 128,
+  maxPreviewChars: 400,
+} as const;
+
+const READ_TIMEOUT_MS = 25_000;
+const MUTATION_TIMEOUT_MS = 25_000;
+const TURN_WAIT_TIMEOUT_MS = 120_000;
+const MAX_STDERR_BYTES = 64_000;
+
+type RunnerResult = {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  aborted: boolean;
+  outputTooLarge: boolean;
+};
+
+export type CodexThreadsRunner = (options: {
+  binary: string;
+  args: string[];
+  timeoutMs: number;
+  signal?: AbortSignal;
+}) => Promise<RunnerResult>;
+
+type ThreadSummary = {
+  threadId: string;
+  name: string | null;
+  cwd: string | null;
+  project: string | null;
+  preview: string | null;
+  status: string;
+  activeFlags: string[];
+  updatedAt: string | null;
+};
+
+const activeMutationKeys = new Set<string>();
+
+function asObject(raw: unknown, allowedKeys: readonly string[]): Record<string, unknown> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new ToolError('invalid_arguments', 'Arguments must be an object');
+  }
+  const value = raw as Record<string, unknown>;
+  const allowed = new Set(allowedKeys);
+  const unknown = Object.keys(value).filter((key) => !allowed.has(key));
+  if (unknown.length > 0) {
+    throw new ToolError('invalid_arguments', `Unknown argument: ${unknown[0]}`);
+  }
+  return value;
+}
+
+function requireString(
+  raw: unknown,
+  field: string,
+  maxChars: number,
+  options: { trim?: boolean } = {},
+): string {
+  if (typeof raw !== 'string') {
+    throw new ToolError('invalid_arguments', `${field} is required and must be a string`);
+  }
+  const value = options.trim === false ? raw : raw.trim();
+  if (!value.trim()) {
+    throw new ToolError('invalid_arguments', `${field} must not be empty`);
+  }
+  if (value.length > maxChars) {
+    throw new ToolError('invalid_arguments', `${field} must be at most ${maxChars} characters`);
+  }
+  return value;
+}
+
+function optionalString(raw: unknown, field: string, maxChars: number): string | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+  return requireString(raw, field, maxChars);
+}
+
+function boundedInteger(
+  raw: unknown,
+  field: string,
+  defaultValue: number,
+  min: number,
+  max: number,
+): number {
+  if (raw === undefined) {
+    return defaultValue;
+  }
+  if (typeof raw !== 'number' || !Number.isInteger(raw) || raw < min || raw > max) {
+    throw new ToolError('invalid_arguments', `${field} must be an integer from ${min} to ${max}`);
+  }
+  return raw;
+}
+
+function requireThreadId(raw: unknown): string {
+  return requireString(raw, 'threadId', CODEX_THREADS_BOUNDS.maxThreadIdChars);
+}
+
+function requireServer(raw: unknown, config: CodexThreadsToolConfig): string {
+  const server = requireString(raw, 'server', CODEX_THREADS_BOUNDS.maxServerNameChars);
+  if (!config.allowedServers.includes(server)) {
+    throw new ToolError('server_not_allowed', `Codex Threads server is not allowed: ${server}`);
+  }
+  return server;
+}
+
+function requireConfig(config: CodexThreadsToolConfig | undefined): CodexThreadsToolConfig {
+  if (!config) {
+    throw new ToolError(
+      'not_configured',
+      'Codex Threads is not configured on the Assistant server',
+    );
+  }
+  return config;
+}
+
+function truncateText(value: string, maxChars: number): { text: string; truncated: boolean } {
+  if (value.length <= maxChars) {
+    return { text: value, truncated: false };
+  }
+  if (maxChars <= 1) {
+    return { text: value.slice(0, maxChars), truncated: true };
+  }
+  return { text: `${value.slice(0, maxChars - 1)}…`, truncated: true };
+}
+
+function compactText(raw: unknown, maxChars: number): string | null {
+  if (typeof raw !== 'string') {
+    return null;
+  }
+  const normalized = raw.replace(/\s+/g, ' ').trim();
+  return normalized ? truncateText(normalized, maxChars).text : null;
+}
+
+function timestampToIso(raw: unknown): string | null {
+  let millis: number;
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    millis = raw < 1_000_000_000_000 ? raw * 1_000 : raw;
+  } else if (typeof raw === 'string' && raw.trim()) {
+    millis = Date.parse(raw);
+  } else {
+    return null;
+  }
+  if (!Number.isFinite(millis)) {
+    return null;
+  }
+  try {
+    return new Date(millis).toISOString();
+  } catch {
+    return null;
+  }
+}
+
+function projectThread(raw: unknown): ThreadSummary | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return null;
+  }
+  const value = raw as Record<string, unknown>;
+  const threadId = typeof value['id'] === 'string' ? value['id'].trim() : '';
+  if (!threadId) {
+    return null;
+  }
+  const cwdRaw = typeof value['cwd'] === 'string' ? value['cwd'].trim() : '';
+  const cwd = cwdRaw ? truncateText(cwdRaw, 1_024).text : null;
+  const statusValue = value['status'];
+  const statusRecord =
+    statusValue && typeof statusValue === 'object' && !Array.isArray(statusValue)
+      ? (statusValue as Record<string, unknown>)
+      : undefined;
+  const status =
+    typeof statusRecord?.['type'] === 'string'
+      ? statusRecord['type']
+      : typeof statusValue === 'string'
+        ? statusValue
+        : 'unknown';
+  const activeFlags = Array.isArray(statusRecord?.['activeFlags'])
+    ? statusRecord['activeFlags']
+        .filter((item): item is string => typeof item === 'string')
+        .slice(0, 10)
+    : [];
+  const rawName = typeof value['name'] === 'string' ? value['name'].trim() : '';
+  return {
+    threadId: truncateText(threadId, CODEX_THREADS_BOUNDS.maxThreadIdChars).text,
+    name: rawName ? truncateText(rawName, CODEX_THREADS_BOUNDS.maxNameChars).text : null,
+    cwd,
+    project: cwd ? path.basename(cwd) || cwd : null,
+    preview: compactText(value['preview'], CODEX_THREADS_BOUNDS.maxPreviewChars),
+    status,
+    activeFlags,
+    updatedAt: timestampToIso(value['updatedAt']),
+  };
+}
+
+function buildInvocationArgs(
+  config: CodexThreadsToolConfig,
+  server: string,
+  commandArgs: string[],
+): string[] {
+  return [
+    ...(config.permissionMode === 'app-server-default' ? ['--no-yolo'] : []),
+    ...commandArgs,
+    '--server',
+    server,
+    '--json',
+  ];
+}
+
+async function defaultRunner(options: {
+  binary: string;
+  args: string[];
+  timeoutMs: number;
+  signal?: AbortSignal;
+}): Promise<RunnerResult> {
+  if (options.signal?.aborted) {
+    throw new ToolError('cancelled', 'Codex Threads operation was cancelled');
+  }
+  return await new Promise<RunnerResult>((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let aborted = false;
+    let outputTooLarge = false;
+    let settled = false;
+    let terminating = false;
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+
+    const child = spawn(options.binary, options.args, {
+      shell: false,
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const terminate = () => {
+      if (terminating) {
+        return;
+      }
+      terminating = true;
+      child.kill('SIGTERM');
+      setTimeout(() => {
+        if (!settled) {
+          child.kill('SIGKILL');
+        }
+      }, 2_000).unref?.();
+    };
+    const timer = setTimeout(() => {
+      timedOut = true;
+      terminate();
+    }, options.timeoutMs);
+    const onAbort = () => {
+      aborted = true;
+      terminate();
+    };
+    options.signal?.addEventListener('abort', onAbort, { once: true });
+
+    const appendBounded = (
+      current: string,
+      currentBytes: number,
+      chunk: string,
+      maxBytes: number,
+    ): { text: string; bytes: number } => {
+      const chunkBytes = Buffer.byteLength(chunk);
+      if (currentBytes + chunkBytes <= maxBytes) {
+        return { text: current + chunk, bytes: currentBytes + chunkBytes };
+      }
+      outputTooLarge = true;
+      terminate();
+      const remainingBytes = Math.max(0, maxBytes - currentBytes);
+      return {
+        text: current + Buffer.from(chunk).subarray(0, remainingBytes).toString('utf8'),
+        bytes: maxBytes,
+      };
+    };
+
+    child.stdout?.setEncoding('utf8');
+    child.stderr?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => {
+      const appended = appendBounded(
+        stdout,
+        stdoutBytes,
+        chunk,
+        CODEX_THREADS_BOUNDS.maxStdoutBytes,
+      );
+      stdout = appended.text;
+      stdoutBytes = appended.bytes;
+    });
+    child.stderr?.on('data', (chunk: string) => {
+      const appended = appendBounded(stderr, stderrBytes, chunk, MAX_STDERR_BYTES);
+      stderr = appended.text;
+      stderrBytes = appended.bytes;
+    });
+    child.on('error', (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      options.signal?.removeEventListener('abort', onAbort);
+      reject(
+        new ToolError(
+          'execution_failed',
+          `Failed to start Codex Threads (${options.binary}): ${error.message}`,
+        ),
+      );
+    });
+    child.on('close', (exitCode) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      options.signal?.removeEventListener('abort', onAbort);
+      resolve({ exitCode, stdout, stderr, timedOut, aborted, outputTooLarge });
+    });
+  });
+}
+
+function errorDetail(stderr: string): string {
+  return stderr.replace(/\s+/g, ' ').trim().slice(0, 300);
+}
+
+async function runJson(
+  config: CodexThreadsToolConfig,
+  runner: CodexThreadsRunner,
+  server: string,
+  commandArgs: string[],
+  ctx: ToolContext,
+  timeoutMs: number,
+): Promise<Record<string, unknown>> {
+  const result = await runner({
+    binary: config.binary,
+    args: buildInvocationArgs(config, server, commandArgs),
+    timeoutMs,
+    ...(ctx.signal ? { signal: ctx.signal } : {}),
+  });
+  if (result.aborted || ctx.signal?.aborted) {
+    throw new ToolError('cancelled', 'Codex Threads operation was cancelled');
+  }
+  if (result.timedOut) {
+    throw new ToolError('timeout', 'Codex Threads did not respond in time');
+  }
+  if (result.outputTooLarge) {
+    throw new ToolError('output_too_large', 'Codex Threads returned too much data');
+  }
+  if (result.exitCode !== 0) {
+    const detail = errorDetail(result.stderr);
+    throw new ToolError(
+      'execution_failed',
+      detail ? `Codex Threads failed: ${detail}` : 'Codex Threads operation failed',
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(result.stdout.trim());
+  } catch {
+    throw new ToolError('execution_failed', 'Codex Threads returned invalid JSON');
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new ToolError('execution_failed', 'Codex Threads returned an invalid result');
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function parseJsonLines(
+  stdout: string,
+  options: { allowTrailingPartial?: boolean } = {},
+): Record<string, unknown>[] {
+  const lines = stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const events: Record<string, unknown>[] = [];
+  for (const [index, line] of lines.entries()) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      if (options.allowTrailingPartial && index === lines.length - 1) {
+        break;
+      }
+      throw new ToolError('execution_failed', 'Codex Threads returned invalid stream JSON');
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new ToolError('execution_failed', 'Codex Threads returned an invalid stream event');
+    }
+    events.push(parsed as Record<string, unknown>);
+  }
+  return events;
+}
+
+function projectWaitedTurn(output: Record<string, unknown>, server: string) {
+  const threadId = requireThreadId(output['threadId']);
+  const accepted = acceptedTurn(output, threadId);
+  const rawText =
+    typeof output['finalAssistantText'] === 'string' ? output['finalAssistantText'] : '';
+  const clipped = truncateText(rawText.trim(), CODEX_THREADS_BOUNDS.maxFinalResponseChars);
+  return {
+    server,
+    status: typeof output['status'] === 'string' ? output['status'] : 'unknown',
+    threadId: accepted.threadId,
+    turnId: accepted.turnId,
+    finalAssistantText: clipped.text || null,
+    textTruncated: clipped.truncated,
+  };
+}
+
+async function runTurnAndWait(
+  config: CodexThreadsToolConfig,
+  runner: CodexThreadsRunner,
+  input: { server: string; threadId: string; message: string },
+  ctx: ToolContext,
+) {
+  const result = await runner({
+    binary: config.binary,
+    args: buildInvocationArgs(config, input.server, [
+      'send',
+      input.threadId,
+      input.message,
+      '--stream',
+    ]),
+    timeoutMs: TURN_WAIT_TIMEOUT_MS,
+    ...(ctx.signal ? { signal: ctx.signal } : {}),
+  });
+  if (result.aborted || ctx.signal?.aborted) {
+    throw new ToolError('cancelled', 'Codex Threads operation was cancelled');
+  }
+  const events = parseJsonLines(result.stdout, { allowTrailingPartial: result.outputTooLarge });
+  const acceptance = events.find(
+    (event) => event['status'] === 'accepted' || event['type'] === 'accepted',
+  );
+  const terminal = [...events]
+    .reverse()
+    .find((event) => ['completed', 'failed', 'interrupted'].includes(String(event['status'])));
+  if (terminal) {
+    return projectWaitedTurn(terminal, input.server);
+  }
+  if (acceptance && (result.timedOut || result.outputTooLarge)) {
+    const accepted = acceptedTurn(acceptance, input.threadId);
+    return {
+      server: input.server,
+      status: 'pending',
+      threadId: accepted.threadId,
+      turnId: accepted.turnId,
+      waitTimedOut: result.timedOut,
+      outputLimitReached: result.outputTooLarge,
+    };
+  }
+  if (result.timedOut) {
+    throw new ToolError('timeout', 'Codex Threads did not accept the turn before wait timeout');
+  }
+  if (result.outputTooLarge) {
+    throw new ToolError('output_too_large', 'Codex Threads returned too much turn data');
+  }
+  if (result.exitCode !== 0) {
+    const detail = errorDetail(result.stderr);
+    throw new ToolError(
+      'execution_failed',
+      detail ? `Codex Threads failed: ${detail}` : 'Codex Threads turn failed',
+    );
+  }
+  throw new ToolError('execution_failed', 'Codex Threads returned no terminal turn result');
+}
+
+function parseListArgs(
+  raw: unknown,
+  config: CodexThreadsToolConfig,
+): {
+  server: string;
+  updatedWithinHours: number;
+  limit: number;
+  cwd?: string;
+} {
+  const args = asObject(raw, ['server', 'updatedWithinHours', 'limit', 'cwd']);
+  const updatedWithinHours = boundedInteger(
+    args['updatedWithinHours'],
+    'updatedWithinHours',
+    CODEX_THREADS_BOUNDS.defaultLookbackHours,
+    1,
+    CODEX_THREADS_BOUNDS.maxLookbackHours,
+  );
+  const limit = boundedInteger(
+    args['limit'],
+    'limit',
+    CODEX_THREADS_BOUNDS.defaultListLimit,
+    1,
+    CODEX_THREADS_BOUNDS.maxListLimit,
+  );
+  const cwd = optionalString(args['cwd'], 'cwd', 2_048);
+  if (cwd && !path.isAbsolute(cwd)) {
+    throw new ToolError('invalid_arguments', 'cwd must be an absolute path');
+  }
+  return {
+    server: requireServer(args['server'], config),
+    updatedWithinHours,
+    limit,
+    ...(cwd ? { cwd } : {}),
+  };
+}
+
+async function listRecent(
+  config: CodexThreadsToolConfig,
+  runner: CodexThreadsRunner,
+  input: { server: string; updatedWithinHours: number; limit: number; cwd?: string },
+  ctx: ToolContext,
+): Promise<{ threads: ThreadSummary[]; truncated: boolean }> {
+  const output = await runJson(
+    config,
+    runner,
+    input.server,
+    [
+      'list',
+      '--limit',
+      String(input.limit),
+      '--since',
+      `${input.updatedWithinHours}h`,
+      '--sort',
+      'updated',
+      '--desc',
+      ...(input.cwd ? ['--cwd', input.cwd] : []),
+    ],
+    ctx,
+    READ_TIMEOUT_MS,
+  );
+  const rawThreads = Array.isArray(output['threads']) ? output['threads'] : [];
+  const threads = rawThreads.map(projectThread).filter((item): item is ThreadSummary => !!item);
+  return {
+    threads,
+    truncated:
+      typeof output['nextCursor'] === 'string' &&
+      output['nextCursor'].length > 0 &&
+      threads.length >= input.limit,
+  };
+}
+
+function parseFindArgs(
+  raw: unknown,
+  config: CodexThreadsToolConfig,
+): {
+  server: string;
+  query: string;
+  updatedWithinHours: number;
+  limit: number;
+} {
+  const args = asObject(raw, ['server', 'query', 'updatedWithinHours', 'limit']);
+  return {
+    server: requireServer(args['server'], config),
+    query: requireString(args['query'], 'query', CODEX_THREADS_BOUNDS.maxFindQueryChars),
+    updatedWithinHours: boundedInteger(
+      args['updatedWithinHours'],
+      'updatedWithinHours',
+      CODEX_THREADS_BOUNDS.defaultLookbackHours,
+      1,
+      CODEX_THREADS_BOUNDS.maxLookbackHours,
+    ),
+    limit: boundedInteger(
+      args['limit'],
+      'limit',
+      CODEX_THREADS_BOUNDS.defaultFindLimit,
+      1,
+      CODEX_THREADS_BOUNDS.maxFindLimit,
+    ),
+  };
+}
+
+function matchThread(
+  thread: ThreadSummary,
+  query: string,
+): { score: number; matchedFields: string[] } | null {
+  const normalized = query.toLowerCase();
+  const tokens = normalized.split(/\s+/).filter(Boolean);
+  const fields = [
+    ['name', thread.name ?? ''],
+    ['preview', thread.preview ?? ''],
+    ['cwd', thread.cwd ?? ''],
+  ] as const;
+  const haystack = fields.map(([, value]) => value.toLowerCase()).join('\n');
+  if (!tokens.every((token) => haystack.includes(token))) {
+    return null;
+  }
+  const matchedFields = fields
+    .filter(([, value]) => tokens.some((token) => value.toLowerCase().includes(token)))
+    .map(([field]) => field);
+  let score = matchedFields.length;
+  if ((thread.name ?? '').toLowerCase().includes(normalized)) {
+    score += 6;
+  }
+  if ((thread.preview ?? '').toLowerCase().includes(normalized)) {
+    score += 3;
+  }
+  if ((thread.cwd ?? '').toLowerCase().includes(normalized)) {
+    score += 2;
+  }
+  return { score, matchedFields };
+}
+
+function parseStatusArgs(
+  raw: unknown,
+  config: CodexThreadsToolConfig,
+): { server: string; threadId: string } {
+  const args = asObject(raw, ['server', 'threadId']);
+  return {
+    server: requireServer(args['server'], config),
+    threadId: requireThreadId(args['threadId']),
+  };
+}
+
+async function loadStatus(
+  config: CodexThreadsToolConfig,
+  runner: CodexThreadsRunner,
+  server: string,
+  threadId: string,
+  ctx: ToolContext,
+): Promise<{
+  server: string;
+  thread: ThreadSummary;
+  active: boolean;
+  activeTurnId: string | null;
+  historyScanTruncated: boolean;
+}> {
+  const output = await runJson(
+    config,
+    runner,
+    server,
+    ['status', threadId, '--load'],
+    ctx,
+    READ_TIMEOUT_MS,
+  );
+  const thread = projectThread(output['thread']);
+  if (!thread) {
+    throw new ToolError('execution_failed', 'Codex Threads status returned no thread');
+  }
+  const activeTurnId =
+    typeof output['activeTurnId'] === 'string' && output['activeTurnId'].trim()
+      ? output['activeTurnId'].trim()
+      : null;
+  return {
+    server,
+    thread,
+    active: activeTurnId !== null,
+    activeTurnId,
+    historyScanTruncated: output['truncated'] === true,
+  };
+}
+
+function parseMessagesArgs(
+  raw: unknown,
+  config: CodexThreadsToolConfig,
+): {
+  server: string;
+  threadId: string;
+  last: number;
+  role?: 'user' | 'assistant';
+} {
+  const args = asObject(raw, ['server', 'threadId', 'last', 'role']);
+  const roleRaw = args['role'];
+  if (roleRaw !== undefined && roleRaw !== 'user' && roleRaw !== 'assistant') {
+    throw new ToolError('invalid_arguments', 'role must be user or assistant');
+  }
+  return {
+    server: requireServer(args['server'], config),
+    threadId: requireThreadId(args['threadId']),
+    last: boundedInteger(
+      args['last'],
+      'last',
+      CODEX_THREADS_BOUNDS.defaultMessageLimit,
+      1,
+      CODEX_THREADS_BOUNDS.maxMessageLimit,
+    ),
+    ...(roleRaw ? { role: roleRaw } : {}),
+  };
+}
+
+function projectMessages(rawMessages: unknown[]): {
+  messages: Array<{
+    role: 'user' | 'assistant';
+    text: string;
+    turnId: string | null;
+    timestamp: string | null;
+  }>;
+  textTruncated: boolean;
+} {
+  const messages: Array<{
+    role: 'user' | 'assistant';
+    text: string;
+    turnId: string | null;
+    timestamp: string | null;
+  }> = [];
+  let remaining = CODEX_THREADS_BOUNDS.maxTranscriptChars;
+  let textTruncated = false;
+  for (let index = rawMessages.length - 1; index >= 0 && remaining > 0; index -= 1) {
+    const raw = rawMessages[index];
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      continue;
+    }
+    const value = raw as Record<string, unknown>;
+    const role = value['role'];
+    const text = typeof value['text'] === 'string' ? value['text'].trim() : '';
+    if ((role !== 'user' && role !== 'assistant') || !text) {
+      continue;
+    }
+    const budget = Math.min(CODEX_THREADS_BOUNDS.maxMessageChars, remaining);
+    const clipped = truncateText(text, budget);
+    textTruncated ||= clipped.truncated;
+    messages.unshift({
+      role,
+      text: clipped.text,
+      turnId: typeof value['turnId'] === 'string' ? value['turnId'] : null,
+      timestamp: timestampToIso(value['turnStartedAt'] ?? value['turnCompletedAt']),
+    });
+    remaining -= clipped.text.length;
+  }
+  if (messages.length < rawMessages.length) {
+    textTruncated = true;
+  }
+  return { messages, textTruncated };
+}
+
+function parseSendArgs(
+  raw: unknown,
+  config: CodexThreadsToolConfig,
+): { server: string; threadId: string; message: string; wait: boolean } {
+  const args = asObject(raw, ['server', 'threadId', 'message', 'wait']);
+  if (args['wait'] !== undefined && typeof args['wait'] !== 'boolean') {
+    throw new ToolError('invalid_arguments', 'wait must be a boolean');
+  }
+  return {
+    server: requireServer(args['server'], config),
+    threadId: requireThreadId(args['threadId']),
+    message: requireString(args['message'], 'message', CODEX_THREADS_BOUNDS.maxPromptChars, {
+      trim: false,
+    }),
+    wait: args['wait'] === true,
+  };
+}
+
+function parseSteerArgs(
+  raw: unknown,
+  config: CodexThreadsToolConfig,
+): { server: string; threadId: string; turnId: string; message: string } {
+  const args = asObject(raw, ['server', 'threadId', 'turnId', 'message']);
+  return {
+    server: requireServer(args['server'], config),
+    threadId: requireThreadId(args['threadId']),
+    turnId: requireString(args['turnId'], 'turnId', CODEX_THREADS_BOUNDS.maxThreadIdChars),
+    message: requireString(args['message'], 'message', CODEX_THREADS_BOUNDS.maxPromptChars, {
+      trim: false,
+    }),
+  };
+}
+
+async function withMutationLock<T>(key: string, task: () => Promise<T>): Promise<T> {
+  if (activeMutationKeys.has(key)) {
+    throw new ToolError('thread_busy', 'Another Codex Threads mutation is already in progress');
+  }
+  activeMutationKeys.add(key);
+  try {
+    return await task();
+  } finally {
+    activeMutationKeys.delete(key);
+  }
+}
+
+function acceptedTurn(output: Record<string, unknown>, fallbackThreadId: string) {
+  const turnId =
+    typeof output['turnId'] === 'string' && output['turnId'].trim()
+      ? output['turnId'].trim()
+      : null;
+  if (!turnId) {
+    throw new ToolError('execution_failed', 'Codex Threads did not return an accepted turn id');
+  }
+  return {
+    status: typeof output['status'] === 'string' ? output['status'] : 'accepted',
+    threadId:
+      typeof output['threadId'] === 'string' && output['threadId'].trim()
+        ? output['threadId'].trim()
+        : fallbackThreadId,
+    turnId,
+  };
+}
+
+function parseCreateArgs(
+  raw: unknown,
+  config: CodexThreadsToolConfig,
+): { server: string; cwd: string; prompt: string; name?: string } {
+  const args = asObject(raw, ['server', 'cwd', 'prompt', 'name']);
+  const cwd = requireString(args['cwd'], 'cwd', 2_048);
+  if (!path.isAbsolute(cwd)) {
+    throw new ToolError('invalid_arguments', 'cwd must be an absolute path');
+  }
+  const name = optionalString(args['name'], 'name', CODEX_THREADS_BOUNDS.maxNameChars);
+  return {
+    server: requireServer(args['server'], config),
+    cwd,
+    prompt: requireString(args['prompt'], 'prompt', CODEX_THREADS_BOUNDS.maxPromptChars, {
+      trim: false,
+    }),
+    ...(name ? { name } : {}),
+  };
+}
+
+async function resolveAllowedCwd(config: CodexThreadsToolConfig, cwd: string): Promise<string> {
+  if (config.allowedCwdRoots.length === 0) {
+    throw new ToolError(
+      'not_configured',
+      'Codex Threads create requires at least one allowedCwdRoots entry',
+    );
+  }
+  let resolvedCwd: string;
+  try {
+    resolvedCwd = await fs.realpath(cwd);
+    const stat = await fs.stat(resolvedCwd);
+    if (!stat.isDirectory()) {
+      throw new ToolError('invalid_arguments', 'cwd must be a directory');
+    }
+  } catch (error) {
+    if (error instanceof ToolError) {
+      throw error;
+    }
+    throw new ToolError('invalid_arguments', 'cwd does not exist or is not readable');
+  }
+  for (const root of config.allowedCwdRoots) {
+    let resolvedRoot: string;
+    try {
+      resolvedRoot = await fs.realpath(root);
+    } catch {
+      throw new ToolError(
+        'not_configured',
+        `Configured Codex Threads cwd root is unavailable: ${root}`,
+      );
+    }
+    const relative = path.relative(resolvedRoot, resolvedCwd);
+    if (relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))) {
+      return resolvedCwd;
+    }
+  }
+  throw new ToolError('cwd_not_allowed', 'cwd is outside the configured Codex Threads roots');
+}
+
+function parseRenameArgs(
+  raw: unknown,
+  config: CodexThreadsToolConfig,
+): { server: string; threadId: string; name: string } {
+  const args = asObject(raw, ['server', 'threadId', 'name']);
+  return {
+    server: requireServer(args['server'], config),
+    threadId: requireThreadId(args['threadId']),
+    name: requireString(args['name'], 'name', CODEX_THREADS_BOUNDS.maxNameChars),
+  };
+}
+
+function errorShape(error: unknown): { code: string; message: string } {
+  if (error instanceof ToolError) {
+    return { code: error.code, message: error.message };
+  }
+  return {
+    code: 'execution_failed',
+    message: error instanceof Error ? error.message : 'Codex Threads operation failed',
+  };
+}
+
+const objectSchema = (properties: Record<string, unknown>, required: string[] = []) => ({
+  type: 'object',
+  properties,
+  ...(required.length > 0 ? { required } : {}),
+  additionalProperties: false,
+});
+
+export function createCodexThreadsToolDefinitions(
+  configured: CodexThreadsToolConfig | undefined,
+  runner: CodexThreadsRunner = defaultRunner,
+): BuiltInToolDefinition[] {
+  const readCapability = ['codex_threads.read'];
+  const writeCapability = ['codex_threads.write'];
+  const lookbackProperty = {
+    type: 'integer',
+    minimum: 1,
+    maximum: CODEX_THREADS_BOUNDS.maxLookbackHours,
+    description: 'Updated-within window in hours. Defaults to 24; maximum 720 (30 days).',
+  };
+  const threadIdProperty = {
+    type: 'string',
+    maxLength: CODEX_THREADS_BOUNDS.maxThreadIdChars,
+    description: 'Opaque Codex thread id returned by another Codex Threads tool.',
+  };
+  const serverProperty = {
+    type: 'string',
+    maxLength: CODEX_THREADS_BOUNDS.maxServerNameChars,
+    ...(configured ? { enum: configured.allowedServers } : {}),
+    description: 'Codex Threads server alias configured by the host.',
+  };
+
+  return [
+    {
+      name: CODEX_THREADS_TOOL_NAMES.list,
+      description:
+        'List recently updated Codex threads with id, name, project folder, preview, status, and update time. Defaults to the last 24 hours and 10 results.',
+      capabilities: readCapability,
+      parameters: objectSchema(
+        {
+          server: serverProperty,
+          updatedWithinHours: lookbackProperty,
+          limit: {
+            type: 'integer',
+            minimum: 1,
+            maximum: CODEX_THREADS_BOUNDS.maxListLimit,
+            description: 'Maximum threads to return. Defaults to 10; maximum 25.',
+          },
+          cwd: { type: 'string', description: 'Optional exact absolute project folder filter.' },
+        },
+        ['server'],
+      ),
+      handler: async (raw, ctx) => {
+        const config = requireConfig(configured);
+        const input = parseListArgs(raw, config);
+        const result = await listRecent(config, runner, input, ctx);
+        return { server: input.server, updatedWithinHours: input.updatedWithinHours, ...result };
+      },
+    },
+    {
+      name: CODEX_THREADS_TOOL_NAMES.find,
+      description:
+        'Find recent Codex threads by matching a short query against bounded name, preview, and project-folder metadata. This is not full transcript search.',
+      capabilities: readCapability,
+      parameters: objectSchema(
+        {
+          server: serverProperty,
+          query: {
+            type: 'string',
+            maxLength: CODEX_THREADS_BOUNDS.maxFindQueryChars,
+            description: 'Words expected in the recent thread name, preview, or project folder.',
+          },
+          updatedWithinHours: lookbackProperty,
+          limit: {
+            type: 'integer',
+            minimum: 1,
+            maximum: CODEX_THREADS_BOUNDS.maxFindLimit,
+            description: 'Maximum matches to return. Defaults to 5; maximum 10.',
+          },
+        },
+        ['server', 'query'],
+      ),
+      handler: async (raw, ctx) => {
+        const config = requireConfig(configured);
+        const input = parseFindArgs(raw, config);
+        const candidates = await listRecent(
+          config,
+          runner,
+          {
+            server: input.server,
+            updatedWithinHours: input.updatedWithinHours,
+            limit: CODEX_THREADS_BOUNDS.findCandidateLimit,
+          },
+          ctx,
+        );
+        const matches = candidates.threads
+          .map((thread) => {
+            const match = matchThread(thread, input.query);
+            return match ? { thread, ...match } : null;
+          })
+          .filter((item): item is NonNullable<typeof item> => !!item)
+          .sort((left, right) => {
+            if (right.score !== left.score) {
+              return right.score - left.score;
+            }
+            return (right.thread.updatedAt ?? '').localeCompare(left.thread.updatedAt ?? '');
+          });
+        return {
+          server: input.server,
+          query: input.query,
+          updatedWithinHours: input.updatedWithinHours,
+          matches: matches.slice(0, input.limit).map(({ thread, matchedFields }) => ({
+            ...thread,
+            matchedFields,
+          })),
+          truncated: candidates.truncated || matches.length > input.limit,
+        };
+      },
+    },
+    {
+      name: CODEX_THREADS_TOOL_NAMES.status,
+      description:
+        'Load and inspect one Codex thread, returning its project, status, and active turn if any.',
+      capabilities: readCapability,
+      parameters: objectSchema({ server: serverProperty, threadId: threadIdProperty }, [
+        'server',
+        'threadId',
+      ]),
+      handler: async (raw, ctx) => {
+        const config = requireConfig(configured);
+        const { server, threadId } = parseStatusArgs(raw, config);
+        return await loadStatus(config, runner, server, threadId, ctx);
+      },
+    },
+    {
+      name: CODEX_THREADS_TOOL_NAMES.messages,
+      description:
+        'Read a compact recent user/assistant transcript from one Codex thread. Defaults to 6 messages and never returns more than 12.',
+      capabilities: readCapability,
+      parameters: objectSchema(
+        {
+          server: serverProperty,
+          threadId: threadIdProperty,
+          last: {
+            type: 'integer',
+            minimum: 1,
+            maximum: CODEX_THREADS_BOUNDS.maxMessageLimit,
+            description: 'Final number of recent messages. Defaults to 6; maximum 12.',
+          },
+          role: {
+            type: 'string',
+            enum: ['user', 'assistant'],
+            description: 'Optional role filter applied inside the bounded recent turn scan.',
+          },
+        },
+        ['server', 'threadId'],
+      ),
+      handler: async (raw, ctx) => {
+        const config = requireConfig(configured);
+        const input = parseMessagesArgs(raw, config);
+        const output = await runJson(
+          config,
+          runner,
+          input.server,
+          [
+            'messages',
+            input.threadId,
+            '--last',
+            String(input.last),
+            '--max-turns',
+            String(CODEX_THREADS_BOUNDS.messageTurnScan),
+            ...(input.role ? ['--role', input.role] : []),
+          ],
+          ctx,
+          READ_TIMEOUT_MS,
+        );
+        const rawMessages = Array.isArray(output['messages']) ? output['messages'] : [];
+        const projected = projectMessages(rawMessages);
+        return {
+          server: input.server,
+          threadId: input.threadId,
+          ...projected,
+          historyTruncated: output['truncated'] === true,
+          scannedTurns: CODEX_THREADS_BOUNDS.messageTurnScan,
+        };
+      },
+    },
+    {
+      name: CODEX_THREADS_TOOL_NAMES.send,
+      description:
+        'Send a new Codex turn, queueing behind an active turn when needed. By default returns immediately; set wait true to wait up to 120 seconds for bounded final text.',
+      capabilities: writeCapability,
+      parameters: objectSchema(
+        {
+          server: serverProperty,
+          threadId: threadIdProperty,
+          message: {
+            type: 'string',
+            maxLength: CODEX_THREADS_BOUNDS.maxPromptChars,
+            description: 'Follow-up message to start as a new turn.',
+          },
+          wait: {
+            type: 'boolean',
+            description:
+              'Wait up to 120 seconds for terminal status and final assistant text. Defaults to false.',
+          },
+        },
+        ['server', 'threadId', 'message'],
+      ),
+      handler: async (raw, ctx) => {
+        const config = requireConfig(configured);
+        const input = parseSendArgs(raw, config);
+        return await withMutationLock(`${input.server}:thread:${input.threadId}`, async () => {
+          if (input.wait) {
+            return await runTurnAndWait(config, runner, input, ctx);
+          }
+          const output = await runJson(
+            config,
+            runner,
+            input.server,
+            ['send', input.threadId, input.message, '--no-wait'],
+            ctx,
+            MUTATION_TIMEOUT_MS,
+          );
+          return { server: input.server, ...acceptedTurn(output, input.threadId) };
+        });
+      },
+    },
+    {
+      name: CODEX_THREADS_TOOL_NAMES.steer,
+      description:
+        'Add guidance to the currently active Codex turn. Requires the exact active turn id from codex_threads_status and fails if that turn is no longer active.',
+      capabilities: writeCapability,
+      parameters: objectSchema(
+        {
+          server: serverProperty,
+          threadId: threadIdProperty,
+          turnId: {
+            type: 'string',
+            maxLength: CODEX_THREADS_BOUNDS.maxThreadIdChars,
+            description: 'Exact active turn id returned by codex_threads_status.',
+          },
+          message: {
+            type: 'string',
+            maxLength: CODEX_THREADS_BOUNDS.maxPromptChars,
+            description: 'Additional guidance for the active turn.',
+          },
+        },
+        ['server', 'threadId', 'turnId', 'message'],
+      ),
+      handler: async (raw, ctx) => {
+        const config = requireConfig(configured);
+        const input = parseSteerArgs(raw, config);
+        return await withMutationLock(`${input.server}:thread:${input.threadId}`, async () => {
+          const output = await runJson(
+            config,
+            runner,
+            input.server,
+            ['steer', input.threadId, input.turnId, input.message],
+            ctx,
+            MUTATION_TIMEOUT_MS,
+          );
+          return { server: input.server, ...acceptedTurn(output, input.threadId) };
+        });
+      },
+    },
+    {
+      name: CODEX_THREADS_TOOL_NAMES.create,
+      description:
+        'Create a Codex thread in an allowed absolute project folder, optionally set its name, and start its initial prompt without waiting for completion.',
+      capabilities: writeCapability,
+      parameters: objectSchema(
+        {
+          server: serverProperty,
+          cwd: { type: 'string', description: 'Absolute project folder allowed by server config.' },
+          prompt: {
+            type: 'string',
+            maxLength: CODEX_THREADS_BOUNDS.maxPromptChars,
+            description: 'Initial task for the new Codex thread.',
+          },
+          name: {
+            type: 'string',
+            maxLength: CODEX_THREADS_BOUNDS.maxNameChars,
+            description: 'Optional readable thread name.',
+          },
+        },
+        ['server', 'cwd', 'prompt'],
+      ),
+      handler: async (raw, ctx) => {
+        const config = requireConfig(configured);
+        const input = parseCreateArgs(raw, config);
+        const cwd = await resolveAllowedCwd(config, input.cwd);
+        return await withMutationLock(`${input.server}:create:${cwd}`, async () => {
+          const created = await runJson(
+            config,
+            runner,
+            input.server,
+            ['new', '--cwd', cwd],
+            ctx,
+            MUTATION_TIMEOUT_MS,
+          );
+          const threadId = requireThreadId(created['threadId']);
+          const errors: Array<{ step: 'name' | 'prompt'; code: string; message: string }> = [];
+          let nameSet = false;
+          if (input.name) {
+            try {
+              await runJson(
+                config,
+                runner,
+                input.server,
+                ['name', threadId, input.name],
+                ctx,
+                MUTATION_TIMEOUT_MS,
+              );
+              nameSet = true;
+            } catch (error) {
+              errors.push({ step: 'name', ...errorShape(error) });
+            }
+          }
+          let promptAccepted = false;
+          let turnId: string | null = null;
+          try {
+            const sent = await runJson(
+              config,
+              runner,
+              input.server,
+              ['send', threadId, input.prompt, '--no-wait'],
+              ctx,
+              MUTATION_TIMEOUT_MS,
+            );
+            const accepted = acceptedTurn(sent, threadId);
+            promptAccepted = true;
+            turnId = accepted.turnId;
+          } catch (error) {
+            errors.push({ step: 'prompt', ...errorShape(error) });
+          }
+          return {
+            server: input.server,
+            status: errors.length > 0 ? 'partial' : 'accepted',
+            threadId,
+            turnId,
+            nameRequested: !!input.name,
+            nameSet,
+            promptAccepted,
+            ...(errors.length > 0 ? { errors } : {}),
+          };
+        });
+      },
+    },
+    {
+      name: CODEX_THREADS_TOOL_NAMES.rename,
+      description: 'Set a non-empty readable name on one Codex thread.',
+      capabilities: writeCapability,
+      parameters: objectSchema(
+        {
+          server: serverProperty,
+          threadId: threadIdProperty,
+          name: {
+            type: 'string',
+            maxLength: CODEX_THREADS_BOUNDS.maxNameChars,
+            description: 'New non-empty thread name. Clearing names is not supported.',
+          },
+        },
+        ['server', 'threadId', 'name'],
+      ),
+      handler: async (raw, ctx) => {
+        const config = requireConfig(configured);
+        const input = parseRenameArgs(raw, config);
+        return await withMutationLock(`${input.server}:thread:${input.threadId}`, async () => {
+          const output = await runJson(
+            config,
+            runner,
+            input.server,
+            ['name', input.threadId, input.name],
+            ctx,
+            MUTATION_TIMEOUT_MS,
+          );
+          return {
+            server: input.server,
+            status: typeof output['status'] === 'string' ? output['status'] : 'accepted',
+            threadId: input.threadId,
+            name: input.name,
+          };
+        });
+      },
+    },
+  ];
+}

--- a/packages/agent-server/src/tools/codingToolHost.test.ts
+++ b/packages/agent-server/src/tools/codingToolHost.test.ts
@@ -245,6 +245,41 @@ describe('CodingToolHost', () => {
     expect(outsideContent).toBe('outside file');
   });
 
+  it('uses the fallback workspace for realtime voice tool contexts', async () => {
+    const dataDir = createTempDir('coding-tool-host-realtime');
+    const fallbackWorkspace = path.join(dataDir, 'coding-workspaces');
+    const host = new CodingToolHost({
+      dataDir,
+      pluginConfig: {
+        enabled: true,
+        mode: 'local',
+        local: {
+          workspaceRoot: '${session.workingDir}',
+        },
+      },
+      loadCodingAgentModule,
+    });
+
+    const ctx: ToolContext = {
+      sessionId: 'voice:conversation-id',
+      signal: new AbortController().signal,
+      sessionHub: {
+        getSessionState: () => undefined,
+        ensureSessionState: async () => {
+          throw new Error('Session not found: voice:conversation-id');
+        },
+      } as never,
+    };
+
+    await host.callTool('write', JSON.stringify({ path: 'voice.txt', content: 'voice file' }), ctx);
+    const result = await host.callTool('read', JSON.stringify({ path: 'voice.txt' }), ctx);
+
+    expect(await fs.readFile(path.join(fallbackWorkspace, 'voice.txt'), 'utf8')).toBe('voice file');
+    expect((result as { content: Array<{ text?: string }> }).content[0]?.text).toContain(
+      'voice file',
+    );
+  });
+
   it('rejects unknown tool names through callTool', async () => {
     const dataDir = createTempDir('coding-tool-host-unknown');
     const host = new CodingToolHost({

--- a/packages/agent-server/src/tools/sessionWorkingDir.ts
+++ b/packages/agent-server/src/tools/sessionWorkingDir.ts
@@ -1,6 +1,13 @@
 import type { ToolContext } from './types';
+import { isRealtimeToolSessionId } from '../voice/constants';
 
 export async function resolveSessionWorkingDir(ctx: ToolContext): Promise<string | undefined> {
+  // Realtime voice tool contexts use a synthetic conversation-scoped ID, not a
+  // persisted chat session. Let callers use their configured non-session fallback.
+  if (isRealtimeToolSessionId(ctx.sessionId)) {
+    return undefined;
+  }
+
   const stateWorkingDir = ctx.sessionHub?.getSessionState(ctx.sessionId)?.summary.attributes?.core?.workingDir;
   if (typeof stateWorkingDir === 'string' && stateWorkingDir.trim().length > 0) {
     return stateWorkingDir.trim();

--- a/packages/agent-server/src/tools/types.ts
+++ b/packages/agent-server/src/tools/types.ts
@@ -224,8 +224,16 @@ export interface ToolHostConfig {
   toolsEnabled: boolean;
 }
 
+export interface CodexThreadsToolConfig {
+  allowedServers: string[];
+  binary: string;
+  permissionMode: 'app-server-default' | 'full-access';
+  allowedCwdRoots: string[];
+}
+
 export interface CreateToolHostDeps {
   sessionHub?: SessionHub;
   sessionIndex?: SessionIndex;
   attachmentPreviewChars?: number;
+  codexThreadsConfig?: CodexThreadsToolConfig;
 }

--- a/packages/agent-server/src/voice/listsTools.test.ts
+++ b/packages/agent-server/src/voice/listsTools.test.ts
@@ -10,6 +10,7 @@ import {
   filterToolsForVoiceRealtime,
   isToolAllowedForVoiceRealtime,
   toRealtimeFunctionTools,
+  withListsInstanceIdDefault,
 } from './listsTools';
 
 const sampleTools: Tool[] = [
@@ -83,6 +84,27 @@ describe('isToolAllowedForVoiceRealtime', () => {
   });
 });
 
+describe('withListsInstanceIdDefault', () => {
+  it('adds the conversation instance only to Lists plugin tools', () => {
+    expect(withListsInstanceIdDefault('lists_list', {}, 'work')).toEqual({ instance_id: 'work' });
+    expect(withListsInstanceIdDefault('codex_threads_list', {}, 'work')).toEqual({});
+    expect(withListsInstanceIdDefault('web_search', { query: 'hello' }, 'work')).toEqual({
+      query: 'hello',
+    });
+  });
+
+  it('preserves an explicit Lists instance', () => {
+    expect(withListsInstanceIdDefault('lists_list', { instance_id: 'personal' }, 'work')).toEqual({
+      instance_id: 'personal',
+    });
+  });
+
+  it('normalizes non-object tool arguments', () => {
+    expect(withListsInstanceIdDefault('codex_threads_list', null, 'work')).toEqual({});
+    expect(withListsInstanceIdDefault('lists_list', [], 'work')).toEqual({ instance_id: 'work' });
+  });
+});
+
 describe('buildRealtimeToolsFromHost', () => {
   it('returns no tools when the allowlist is omitted', async () => {
     const tools = await buildRealtimeToolsFromHost({
@@ -106,6 +128,21 @@ describe('buildRealtimeToolsFromHost', () => {
     ]);
     expect(tools[2]).toEqual(buildRealtimeInteractionEndTool());
     expect(tools[2]?.description).toContain('A spoken acknowledgment does not end the call');
+  });
+
+  it('exposes an exact Codex Threads tool to Realtime when allowlisted', async () => {
+    const codexTool: Tool = {
+      name: 'codex_threads_list',
+      description: 'List recent Codex threads',
+      parameters: { type: 'object', additionalProperties: false },
+    };
+    const tools = await buildRealtimeToolsFromHost({
+      listTools: async () => [...sampleTools, codexTool],
+      toolAllowlist: ['codex_threads_list'],
+      toolDenylist: undefined,
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual(['codex_threads_list']);
   });
 });
 

--- a/packages/agent-server/src/voice/listsTools.ts
+++ b/packages/agent-server/src/voice/listsTools.ts
@@ -66,6 +66,23 @@ export function isToolAllowedForVoiceRealtime(
   return true;
 }
 
+/** Apply the voice conversation's Lists profile only to Lists plugin tools. */
+export function withListsInstanceIdDefault(
+  name: string,
+  args: unknown,
+  listsInstanceId: string,
+): Record<string, unknown> {
+  const normalizedArgs =
+    args && typeof args === 'object' && !Array.isArray(args)
+      ? (args as Record<string, unknown>)
+      : {};
+  const instanceId = listsInstanceId.trim();
+  if (!name.startsWith('lists_') || !instanceId || normalizedArgs['instance_id']) {
+    return normalizedArgs;
+  }
+  return { ...normalizedArgs, instance_id: instanceId };
+}
+
 function normalizeParameters(parameters: unknown): Record<string, unknown> {
   if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
     return parameters as Record<string, unknown>;
@@ -121,6 +138,5 @@ export function buildRealtimeInstructions(
     contextBlock.trim().length > 0
       ? `Recent conversation context:\n${contextBlock.trim()}`
       : 'No prior conversation context.';
-
   return `${base}\n${context}`;
 }

--- a/packages/agent-server/src/voice/service.ts
+++ b/packages/agent-server/src/voice/service.ts
@@ -6,6 +6,7 @@ import {
   buildRealtimeInstructions,
   buildRealtimeToolsFromHost,
   isToolAllowedForVoiceRealtime,
+  withListsInstanceIdDefault,
 } from './listsTools';
 import { isInteractionEndTool } from '../interactionEndTool';
 import {
@@ -448,15 +449,13 @@ export class VoiceService {
       return;
     }
 
-    let args: Record<string, unknown> = {};
+    let parsedArgs: unknown = {};
     try {
-      args = JSON.parse(argsJson) as Record<string, unknown>;
+      parsedArgs = JSON.parse(argsJson) as unknown;
     } catch {
-      args = {};
+      parsedArgs = {};
     }
-    if (!args['instance_id'] && live.listsInstanceId) {
-      args['instance_id'] = live.listsInstanceId;
-    }
+    const args = withListsInstanceIdDefault(name, parsedArgs, live.listsInstanceId);
 
     await this.store.appendJournal(live.conversationId, {
       kind: 'tool_request',


### PR DESCRIPTION
## Summary

- add a bounded, allowlisted Codex Threads tool integration around the local CLI
- support read/write capability scoping, server restrictions, working-directory restrictions, and realtime voice exposure
- support exact turn-specific transcript retrieval for asynchronous relay workflows
- document the configuration and add focused unit/integration coverage

## Tests

- `npx prettier --check packages/agent-server/src/tools/codexThreads.ts packages/agent-server/src/tools/codexThreads.test.ts docs/CONFIG.md`
- `npx vitest --run packages/agent-server/src/tools/codexThreads.test.ts packages/agent-server/src/config.test.ts packages/agent-server/src/toolScopingIntegration.test.ts` (71 passed)
