### PR TITLE
Add Move to list from global search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Added
 
-- Added Move to list on global search list-item results so items can be reassigned from the command palette without opening them first.
+- Added Move to list on global search list-item results so items can be reassigned from the command palette without opening them first. ([#130](https://github.com/kcosr/assistant/pull/130))
 - Added a Herdr-inspired dark theme with coordinated prominent-action styling and a persistent preference for showing or hiding selected panel outlines. ([#129](https://github.com/kcosr/assistant/pull/129))
 - Added configurable native Pi SDK tool approvals that block selected exact-name or glob-matched tools until an interactive client approves or denies them, with fail-closed handling and composer-level approval controls. ([#128](https://github.com/kcosr/assistant/pull/128))
 - Added one-shot scheduled reminders with scheduled-session visibility, durable delivery, notification playback, and retry handling. ([#127](https://github.com/kcosr/assistant/pull/127))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Added Move to list on global search list-item results so items can be reassigned from the command palette without opening them first.
 - Added a Herdr-inspired dark theme with coordinated prominent-action styling and a persistent preference for showing or hiding selected panel outlines. ([#129](https://github.com/kcosr/assistant/pull/129))
 - Added configurable native Pi SDK tool approvals that block selected exact-name or glob-matched tools until an interactive client approves or denies them, with fail-closed handling and composer-level approval controls. ([#128](https://github.com/kcosr/assistant/pull/128))
 - Added one-shot scheduled reminders with scheduled-session visibility, durable delivery, notification playback, and retry handling. ([#127](https://github.com/kcosr/assistant/pull/127))

--- a/docs/design/global-search-command-palette.md
+++ b/docs/design/global-search-command-palette.md
@@ -268,6 +268,7 @@ Default launch behavior:
 │   │   Open workspace    │                   │
 │   │   Pin to header     │                   │
 │   │   Replace           │                   │
+│   │   Move to list      │ ← list items only │
 │   └─────────────────────┘                   │
 └─────────────────────────────────────────────┘
 ```
@@ -296,6 +297,7 @@ Default launch behavior:
 | **Open workspace** | Add new panel docked to right of workspace | No |
 | **Pin to header** | Open result as a pinned panel in the header dock | No |
 | **Replace** | Replace selected panel with new panel showing result | Yes |
+| **Move to list** | List-item results only: close the palette, open the searchable list picker, and move the item via the lists API without opening the item | No |
 
 ---
 

--- a/packages/web-client/src/controllers/commandPaletteController.test.ts
+++ b/packages/web-client/src/controllers/commandPaletteController.test.ts
@@ -7,18 +7,27 @@ import {
 } from './commandPaletteController';
 
 describe('CommandPaletteController', () => {
+  let activeController: CommandPaletteController | null = null;
+
   beforeEach(() => {
     document.body.innerHTML = '';
     vi.useFakeTimers();
     window.localStorage.clear();
+    activeController = null;
   });
 
   afterEach(() => {
+    activeController?.detach();
+    activeController = null;
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  const buildController = () => {
+  const buildController = (options?: {
+    getSelectedPanelId?: () => string | null;
+    onLaunch?: CommandPaletteControllerOptions['onLaunch'];
+  }) => {
+    activeController?.detach();
     const overlay = document.createElement('div');
     const palette = document.createElement('div');
     const input = document.createElement('input');
@@ -39,6 +48,7 @@ describe('CommandPaletteController', () => {
       results: [],
     }));
     const resolveIcon = vi.fn(() => '<svg></svg>');
+    const onLaunch = options?.onLaunch ?? vi.fn();
 
     const controller = new CommandPaletteController({
       overlay,
@@ -51,18 +61,20 @@ describe('CommandPaletteController', () => {
       triggerButton,
       fetchScopes,
       fetchResults,
-      getSelectedPanelId: () => null,
-      onLaunch: vi.fn(),
+      getSelectedPanelId: options?.getSelectedPanelId ?? (() => null),
+      onLaunch,
       resolveIcon,
     });
 
     controller.attach();
+    activeController = controller;
 
     return {
       controller,
       input,
       fetchResults,
       resolveIcon,
+      onLaunch,
     };
   };
 
@@ -225,5 +237,80 @@ describe('CommandPaletteController', () => {
       document.querySelectorAll<HTMLElement>('.command-palette-group'),
     ).map((el) => el.textContent);
     expect(headers).toEqual(['List items', 'Lists', 'Notes']);
+  });
+
+  it('includes Move to list in the action menu for list item results', async () => {
+    const onLaunch = vi.fn(() => true);
+    const { controller, input, fetchResults } = buildController({ onLaunch });
+    const result: SearchApiResult = {
+      pluginId: 'lists',
+      instanceId: 'default',
+      id: 'item-1',
+      title: 'Buy milk',
+      launch: {
+        panelType: 'lists',
+        payload: {
+          type: 'lists_show',
+          listId: 'tasks',
+          itemId: 'item-1',
+        },
+      },
+    };
+    fetchResults.mockResolvedValueOnce({ results: [result] });
+
+    controller.open();
+    input.value = 'milk';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    await vi.runAllTimersAsync();
+
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true }),
+    );
+
+    const labels = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('.command-palette-menu-item'),
+    ).map((button) => button.textContent);
+    expect(labels).toContain('Move to list');
+    expect(labels).toContain('Open modal');
+
+    const moveButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('.command-palette-menu-item'),
+    ).find((button) => button.textContent === 'Move to list');
+    moveButton?.click();
+
+    expect(onLaunch).toHaveBeenCalledWith(result, { type: 'move-to-list' });
+  });
+
+  it('omits Move to list for non list-item results', async () => {
+    const { controller, input, fetchResults } = buildController();
+    fetchResults.mockResolvedValueOnce({
+      results: [
+        {
+          pluginId: 'lists',
+          instanceId: 'default',
+          id: 'list:tasks',
+          title: 'Tasks',
+          launch: {
+            panelType: 'lists',
+            payload: { type: 'lists_show', listId: 'tasks' },
+          },
+        },
+      ],
+    });
+
+    controller.open();
+    input.value = 'tasks';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    await vi.runAllTimersAsync();
+
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true }),
+    );
+
+    const labels = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('.command-palette-menu-item'),
+    ).map((button) => button.textContent);
+    expect(labels).toContain('Open modal');
+    expect(labels).not.toContain('Move to list');
   });
 });

--- a/packages/web-client/src/controllers/commandPaletteController.ts
+++ b/packages/web-client/src/controllers/commandPaletteController.ts
@@ -1,3 +1,5 @@
+import { isListItemSearchResult } from './searchListItemMove';
+
 export interface SearchableScope {
   pluginId: string;
   label: string;
@@ -39,7 +41,8 @@ export type LaunchAction =
   | { type: 'modal' }
   | { type: 'workspace' }
   | { type: 'pin' }
-  | { type: 'replace' };
+  | { type: 'replace' }
+  | { type: 'move-to-list' };
 
 export interface CommandPaletteControllerOptions {
   overlay: HTMLElement | null;
@@ -255,6 +258,11 @@ export class CommandPaletteController {
       }
     });
     document.addEventListener('keydown', this.handleKeyDown);
+  }
+
+  detach(): void {
+    this.close();
+    document.removeEventListener('keydown', this.handleKeyDown);
   }
 
   open(): void {
@@ -1385,12 +1393,20 @@ export class CommandPaletteController {
       return;
     }
     const hasSelection = Boolean(this.options.getSelectedPanelId());
-    const entries = MAIN_MENU_ITEMS.map((item) => ({
+    const activeResult = this.getActiveResults()[this.resultIndex];
+    const entries: MenuEntry[] = MAIN_MENU_ITEMS.map((item) => ({
       id: item.id,
       label: item.label,
       disabled: Boolean(item.requiresSelection && !hasSelection),
       onSelect: () => this.executeAction(item.action),
     }));
+    if (activeResult && isListItemSearchResult(activeResult)) {
+      entries.push({
+        id: 'move-to-list',
+        label: 'Move to list',
+        onSelect: () => this.executeAction({ type: 'move-to-list' }),
+      });
+    }
     let index = entries.findIndex((entry) => !entry.disabled);
     if (index < 0) {
       index = 0;

--- a/packages/web-client/src/controllers/searchListItemMove.test.ts
+++ b/packages/web-client/src/controllers/searchListItemMove.test.ts
@@ -1,0 +1,333 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DialogManager } from './dialogManager';
+import type { SearchApiResult } from './commandPaletteController';
+import {
+  getListItemSearchRef,
+  isListItemSearchResult,
+  promptAndMoveListItemFromSearch,
+} from './searchListItemMove';
+
+const createDialogManager = (): DialogManager =>
+  ({
+    hasOpenDialog: false,
+    showConfirmDialog: vi.fn(),
+    showTextInputDialog: vi.fn(),
+    registerExternalDialog: vi.fn(),
+    releaseExternalDialog: vi.fn(),
+    closeOpenDialog: vi.fn(),
+  }) as unknown as DialogManager;
+
+const listItemResult = (overrides?: Partial<SearchApiResult>): SearchApiResult => ({
+  pluginId: 'lists',
+  instanceId: 'default',
+  id: 'item-1',
+  title: 'Buy milk',
+  subtitle: 'Groceries',
+  launch: {
+    panelType: 'lists',
+    payload: {
+      type: 'lists_show',
+      instance_id: 'default',
+      listId: 'groceries',
+      itemId: 'item-1',
+    },
+  },
+  ...overrides,
+});
+
+describe('searchListItemMove', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('identifies list item search results', () => {
+    expect(isListItemSearchResult(listItemResult())).toBe(true);
+    expect(
+      isListItemSearchResult({
+        pluginId: 'lists',
+        instanceId: 'default',
+        id: 'list:groceries',
+        title: 'Groceries',
+        launch: {
+          panelType: 'lists',
+          payload: { type: 'lists_show', listId: 'groceries' },
+        },
+      }),
+    ).toBe(false);
+    expect(
+      isListItemSearchResult({
+        pluginId: 'notes',
+        instanceId: 'default',
+        id: 'note-1',
+        title: 'A note',
+        launch: {
+          panelType: 'notes',
+          payload: { type: 'notes_show', title: 'A note' },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('extracts item/list/instance from the launch payload', () => {
+    expect(getListItemSearchRef(listItemResult())).toEqual({
+      itemId: 'item-1',
+      listId: 'groceries',
+      instanceId: 'default',
+    });
+    expect(
+      getListItemSearchRef(
+        listItemResult({
+          instanceId: 'home',
+          launch: {
+            panelType: 'lists',
+            payload: {
+              type: 'lists_show',
+              instance_id: 'work',
+              listId: 'tasks',
+              itemId: 'item-9',
+            },
+          },
+        }),
+      ),
+    ).toEqual({
+      itemId: 'item-9',
+      listId: 'tasks',
+      instanceId: 'work',
+    });
+  });
+
+  it('prompts for a list and moves the item via the lists API', async () => {
+    const setStatus = vi.fn();
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.endsWith('/list')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            result: [
+              { id: 'groceries', name: 'Groceries' },
+              { id: 'today', name: 'Today' },
+              { id: 'work', name: 'Work' },
+            ],
+          }),
+        };
+      }
+      if (url.endsWith('/item-move')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            result: { id: 'item-1', listId: 'today' },
+          }),
+        };
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    }) as unknown as typeof import('../utils/api').apiFetch;
+
+    const promise = promptAndMoveListItemFromSearch({
+      result: listItemResult(),
+      dialogManager: createDialogManager(),
+      setStatus,
+      fetchImpl,
+    });
+
+    await vi.waitFor(() => {
+      expect(document.querySelector('.list-selection-dialog')).not.toBeNull();
+    });
+
+    const items = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('.list-selection-item'),
+    );
+    // Source list excluded
+    expect(items.map((item) => item.dataset['listId'])).toEqual(['today', 'work']);
+
+    const today = items.find((item) => item.dataset['listId'] === 'today');
+    today?.click();
+    document.querySelector<HTMLButtonElement>('.confirm-dialog-button.primary')?.click();
+
+    await expect(promise).resolves.toBe(true);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      '/api/plugins/lists/operations/list',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ instance_id: 'default' }),
+      }),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      '/api/plugins/lists/operations/item-move',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          instance_id: 'default',
+          id: 'item-1',
+          targetListId: 'today',
+        }),
+      }),
+    );
+    expect(setStatus).toHaveBeenCalledWith('Loading lists…');
+    expect(setStatus).toHaveBeenCalledWith('Moved "Buy milk" to "Today"');
+  });
+
+  it('reports when no other lists are available', async () => {
+    const setStatus = vi.fn();
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        result: [{ id: 'groceries', name: 'Groceries' }],
+      }),
+    })) as unknown as typeof import('../utils/api').apiFetch;
+
+    await expect(
+      promptAndMoveListItemFromSearch({
+        result: listItemResult(),
+        dialogManager: createDialogManager(),
+        setStatus,
+        fetchImpl,
+      }),
+    ).resolves.toBe(false);
+
+    expect(setStatus).toHaveBeenCalledWith('No other lists available');
+    expect(document.querySelector('.list-selection-dialog')).toBeNull();
+  });
+
+  it('returns false when the picker is cancelled', async () => {
+    const setStatus = vi.fn();
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        result: [
+          { id: 'groceries', name: 'Groceries' },
+          { id: 'today', name: 'Today' },
+        ],
+      }),
+    })) as unknown as typeof import('../utils/api').apiFetch;
+
+    const promise = promptAndMoveListItemFromSearch({
+      result: listItemResult(),
+      dialogManager: createDialogManager(),
+      setStatus,
+      fetchImpl,
+    });
+
+    await vi.waitFor(() => {
+      expect(document.querySelector('.list-selection-dialog')).not.toBeNull();
+    });
+
+    document.querySelector<HTMLButtonElement>('.confirm-dialog-button.cancel')?.click();
+    await expect(promise).resolves.toBe(false);
+    expect(setStatus).toHaveBeenCalledWith('Loading lists…');
+    expect(setStatus).not.toHaveBeenCalledWith(expect.stringContaining('Moved'));
+  });
+
+  it('rejects non-list-item results', async () => {
+    const setStatus = vi.fn();
+    const fetchImpl = vi.fn();
+
+    await expect(
+      promptAndMoveListItemFromSearch({
+        result: {
+          pluginId: 'notes',
+          instanceId: 'default',
+          id: 'note-1',
+          title: 'A note',
+          launch: {
+            panelType: 'notes',
+            payload: { type: 'notes_show', title: 'A note' },
+          },
+        },
+        dialogManager: createDialogManager(),
+        setStatus,
+        fetchImpl: fetchImpl as unknown as typeof import('../utils/api').apiFetch,
+      }),
+    ).resolves.toBe(false);
+
+    expect(setStatus).toHaveBeenCalledWith('Move to list is only available for list items');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('defaults instanceId when payload and result omit it', () => {
+    expect(
+      getListItemSearchRef({
+        pluginId: 'lists',
+        instanceId: '',
+        id: 'item-2',
+        title: 'Milk',
+        launch: {
+          panelType: 'lists',
+          payload: {
+            type: 'lists_show',
+            listId: 'groceries',
+            itemId: 'item-2',
+          },
+        },
+      }),
+    ).toEqual({
+      itemId: 'item-2',
+      listId: 'groceries',
+      instanceId: 'default',
+    });
+  });
+
+  it('reports when loading destination lists fails', async () => {
+    const setStatus = vi.fn();
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'boom' }),
+    })) as unknown as typeof import('../utils/api').apiFetch;
+
+    await expect(
+      promptAndMoveListItemFromSearch({
+        result: listItemResult(),
+        dialogManager: createDialogManager(),
+        setStatus,
+        fetchImpl,
+      }),
+    ).resolves.toBe(false);
+
+    expect(setStatus).toHaveBeenCalledWith('Loading lists…');
+    expect(setStatus).toHaveBeenCalledWith('Failed to load lists');
+    expect(document.querySelector('.list-selection-dialog')).toBeNull();
+  });
+
+  it('reports when the item-move API fails', async () => {
+    const setStatus = vi.fn();
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.endsWith('/list')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            result: [
+              { id: 'groceries', name: 'Groceries' },
+              { id: 'today', name: 'Today' },
+            ],
+          }),
+        };
+      }
+      return {
+        ok: false,
+        status: 500,
+        json: async () => ({ error: 'move failed' }),
+      };
+    }) as unknown as typeof import('../utils/api').apiFetch;
+
+    const promise = promptAndMoveListItemFromSearch({
+      result: listItemResult(),
+      dialogManager: createDialogManager(),
+      setStatus,
+      fetchImpl,
+    });
+
+    await vi.waitFor(() => {
+      expect(document.querySelector('.list-selection-dialog')).not.toBeNull();
+    });
+
+    document.querySelector<HTMLButtonElement>('.confirm-dialog-button.primary')?.click();
+    await expect(promise).resolves.toBe(false);
+    expect(setStatus).toHaveBeenCalledWith('Failed to move item');
+  });
+});

--- a/packages/web-client/src/controllers/searchListItemMove.ts
+++ b/packages/web-client/src/controllers/searchListItemMove.ts
@@ -1,0 +1,169 @@
+import { apiFetch } from '../utils/api';
+import type { DialogManager } from './dialogManager';
+import { openListSelectionDialog, type ListSelectionItem } from './listSelectionDialog';
+import type { SearchApiResult } from './commandPaletteController';
+
+export interface ListItemSearchRef {
+  itemId: string;
+  listId: string;
+  instanceId: string;
+}
+
+export interface PromptAndMoveListItemOptions {
+  result: SearchApiResult;
+  dialogManager: DialogManager;
+  setStatus: (message: string) => void;
+  /** Optional fetch override for tests */
+  fetchImpl?: typeof apiFetch;
+}
+
+type OperationResponse<T> = {
+  result?: T;
+  error?: string;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+export function getListItemSearchRef(result: SearchApiResult): ListItemSearchRef | null {
+  if (result.launch.panelType !== 'lists') {
+    return null;
+  }
+  const payload = asRecord(result.launch.payload);
+  if (!payload) {
+    return null;
+  }
+  const itemId = typeof payload['itemId'] === 'string' ? payload['itemId'].trim() : '';
+  const listId = typeof payload['listId'] === 'string' ? payload['listId'].trim() : '';
+  if (!itemId || !listId) {
+    return null;
+  }
+  const payloadInstance =
+    typeof payload['instance_id'] === 'string' ? payload['instance_id'].trim() : '';
+  const resultInstance = typeof result.instanceId === 'string' ? result.instanceId.trim() : '';
+  const instanceId = payloadInstance || resultInstance || 'default';
+  return { itemId, listId, instanceId };
+}
+
+export function isListItemSearchResult(result: SearchApiResult): boolean {
+  return getListItemSearchRef(result) !== null;
+}
+
+function parseListSelectionItems(value: unknown): ListSelectionItem[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const items: ListSelectionItem[] = [];
+  for (const entry of value) {
+    const record = asRecord(entry);
+    if (!record) {
+      continue;
+    }
+    const id = typeof record['id'] === 'string' ? record['id'].trim() : '';
+    const name = typeof record['name'] === 'string' ? record['name'].trim() : '';
+    if (!id || !name) {
+      continue;
+    }
+    items.push({ id, name });
+  }
+  return items;
+}
+
+async function callListsOperation<T>(
+  operation: string,
+  body: Record<string, unknown>,
+  fetchImpl: typeof apiFetch,
+): Promise<T> {
+  const response = await fetchImpl(`/api/plugins/lists/operations/${operation}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  let payload: OperationResponse<T> | null = null;
+  try {
+    payload = (await response.json()) as OperationResponse<T>;
+  } catch {
+    // ignore JSON parse failures
+  }
+
+  if (!response.ok || !payload || payload.result === undefined || payload.error) {
+    const message = payload?.error ? payload.error : `Request failed (${response.status})`;
+    throw new Error(message);
+  }
+
+  return payload.result;
+}
+
+/**
+ * Open the searchable list picker and move a list item from a global search result.
+ * Does not require a lists panel to be open.
+ */
+export async function promptAndMoveListItemFromSearch(
+  options: PromptAndMoveListItemOptions,
+): Promise<boolean> {
+  const ref = getListItemSearchRef(options.result);
+  if (!ref) {
+    options.setStatus('Move to list is only available for list items');
+    return false;
+  }
+
+  const fetchImpl = options.fetchImpl ?? apiFetch;
+  const instanceBody = { instance_id: ref.instanceId };
+
+  options.setStatus('Loading lists…');
+
+  let targets: ListSelectionItem[] = [];
+  try {
+    const rawLists = await callListsOperation<unknown>('list', instanceBody, fetchImpl);
+    targets = parseListSelectionItems(rawLists).filter((list) => list.id !== ref.listId);
+  } catch (error) {
+    console.error('Failed to load lists for search move:', error);
+    options.setStatus('Failed to load lists');
+    return false;
+  }
+
+  if (targets.length === 0) {
+    options.setStatus('No other lists available');
+    return false;
+  }
+
+  targets.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+
+  const itemLabel = options.result.title.trim() || ref.itemId;
+  const selected = await openListSelectionDialog({
+    dialogManager: options.dialogManager,
+    title: 'Move Item',
+    message: `Move "${itemLabel}" to which list?`,
+    items: targets,
+    confirmText: 'Move',
+    emptyText: 'No matching lists',
+    showIds: false,
+  });
+
+  if (!selected) {
+    return false;
+  }
+
+  try {
+    await callListsOperation(
+      'item-move',
+      {
+        ...instanceBody,
+        id: ref.itemId,
+        targetListId: selected.id,
+      },
+      fetchImpl,
+    );
+    options.setStatus(`Moved "${itemLabel}" to "${selected.name}"`);
+    return true;
+  } catch (error) {
+    console.error('Failed to move list item from search:', error);
+    options.setStatus('Failed to move item');
+    return false;
+  }
+}

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -56,6 +56,7 @@ import {
   type SearchApiResponse,
   type SearchableScope,
 } from './controllers/commandPaletteController';
+import { promptAndMoveListItemFromSearch } from './controllers/searchListItemMove';
 import { PanelWorkspaceController } from './controllers/panelWorkspaceController';
 import {
   closeShareModal,
@@ -4585,6 +4586,15 @@ async function main(): Promise<void> {
   };
 
   const handleSearchLaunch = (result: SearchApiResult, action: LaunchAction): boolean => {
+    if (action.type === 'move-to-list') {
+      void promptAndMoveListItemFromSearch({
+        result,
+        dialogManager,
+        setStatus: (text) => setStatus(statusEl, text),
+      });
+      return true;
+    }
+
     if (!panelWorkspace) {
       return false;
     }


### PR DESCRIPTION
## Summary
- Add a **Move to list** action on command-palette results for list items
- Reuse the searchable list picker and lists `item-move` API so items can be reassigned without opening them
- Cover success, cancel, empty-target, and error paths; update design docs

## Test plan
- [x] Unit tests for command palette menu visibility and move helper
- [ ] Manual: search for a list item → open action menu → Move to list → pick destination → confirm item moved
- [ ] Manual: cancel picker and verify no move
- [ ] Manual: verify non-list-item results do not show Move to list
