### PR TITLE
Add macOS Right Option chat focus setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Added an opt-in macOS setting that focuses the selected chat input when Right Option is pressed without consuming the key event. ([#132](https://github.com/kcosr/assistant/pull/132))
 - Added Move to list on global search list-item results so items can be reassigned from the command palette without opening them first. ([#130](https://github.com/kcosr/assistant/pull/130))
 - Added a Herdr-inspired dark theme with coordinated prominent-action styling and a persistent preference for showing or hiding selected panel outlines. ([#129](https://github.com/kcosr/assistant/pull/129))
 - Added configurable native Pi SDK tool approvals that block selected exact-name or glob-matched tools until an interactive client approves or denies them, with fail-closed handling and composer-level approval controls. ([#128](https://github.com/kcosr/assistant/pull/128))

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ export PATH="$PATH:$HOME/.pi/skills/notes:$HOME/.pi/skills/lists"
 | `Ctrl + H` | Toggle header panel navigation mode |
 | `Ctrl + Shift + S` | Split active panel (placement mode) |
 | `Ctrl + I` | Toggle text input focus |
+| `Right Option` (macOS, opt-in) | Focus the selected chat input without consuming the key event |
 | `Ctrl + C/L/N` | Focus last-used chat/lists/notes panel (opens modal if none) |
 | `Ctrl + R` | Toggle speech recording (if available) |
 | `Cmd + Shift + S` (macOS) | Toggle sessions sidebar |

--- a/docs/UI_SPEC.md
+++ b/docs/UI_SPEC.md
@@ -174,8 +174,9 @@ Panels can register additional shortcuts scoped to the focused panel.
 
 - Chat transcript UI with tool output rendering.
 - Includes its own message composer (input, context toggle, brief toggle, mic).
-- Keyboard: `Ctrl+I` toggles input focus; when the input is not focused, `s` opens the session
-  picker, `m` focuses the model dropdown, and `t` focuses the thinking dropdown.
+- Keyboard: `Ctrl+I` toggles input focus. An opt-in macOS setting makes Right Option focus the
+  selected chat input without consuming the key event. When the input is not focused, `s` opens
+  the session picker, `m` focuses the model dropdown, and `t` focuses the thinking dropdown.
 - Voice capture auto-submits on recognition end (no spoken "submit" keyword).
 - Mic button and media play/pause key cancel active output; subsequent press starts recording.
 - Long-pressing the mic enables continuous listening and starts recording once the long-press threshold is reached.

--- a/packages/web-client/public/index.html
+++ b/packages/web-client/public/index.html
@@ -231,6 +231,12 @@
               </label>
             </div>
             <div class="settings-dropdown-item">
+              <label for="right-option-focus-chat-checkbox">
+                <input type="checkbox" id="right-option-focus-chat-checkbox" />
+                Right Option focuses chat input (macOS)
+              </label>
+            </div>
+            <div class="settings-dropdown-item">
               <label for="auto-scroll-checkbox">
                 <input type="checkbox" id="auto-scroll-checkbox" />
                 Auto-scroll on new messages

--- a/packages/web-client/src/controllers/keyboardNavigationController.test.ts
+++ b/packages/web-client/src/controllers/keyboardNavigationController.test.ts
@@ -68,6 +68,7 @@ function buildOptions(
       showTextInputDialog: vi.fn(),
     } as unknown as DialogManager,
     isKeyboardShortcutsEnabled: () => true,
+    isRightOptionFocusChatEnabled: () => false,
     getSpeechAudioController: () => null,
     cancelAllActiveOperations: () => false,
     startPushToTalk: async () => {},
@@ -107,6 +108,21 @@ function attachShortcutRegistry(
   registry.attach();
   return {
     detach: () => registry.detach(),
+  };
+}
+
+function setNavigatorPlatform(platform: string): () => void {
+  const descriptor = Object.getOwnPropertyDescriptor(window.navigator, 'platform');
+  Object.defineProperty(window.navigator, 'platform', {
+    configurable: true,
+    value: platform,
+  });
+  return () => {
+    if (descriptor) {
+      Object.defineProperty(window.navigator, 'platform', descriptor);
+    } else {
+      Reflect.deleteProperty(window.navigator, 'platform');
+    }
   };
 }
 
@@ -836,6 +852,125 @@ describe('KeyboardNavigationController chat shortcuts', () => {
     expect(document.activeElement).not.toBe(input);
 
     detach();
+  });
+
+  it('focuses the selected chat input on Right Option without consuming the event', () => {
+    const restorePlatform = setNavigatorPlatform('MacIntel');
+    try {
+      const panelFrame = document.createElement('div');
+      panelFrame.className = 'panel-frame is-active';
+      panelFrame.dataset['panelId'] = 'panel-1';
+      document.body.appendChild(panelFrame);
+
+      const otherInput = document.createElement('input');
+      const chatInput = document.createElement('textarea');
+      document.body.append(otherInput, chatInput);
+      otherInput.focus();
+
+      const options = buildOptions(panelFrame);
+      options.isRightOptionFocusChatEnabled = () => true;
+      options.getInputEl = () => chatInput;
+      options.focusInput = () => chatInput.focus();
+
+      const controller = new KeyboardNavigationController(options);
+      const event = new KeyboardEvent('keydown', {
+        key: 'Alt',
+        code: 'AltRight',
+        altKey: true,
+        cancelable: true,
+      });
+      const preventDefault = vi.spyOn(event, 'preventDefault');
+      const stopPropagation = vi.spyOn(event, 'stopPropagation');
+
+      (
+        controller as unknown as {
+          handleRightOptionFocus: (keyboardEvent: KeyboardEvent) => void;
+        }
+      ).handleRightOptionFocus(event);
+
+      expect(document.activeElement).toBe(chatInput);
+      expect(preventDefault).not.toHaveBeenCalled();
+      expect(stopPropagation).not.toHaveBeenCalled();
+    } finally {
+      restorePlatform();
+    }
+  });
+
+  it('keeps the selected chat input focused on repeated Right Option events', () => {
+    const restorePlatform = setNavigatorPlatform('MacIntel');
+    try {
+      const panelFrame = document.createElement('div');
+      panelFrame.className = 'panel-frame is-active';
+      panelFrame.dataset['panelId'] = 'panel-1';
+      document.body.appendChild(panelFrame);
+
+      const chatInput = document.createElement('textarea');
+      document.body.appendChild(chatInput);
+      chatInput.focus();
+
+      const options = buildOptions(panelFrame);
+      options.isRightOptionFocusChatEnabled = () => true;
+      options.getInputEl = () => chatInput;
+      options.focusInput = vi.fn(() => chatInput.focus());
+
+      const controller = new KeyboardNavigationController(options);
+      const event = new KeyboardEvent('keydown', {
+        key: 'Alt',
+        code: 'AltRight',
+        altKey: true,
+        repeat: true,
+      });
+
+      (
+        controller as unknown as {
+          handleRightOptionFocus: (keyboardEvent: KeyboardEvent) => void;
+        }
+      ).handleRightOptionFocus(event);
+
+      expect(document.activeElement).toBe(chatInput);
+      expect(options.focusInput).not.toHaveBeenCalled();
+    } finally {
+      restorePlatform();
+    }
+  });
+
+  it.each([
+    ['the preference is disabled', false, 'AltRight'],
+    ['Left Option is pressed', true, 'AltLeft'],
+  ])('does not focus the chat input when %s', (_case, enabled, code) => {
+    const restorePlatform = setNavigatorPlatform('MacIntel');
+    try {
+      const panelFrame = document.createElement('div');
+      panelFrame.className = 'panel-frame is-active';
+      panelFrame.dataset['panelId'] = 'panel-1';
+      document.body.appendChild(panelFrame);
+
+      const chatInput = document.createElement('textarea');
+      document.body.appendChild(chatInput);
+
+      const options = buildOptions(panelFrame);
+      options.isRightOptionFocusChatEnabled = () => enabled;
+      options.getInputEl = () => chatInput;
+      options.focusInput = vi.fn(() => chatInput.focus());
+
+      const controller = new KeyboardNavigationController(options);
+      const event = new KeyboardEvent('keydown', {
+        key: 'Alt',
+        code,
+        altKey: true,
+      });
+
+      (
+        controller as unknown as {
+          handleRightOptionFocus: (keyboardEvent: KeyboardEvent) => void;
+        }
+      ).handleRightOptionFocus(event);
+
+      expect(options.focusInput).not.toHaveBeenCalled();
+      expect(document.activeElement).not.toBe(chatInput);
+    } finally {
+      restorePlatform();
+    }
   });
 
   it.each([

--- a/packages/web-client/src/controllers/keyboardNavigationController.ts
+++ b/packages/web-client/src/controllers/keyboardNavigationController.ts
@@ -20,6 +20,7 @@ export interface KeyboardNavigationControllerOptions {
   dialogManager: DialogManager;
   shortcutRegistry?: KeyboardShortcutRegistry;
   isKeyboardShortcutsEnabled: () => boolean;
+  isRightOptionFocusChatEnabled: () => boolean;
   getSpeechAudioController: () => SpeechAudioController | null;
   cancelAllActiveOperations: () => boolean;
   startPushToTalk: () => Promise<void>;
@@ -116,6 +117,7 @@ export class KeyboardNavigationController {
     this.hasAttached = true;
 
     this.registerShortcuts();
+    this.attachRightOptionFocus();
     this.attachTabNavigation();
     this.attachHeaderPanelSelection();
     this.attachPanelNavigation();
@@ -2160,6 +2162,37 @@ export class KeyboardNavigationController {
         }
       }
     });
+  }
+
+  private attachRightOptionFocus(): void {
+    document.addEventListener(
+      'keydown',
+      (event: KeyboardEvent) => this.handleRightOptionFocus(event),
+      true,
+    );
+  }
+
+  private handleRightOptionFocus(event: KeyboardEvent): void {
+    if (!isMacPlatform() || !this.options.isRightOptionFocusChatEnabled()) {
+      return;
+    }
+    if (!this.options.isKeyboardShortcutsEnabled() || this.options.dialogManager.hasOpenDialog) {
+      return;
+    }
+    if (areKeyboardShortcutsBlockedByOverlay()) {
+      return;
+    }
+    const isRightOption =
+      event.code === 'AltRight' ||
+      (event.key === 'Alt' && event.location === KeyboardEvent.DOM_KEY_LOCATION_RIGHT);
+    if (!isRightOption || event.ctrlKey || event.metaKey || event.shiftKey) {
+      return;
+    }
+    const inputEl = this.options.getInputEl();
+    if (!inputEl || document.activeElement === inputEl) {
+      return;
+    }
+    this.focusZone('input');
   }
 
   private attachSidebarNavigation(): void {

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -567,6 +567,7 @@ async function main(): Promise<void> {
     listItemEditorModeSelect: listItemEditorModeSelectEl,
     autoFocusChatCheckbox: autoFocusChatCheckboxEl,
     keyboardShortcutsCheckbox: keyboardShortcutsCheckboxEl,
+    rightOptionFocusChatCheckbox: rightOptionFocusChatCheckboxEl,
     autoScrollCheckbox: autoScrollCheckboxEl,
     selectedPanelOutlinesCheckbox: selectedPanelOutlinesCheckboxEl,
     synthesizedPanelTitlesCheckbox: synthesizedPanelTitlesCheckboxEl,
@@ -651,6 +652,7 @@ async function main(): Promise<void> {
   const VOICE_SETTINGS_STORAGE_KEY = 'aiAssistantVoiceSettings';
   const KEYBOARD_SHORTCUTS_STORAGE_KEY = 'aiAssistantKeyboardShortcutsEnabled';
   const KEYBOARD_SHORTCUT_BINDINGS_STORAGE_KEY = 'aiAssistantKeyboardShortcutBindings';
+  const RIGHT_OPTION_FOCUS_CHAT_STORAGE_KEY = 'aiAssistantRightOptionFocusChatEnabled';
   const AUTO_FOCUS_CHAT_STORAGE_KEY = 'aiAssistantAutoFocusChatOnSessionReady';
   const AUTO_SCROLL_STORAGE_KEY = 'aiAssistantAutoScrollEnabled';
   const SELECTED_PANEL_OUTLINES_STORAGE_KEY = 'aiAssistantSelectedPanelOutlinesEnabled';
@@ -695,6 +697,7 @@ async function main(): Promise<void> {
     voiceStorageKey: VOICE_SETTINGS_STORAGE_KEY,
     keyboardShortcutsStorageKey: KEYBOARD_SHORTCUTS_STORAGE_KEY,
     keyboardShortcutsBindingsStorageKey: KEYBOARD_SHORTCUT_BINDINGS_STORAGE_KEY,
+    rightOptionFocusChatStorageKey: RIGHT_OPTION_FOCUS_CHAT_STORAGE_KEY,
     autoFocusChatStorageKey: AUTO_FOCUS_CHAT_STORAGE_KEY,
     autoScrollStorageKey: AUTO_SCROLL_STORAGE_KEY,
     selectedPanelOutlinesStorageKey: SELECTED_PANEL_OUTLINES_STORAGE_KEY,
@@ -706,6 +709,7 @@ async function main(): Promise<void> {
   let currentVoiceSettings = initialVoiceSettings;
   let keyboardShortcutsEnabled = initialPreferences.keyboardShortcutsEnabled;
   const keyboardShortcutBindings = initialPreferences.keyboardShortcutBindings;
+  let rightOptionFocusChatEnabled = initialPreferences.rightOptionFocusChatEnabled;
   let autoFocusChatOnSessionReady = initialPreferences.autoFocusChatOnSessionReady;
   let autoScrollEnabled = initialPreferences.autoScrollEnabled;
   const selectedPanelOutlinesEnabled = initialPreferences.selectedPanelOutlinesEnabled;
@@ -3933,16 +3937,19 @@ async function main(): Promise<void> {
   wirePreferencesCheckboxes({
     autoFocusChatCheckbox: autoFocusChatCheckboxEl,
     keyboardShortcutsCheckbox: keyboardShortcutsCheckboxEl,
+    rightOptionFocusChatCheckbox: rightOptionFocusChatCheckboxEl,
     autoScrollCheckbox: autoScrollCheckboxEl,
     selectedPanelOutlinesCheckbox: selectedPanelOutlinesCheckboxEl,
     synthesizedPanelTitlesCheckbox: synthesizedPanelTitlesCheckboxEl,
     initialAutoFocusChatOnSessionReady: autoFocusChatOnSessionReady,
     initialKeyboardShortcutsEnabled: keyboardShortcutsEnabled,
+    initialRightOptionFocusChatEnabled: rightOptionFocusChatEnabled,
     initialAutoScrollEnabled: autoScrollEnabled,
     initialSelectedPanelOutlinesEnabled: selectedPanelOutlinesEnabled,
     initialSynthesizedPanelTitlesEnabled: synthesizedPanelTitlesEnabled,
     autoFocusChatStorageKey: AUTO_FOCUS_CHAT_STORAGE_KEY,
     keyboardShortcutsStorageKey: KEYBOARD_SHORTCUTS_STORAGE_KEY,
+    rightOptionFocusChatStorageKey: RIGHT_OPTION_FOCUS_CHAT_STORAGE_KEY,
     autoScrollStorageKey: AUTO_SCROLL_STORAGE_KEY,
     selectedPanelOutlinesStorageKey: SELECTED_PANEL_OUTLINES_STORAGE_KEY,
     synthesizedPanelTitlesStorageKey: SYNTHESIZED_PANEL_TITLES_STORAGE_KEY,
@@ -3951,6 +3958,9 @@ async function main(): Promise<void> {
     },
     setKeyboardShortcutsEnabled: (enabled) => {
       keyboardShortcutsEnabled = enabled;
+    },
+    setRightOptionFocusChatEnabled: (enabled) => {
+      rightOptionFocusChatEnabled = enabled;
     },
     setAutoScrollEnabled: (enabled) => {
       autoScrollEnabled = enabled;
@@ -5639,6 +5649,7 @@ async function main(): Promise<void> {
       dialogManager,
       shortcutRegistry: keyboardShortcutRegistry,
       isKeyboardShortcutsEnabled: () => keyboardShortcutsEnabled,
+      isRightOptionFocusChatEnabled: () => rightOptionFocusChatEnabled,
       getSpeechAudioController: () => getActiveChatInputRuntime()?.speechAudioController ?? null,
       cancelAllActiveOperations,
       startPushToTalk,

--- a/packages/web-client/src/utils/clientPreferences.test.ts
+++ b/packages/web-client/src/utils/clientPreferences.test.ts
@@ -15,6 +15,7 @@ const defaultOptions = {
   voiceStorageKey: 'voice',
   keyboardShortcutsStorageKey: 'shortcuts',
   keyboardShortcutsBindingsStorageKey: 'shortcut-bindings',
+  rightOptionFocusChatStorageKey: 'right-option-focus-chat',
   autoFocusChatStorageKey: 'autofocus',
   autoScrollStorageKey: 'autoscroll',
   selectedPanelOutlinesStorageKey: 'selected-panel-outlines',
@@ -49,6 +50,7 @@ describe('loadClientPreferences', () => {
     expect(preferences.voice.startupPreRollMs).toBe(512);
     expect(preferences.synthesizedPanelTitlesEnabled).toBe(false);
     expect(preferences.selectedPanelOutlinesEnabled).toBe(true);
+    expect(preferences.rightOptionFocusChatEnabled).toBe(false);
   });
 
   it('defaults tool audio mode on in Capacitor Android when unset', () => {
@@ -146,5 +148,13 @@ describe('loadClientPreferences', () => {
     const preferences = loadClientPreferences(defaultOptions);
 
     expect(preferences.selectedPanelOutlinesEnabled).toBe(false);
+  });
+
+  it('loads the right Option chat focus preference when enabled', () => {
+    localStorage.setItem(defaultOptions.rightOptionFocusChatStorageKey, 'true');
+
+    const preferences = loadClientPreferences(defaultOptions);
+
+    expect(preferences.rightOptionFocusChatEnabled).toBe(true);
   });
 });

--- a/packages/web-client/src/utils/clientPreferences.ts
+++ b/packages/web-client/src/utils/clientPreferences.ts
@@ -10,6 +10,7 @@ export interface ClientPreferencesState {
   voice: VoiceSettings;
   keyboardShortcutsEnabled: boolean;
   keyboardShortcutBindings: ShortcutBindingOverrides | null;
+  rightOptionFocusChatEnabled: boolean;
   autoFocusChatOnSessionReady: boolean;
   autoScrollEnabled: boolean;
   selectedPanelOutlinesEnabled: boolean;
@@ -21,6 +22,7 @@ export function loadClientPreferences(options: {
   voiceStorageKey: string;
   keyboardShortcutsStorageKey: string;
   keyboardShortcutsBindingsStorageKey: string;
+  rightOptionFocusChatStorageKey: string;
   autoFocusChatStorageKey: string;
   autoScrollStorageKey: string;
   selectedPanelOutlinesStorageKey: string;
@@ -32,6 +34,7 @@ export function loadClientPreferences(options: {
   });
   let keyboardShortcutsEnabled = true;
   let keyboardShortcutBindings: ShortcutBindingOverrides | null = null;
+  let rightOptionFocusChatEnabled = false;
   let autoFocusChatOnSessionReady = true;
   let autoScrollEnabled = true;
   let selectedPanelOutlinesEnabled = true;
@@ -55,6 +58,10 @@ export function loadClientPreferences(options: {
       if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
         keyboardShortcutBindings = parsed as ShortcutBindingOverrides;
       }
+    }
+    const rightOptionFocusStored = localStorage.getItem(options.rightOptionFocusChatStorageKey);
+    if (rightOptionFocusStored === 'true') {
+      rightOptionFocusChatEnabled = true;
     }
     const autoFocusStored = localStorage.getItem(options.autoFocusChatStorageKey);
     if (autoFocusStored === 'false') {
@@ -88,6 +95,7 @@ export function loadClientPreferences(options: {
     voice,
     keyboardShortcutsEnabled,
     keyboardShortcutBindings,
+    rightOptionFocusChatEnabled,
     autoFocusChatOnSessionReady,
     autoScrollEnabled,
     selectedPanelOutlinesEnabled,
@@ -99,21 +107,25 @@ export function loadClientPreferences(options: {
 export function wirePreferencesCheckboxes(options: {
   autoFocusChatCheckbox: HTMLInputElement;
   keyboardShortcutsCheckbox: HTMLInputElement;
+  rightOptionFocusChatCheckbox: HTMLInputElement;
   autoScrollCheckbox: HTMLInputElement;
   selectedPanelOutlinesCheckbox: HTMLInputElement;
   synthesizedPanelTitlesCheckbox: HTMLInputElement;
   initialAutoFocusChatOnSessionReady: boolean;
   initialKeyboardShortcutsEnabled: boolean;
+  initialRightOptionFocusChatEnabled: boolean;
   initialAutoScrollEnabled: boolean;
   initialSelectedPanelOutlinesEnabled: boolean;
   initialSynthesizedPanelTitlesEnabled: boolean;
   autoFocusChatStorageKey: string;
   keyboardShortcutsStorageKey: string;
+  rightOptionFocusChatStorageKey: string;
   autoScrollStorageKey: string;
   selectedPanelOutlinesStorageKey: string;
   synthesizedPanelTitlesStorageKey: string;
   setAutoFocusChatOnSessionReady: (enabled: boolean) => void;
   setKeyboardShortcutsEnabled: (enabled: boolean) => void;
+  setRightOptionFocusChatEnabled: (enabled: boolean) => void;
   setAutoScrollEnabled: (enabled: boolean) => void;
   setSelectedPanelOutlinesEnabled: (enabled: boolean) => void;
   setSynthesizedPanelTitlesEnabled: (enabled: boolean) => void;
@@ -135,6 +147,17 @@ export function wirePreferencesCheckboxes(options: {
     options.setKeyboardShortcutsEnabled(enabled);
     try {
       localStorage.setItem(options.keyboardShortcutsStorageKey, enabled ? 'true' : 'false');
+    } catch {
+      // Ignore localStorage errors
+    }
+  });
+
+  options.rightOptionFocusChatCheckbox.checked = options.initialRightOptionFocusChatEnabled;
+  options.rightOptionFocusChatCheckbox.addEventListener('change', () => {
+    const enabled = options.rightOptionFocusChatCheckbox.checked;
+    options.setRightOptionFocusChatEnabled(enabled);
+    try {
+      localStorage.setItem(options.rightOptionFocusChatStorageKey, enabled ? 'true' : 'false');
     } catch {
       // Ignore localStorage errors
     }

--- a/packages/web-client/src/utils/webClientElements.test.ts
+++ b/packages/web-client/src/utils/webClientElements.test.ts
@@ -71,6 +71,7 @@ describe('getWebClientElements', () => {
     expect(elements?.voiceTtsGainSlider.id).toBe('voice-tts-gain-slider');
     expect(elements?.voiceTtsGainValue.id).toBe('voice-tts-gain-value');
     expect(elements?.selectedPanelOutlinesCheckbox.id).toBe('selected-panel-outlines-checkbox');
+    expect(elements?.rightOptionFocusChatCheckbox.id).toBe('right-option-focus-chat-checkbox');
   });
 
   it('keeps the voice settings modal hidden in the static document', () => {

--- a/packages/web-client/src/utils/webClientElements.ts
+++ b/packages/web-client/src/utils/webClientElements.ts
@@ -40,6 +40,7 @@ export interface WebClientElements {
   listItemEditorModeSelect: HTMLSelectElement | null;
   autoFocusChatCheckbox: HTMLInputElement;
   keyboardShortcutsCheckbox: HTMLInputElement;
+  rightOptionFocusChatCheckbox: HTMLInputElement;
   autoScrollCheckbox: HTMLInputElement;
   selectedPanelOutlinesCheckbox: HTMLInputElement;
   synthesizedPanelTitlesCheckbox: HTMLInputElement;
@@ -154,6 +155,9 @@ export function getWebClientElements(): WebClientElements | null {
   const listItemEditorModeSelect = getElement<HTMLSelectElement>('list-item-editor-mode-select');
   const autoFocusChatCheckbox = getElement<HTMLInputElement>('autofocus-chat-checkbox');
   const keyboardShortcutsCheckbox = getElement<HTMLInputElement>('keyboard-shortcuts-checkbox');
+  const rightOptionFocusChatCheckbox = getElement<HTMLInputElement>(
+    'right-option-focus-chat-checkbox',
+  );
   const autoScrollCheckbox = getElement<HTMLInputElement>('auto-scroll-checkbox');
   const selectedPanelOutlinesCheckbox = getElement<HTMLInputElement>(
     'selected-panel-outlines-checkbox',
@@ -199,6 +203,7 @@ export function getWebClientElements(): WebClientElements | null {
     !voiceTtsGainValue ||
     !autoFocusChatCheckbox ||
     !keyboardShortcutsCheckbox ||
+    !rightOptionFocusChatCheckbox ||
     !autoScrollCheckbox ||
     !selectedPanelOutlinesCheckbox ||
     !synthesizedPanelTitlesCheckbox ||
@@ -250,6 +255,7 @@ export function getWebClientElements(): WebClientElements | null {
     listItemEditorModeSelect,
     autoFocusChatCheckbox,
     keyboardShortcutsCheckbox,
+    rightOptionFocusChatCheckbox,
     autoScrollCheckbox,
     selectedPanelOutlinesCheckbox,
     synthesizedPanelTitlesCheckbox,


### PR DESCRIPTION
## Summary

- add a persisted, opt-in macOS setting for focusing the selected chat composer with Right Option
- preserve the Right Option event for external dictation tools and keep repeated keydown events focus-only
- document the behavior and cover preference, settings element, platform, side, and event-consumption cases

## Verification

- `npm test -- packages/web-client/src/controllers/keyboardNavigationController.test.ts packages/web-client/src/utils/clientPreferences.test.ts packages/web-client/src/utils/webClientElements.test.ts`
- `npm run build --workspace @assistant/web-client`
- targeted ESLint checks
- full deploy checkout `npm run build`
- `npm run android:build`
