### PR TITLE
Fix Android Auto-listen after scheduled wakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@
 
 ### Fixed
 
-- Fixed Android one-shot scheduled wake replies ignoring Auto Listen in Response and Manual modes, while preserving recognition suppression for other server-origin replies.
+- Fixed Android one-shot scheduled wake replies ignoring Auto Listen in Response and Manual modes, while preserving recognition suppression for other server-origin replies. ([#134](https://github.com/kcosr/assistant/pull/134))
 
 - Fixed voice-first Pi sessions failing before an initial typed message by making native ESM runtime dependencies resolvable from bundled plugin servers. ([#127](https://github.com/kcosr/assistant/pull/127))
 - Fixed Android packaging and layout drift by exactly pinning and verifying the native Capacitor dependency stack. ([#124](https://github.com/kcosr/assistant/pull/124))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@
 
 ### Fixed
 
+- Fixed Android one-shot scheduled wake replies ignoring Auto Listen in Response and Manual modes, while preserving recognition suppression for other server-origin replies.
+
 - Fixed voice-first Pi sessions failing before an initial typed message by making native ESM runtime dependencies resolvable from bundled plugin servers. ([#127](https://github.com/kcosr/assistant/pull/127))
 - Fixed Android packaging and layout drift by exactly pinning and verifying the native Capacitor dependency stack. ([#124](https://github.com/kcosr/assistant/pull/124))
 - Fixed the Android in-app floating speaking control to use the same Skip transition as the headset control, preserving a pending Auto Listen follow-up instead of suppressing it. ([#123](https://github.com/kcosr/assistant/pull/123))

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -813,6 +813,13 @@ read-only other-session wake-ups with only safe summary fields: `kind`, `scope`,
 scheduled-sessions panel uses the same plugin operation without a session context to show all
 wake-ups for administration.
 
+On Android, one-shot wake replies follow the existing Thread audio mode and Auto-listen settings:
+Response mode speaks then listens when Auto-listen is on, and Manual mode listens without automatic
+speech. Disabling Auto-listen prevents automatic recognition. No voice tool or separate wake setting
+is required. Each eligible connected Android device applies its own settings and notification-session
+filter; wakes are not tied to the device that scheduled them. This requires the updated Android app
+and backend. Recurring cron sessions do not receive this wake-specific recognition behavior.
+
 Reminder tools:
 
 - `scheduled_sessions_reminder_create`

--- a/docs/design/mobile-voice-tool-mode-android-contract.md
+++ b/docs/design/mobile-voice-tool-mode-android-contract.md
@@ -129,11 +129,11 @@ For any item that could transition into recognition:
   queued item still passes pre-listen validation
 - if the user manually interrupts playback, start recognition immediately only when
   `Auto-listen` is enabled
-- when a successful local-origin turn produces no final speakable response, admit the server's
+- when a successful local-origin or scheduled wake turn produces no final speakable response, admit the server's
   ephemeral `turn_settled` signal as a `listen_only` queue item after the run is released and only
   if no queued continuation remains
 - suppress settlement-driven Auto Listen after a same-request `voice_ask` or `interaction_end`,
-  for server-origin/interrupted/error turns, and when a newer `turn_start` makes a pending
+  for other server-origin turns, interrupted/error turns, and when a newer `turn_start` makes a pending
   settlement stale
 - while listening, manual stop cancels recognition
 
@@ -145,8 +145,13 @@ For any item that could transition into recognition:
   turns
 - when `localResponseVoiceOnlyEnabled` is enabled, reject automatic response behavior for replies
   carrying another client's `turnOriginId`
-- admit replies without a `turnOriginId` as server-initiated broadcasts, but always suppress Auto
-  Listen so one scheduled or server-generated turn cannot arm recognition on multiple devices
+- admit replies without a `turnOriginId` as server-initiated broadcasts; suppress Auto Listen unless
+  the response carries `turnSource = scheduled_wakeup`
+- one-shot scheduled wakes use the existing Auto Listen setting in Response and Manual modes,
+  including successful settlement without speakable output; there is no additional wake toggle
+- scheduled wakes have no device ownership and can arm every eligible connected device according
+  to its own Auto Listen setting and notification-session filter; recurring cron turns remain
+  ordinary server-origin turns
 - this origin filter does not apply to `voice_speak`, `voice_ask`, external notifications, manual
   notification playback, or explicit microphone starts
 - Android does not persist its locally generated process identifier; a process restart intentionally

--- a/docs/design/mobile-voice-tool-mode-backend-contract.md
+++ b/docs/design/mobile-voice-tool-mode-backend-contract.md
@@ -54,6 +54,9 @@ Shared durable notification fields needed by Android:
 - optional `ttsText`
 - optional `sourceEventId`
 - optional `sessionActivitySeq` for stale ask validation before auto-listen
+- optional `turnSource = scheduled_wakeup` on final-response notifications for one-shot wakes;
+  the same `turnSource` accompanies assistant completion payloads and `turn_settled` messages so
+  Android can apply Auto Listen without inventing a device origin
 
 The durable record and the live broadcast mutation are related but distinct shapes. Android may
 consume the mutation stream over `panel_event` and recover by listing durable notifications over the

--- a/packages/agent-server/src/chatProcessor.test.ts
+++ b/packages/agent-server/src/chatProcessor.test.ts
@@ -371,7 +371,12 @@ describe('processUserMessage stream event emission', () => {
     });
   });
 
-  it('emits assistant_chunk and assistant_done events for pi runs', async () => {
+  const turnMetadataCases = [
+    { turnOriginId: 'android-process-1' },
+    { turnSource: 'scheduled_wakeup' as const },
+  ];
+
+  it.each(turnMetadataCases)('propagates Pi turn metadata %j', async (turnMetadata) => {
     vi.mocked(resolvePiSdkModel).mockResolvedValue({
       model: { id: 'gpt-4o-mini', provider: 'openai', api: 'openai' } as never,
       providerId: 'openai',
@@ -452,7 +457,7 @@ describe('processUserMessage stream event emission', () => {
       sessionId: 's1',
       state,
       text: 'hi',
-      turnOriginId: 'android-process-1',
+      ...turnMetadata,
       sessionHub,
       envConfig: {
         apiKey: 'test-api-key',
@@ -491,8 +496,12 @@ describe('processUserMessage stream event emission', () => {
     expect(chunkTexts).toEqual(['Hello', ' world']);
     const doneEvent = events.find((event) => event.type === 'assistant_done');
     expect(doneEvent?.payload?.text).toBe('Hello world');
-    expect(doneEvent?.type === 'assistant_done' ? doneEvent.payload.turnOriginId : undefined).toBe(
-      'android-process-1',
+    expect(doneEvent?.payload).toMatchObject(turnMetadata);
+    if ('turnSource' in turnMetadata) {
+      expect(doneEvent?.payload).not.toHaveProperty('turnOriginId');
+    }
+    expect(publishFinalResponseNotification).toHaveBeenCalledWith(
+      expect.objectContaining(turnMetadata),
     );
 
     expect(broadcast.some((message) => message.type === 'text_done')).toBe(true);
@@ -503,7 +512,7 @@ describe('processUserMessage stream event emission', () => {
           sessionId: 's1',
           status: 'completed',
           hasSpeakableOutput: true,
-          turnOriginId: 'android-process-1',
+          ...turnMetadata,
         }),
       ]),
     );

--- a/packages/agent-server/src/chatProcessor.ts
+++ b/packages/agent-server/src/chatProcessor.ts
@@ -59,8 +59,10 @@ function buildAssistantDoneEvents(options: {
   fullText: string;
   piSdkMessage: PiSdkMessage | undefined;
   turnOriginId?: string;
+  turnSource?: 'scheduled_wakeup';
 }): ChatEvent[] {
-  const { sessionId, turnId, responseId, fullText, piSdkMessage, turnOriginId } = options;
+  const { sessionId, turnId, responseId, fullText, piSdkMessage, turnOriginId, turnSource } =
+    options;
   const base = createChatEventBase({
     sessionId,
     ...(turnId ? { turnId } : {}),
@@ -79,6 +81,7 @@ function buildAssistantDoneEvents(options: {
           ...(block.phase ? { phase: block.phase } : {}),
           ...(block.textSignature ? { textSignature: block.textSignature } : {}),
           ...(turnOriginId ? { turnOriginId } : {}),
+          ...(turnSource ? { turnSource } : {}),
         },
       }));
   }
@@ -90,7 +93,11 @@ function buildAssistantDoneEvents(options: {
       ...base,
       id: randomUUID(),
       type: 'assistant_done',
-      payload: { text: fullText, ...(turnOriginId ? { turnOriginId } : {}) },
+      payload: {
+        text: fullText,
+        ...(turnOriginId ? { turnOriginId } : {}),
+        ...(turnSource ? { turnSource } : {}),
+      },
     },
   ];
 }
@@ -169,6 +176,7 @@ export interface ChatProcessorOptions {
   requestId?: string;
   responseId?: string;
   turnOriginId?: string;
+  turnSource?: 'scheduled_wakeup';
   sessionHub: SessionHub;
   envConfig: EnvConfig;
   chatCompletionTools: unknown[];
@@ -299,6 +307,7 @@ export async function processUserMessage(
   const responseId = options.responseId ?? randomUUID();
   const requestId = requestIdOption ?? responseId;
   const turnOriginId = options.turnOriginId?.trim() || undefined;
+  const turnSource = options.turnSource;
   const agentExchangeId = agentMessageContext?.exchangeId ?? agentMessageContext?.responseId;
 
   console.log('[chatProcessor] processUserMessage start', {
@@ -544,6 +553,7 @@ export async function processUserMessage(
       callbackBaseUrl: external.callbackBaseUrl,
       sessionId,
       ...(turnOriginId ? { turnOriginId } : {}),
+      ...(turnSource ? { turnSource } : {}),
     });
 
     await postExternalUserInput({
@@ -604,6 +614,7 @@ export async function processUserMessage(
     activeToolCalls: new Map(),
     ...(turnId ? { turnId } : {}),
     ...(turnOriginId ? { turnOriginId } : {}),
+    ...(turnSource ? { turnSource } : {}),
     ...(agentExchangeId ? { agentExchangeId } : {}),
     ...(ttsSession ? { ttsSession } : {}),
   };
@@ -632,6 +643,7 @@ export async function processUserMessage(
           text: partialText,
           interrupted: true,
           ...(run.turnOriginId ? { turnOriginId: run.turnOriginId } : {}),
+          ...(run.turnSource ? { turnSource: run.turnSource } : {}),
         },
       },
     ];
@@ -710,6 +722,7 @@ export async function processUserMessage(
         status: 'interrupted',
         hasSpeakableOutput: false,
         ...(turnOriginId ? { turnOriginId } : {}),
+        ...(turnSource ? { turnSource } : {}),
       };
       if (timedOut) {
         throw new ChatRunError('upstream_timeout', 'Chat backend request timed out', {
@@ -762,6 +775,7 @@ export async function processUserMessage(
           fullText,
           piSdkMessage: runResult.piSdkMessage,
           ...(turnOriginId ? { turnOriginId } : {}),
+          ...(turnSource ? { turnSource } : {}),
         }) as Array<Extract<ChatEvent, { type: 'assistant_done' }>>;
         turnSettlement = {
           requestId: turnId ?? requestId,
@@ -769,6 +783,7 @@ export async function processUserMessage(
           status: 'completed',
           hasSpeakableOutput: hasSpeakableAssistantOutput(assistantDoneEvents),
           ...(turnOriginId ? { turnOriginId } : {}),
+          ...(turnSource ? { turnSource } : {}),
         };
         for (const event of assistantDoneEvents) {
           logDebugChatEventRecord({
@@ -825,6 +840,7 @@ export async function processUserMessage(
         sessionHub,
         summary: notificationSummary,
         ...(turnOriginId ? { turnOriginId } : {}),
+        ...(turnSource ? { turnSource } : {}),
       });
       const assistantTimestampMs =
         (runResult.piSdkMessage &&
@@ -882,6 +898,7 @@ export async function processUserMessage(
       status: 'completed',
       hasSpeakableOutput: false,
       ...(turnOriginId ? { turnOriginId } : {}),
+      ...(turnSource ? { turnSource } : {}),
     };
 
     if (runResult.provider === 'pi' && runResult.piSdkMessage?.role === 'assistant') {
@@ -983,6 +1000,7 @@ export async function processUserMessage(
         status: timedOut ? 'interrupted' : 'error',
         hasSpeakableOutput: false,
         ...(turnOriginId ? { turnOriginId } : {}),
+        ...(turnSource ? { turnSource } : {}),
       };
     }
 

--- a/packages/agent-server/src/externalAgents.test.ts
+++ b/packages/agent-server/src/externalAgents.test.ts
@@ -64,6 +64,18 @@ describe('externalAgents helpers', () => {
   });
 });
 
+it('carries scheduled wake source without fabricating a device origin', () => {
+  const url = new URL(
+    buildExternalCallbackUrl({
+      callbackBaseUrl: 'http://example.test/api',
+      sessionId: 'EXTERNAL-1',
+      turnSource: 'scheduled_wakeup',
+    }),
+  );
+  expect(url.searchParams.get('turnSource')).toBe('scheduled_wakeup');
+  expect(url.searchParams.has('turnOriginId')).toBe(false);
+});
+
 describe('ws external forwarding', () => {
   it('forwards user text to external inputUrl with callbackUrl', async () => {
     const response = new Response('ok', { status: 200 });

--- a/packages/agent-server/src/externalAgents.ts
+++ b/packages/agent-server/src/externalAgents.ts
@@ -4,8 +4,9 @@ export function buildExternalCallbackUrl(options: {
   callbackBaseUrl: string;
   sessionId: string;
   turnOriginId?: string;
+  turnSource?: 'scheduled_wakeup';
 }): string {
-  const { callbackBaseUrl, sessionId, turnOriginId } = options;
+  const { callbackBaseUrl, sessionId, turnOriginId, turnSource } = options;
   const url = new URL(callbackBaseUrl);
 
   const basePath = url.pathname.endsWith('/') ? url.pathname : `${url.pathname}/`;
@@ -15,6 +16,9 @@ export function buildExternalCallbackUrl(options: {
   url.pathname = joined;
   if (turnOriginId) {
     url.searchParams.set('turnOriginId', turnOriginId);
+  }
+  if (turnSource) {
+    url.searchParams.set('turnSource', turnSource);
   }
   return url.toString();
 }

--- a/packages/agent-server/src/http/routes/external.ts
+++ b/packages/agent-server/src/http/routes/external.ts
@@ -57,6 +57,10 @@ export const handleExternalRoutes: HttpRouteHandler = async (
 
     const responseId = createExternalResponseId();
     const turnOriginId = url.searchParams.get('turnOriginId')?.trim() || undefined;
+    const turnSource =
+      url.searchParams.get('turnSource') === 'scheduled_wakeup'
+        ? ('scheduled_wakeup' as const)
+        : undefined;
 
     let notificationSummary = summary;
     try {
@@ -91,7 +95,11 @@ export const handleExternalRoutes: HttpRouteHandler = async (
           responseId,
         }),
         type: 'assistant_done',
-        payload: { text, ...(turnOriginId ? { turnOriginId } : {}) },
+        payload: {
+          text,
+          ...(turnOriginId ? { turnOriginId } : {}),
+          ...(turnSource ? { turnSource } : {}),
+        },
       },
     ];
     await appendAndBroadcastChatEvents(
@@ -109,6 +117,7 @@ export const handleExternalRoutes: HttpRouteHandler = async (
       sessionHub: context.sessionHub,
       summary: notificationSummary,
       ...(turnOriginId ? { turnOriginId } : {}),
+      ...(turnSource ? { turnSource } : {}),
     });
 
     res.statusCode = 200;

--- a/packages/agent-server/src/httpExternalAgents.test.ts
+++ b/packages/agent-server/src/httpExternalAgents.test.ts
@@ -408,7 +408,7 @@ describe('external agents HTTP endpoints', () => {
       method: 'POST',
       hostname: '127.0.0.1',
       port,
-      path: '/external/sessions/EXTERNAL-REUSE/messages?turnOriginId=android-process-1',
+      path: '/external/sessions/EXTERNAL-REUSE/messages?turnOriginId=android-process-1&turnSource=scheduled_wakeup',
       headers: { 'Content-Type': 'text/plain' },
       body: 'Hello *world*',
     });
@@ -421,7 +421,7 @@ describe('external agents HTTP endpoints', () => {
         event.type === 'assistant_done' &&
         (event as { payload?: { text?: string } }).payload?.text === 'Hello *world*',
     );
-    expect(assistantDone).toBeTruthy();
+    expect(assistantDone).toMatchObject({ payload: { turnSource: 'scheduled_wakeup' } });
     expect(
       assistantDone?.type === 'assistant_done' ? assistantDone.payload.turnOriginId : undefined,
     ).toBe('android-process-1');
@@ -433,6 +433,7 @@ describe('external agents HTTP endpoints', () => {
       source: 'system',
       sourceEventId: expect.any(String),
       turnOriginId: 'android-process-1',
+      turnSource: 'scheduled_wakeup',
     });
 
     const broadcastMessages = sessionHub.broadcasts

--- a/packages/agent-server/src/notificationProducers.test.ts
+++ b/packages/agent-server/src/notificationProducers.test.ts
@@ -35,7 +35,12 @@ describe('notification producers', () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  it('publishes final responses as session attention singleton notifications', async () => {
+  const turnMetadataCases = [
+    { turnOriginId: 'android-process-1' },
+    { turnSource: 'scheduled_wakeup' as const },
+  ];
+
+  it.each(turnMetadataCases)('publishes final notification metadata %j', async (turnMetadata) => {
     const sessionHub = {
       broadcastToAll: vi.fn(),
     } as any;
@@ -47,7 +52,7 @@ describe('notification producers', () => {
       sessionHub,
       sessionIndex,
       summary: { revision: 6 } as any,
-      turnOriginId: 'android-process-1',
+      ...turnMetadata,
     });
 
     const { notifications } = await getNotificationsStore().list();
@@ -61,7 +66,7 @@ describe('notification producers', () => {
       sourceEventId: 'response-1',
       sessionActivitySeq: 6,
       sessionTitle: 'Demo session',
-      turnOriginId: 'android-process-1',
+      ...turnMetadata,
     });
     expect(sessionHub.broadcastToAll).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/agent-server/src/notificationProducers.ts
+++ b/packages/agent-server/src/notificationProducers.ts
@@ -17,6 +17,7 @@ export async function publishFinalResponseNotification(options: {
   sessionIndex?: ToolContext['sessionIndex'];
   summary?: Pick<SessionSummary, 'revision'> | null;
   turnOriginId?: string;
+  turnSource?: 'scheduled_wakeup';
 }): Promise<void> {
   if (!options.text.trim()) {
     return;
@@ -41,6 +42,7 @@ export async function publishFinalResponseNotification(options: {
           ? { sessionActivitySeq: getSessionActivitySeq(options.summary) }
           : {}),
         ...(options.turnOriginId ? { turnOriginId: options.turnOriginId } : {}),
+        ...(options.turnSource ? { turnSource: options.turnSource } : {}),
       },
       source: 'system',
       ...(options.sessionHub ? { sessionHub: options.sessionHub } : {}),

--- a/packages/agent-server/src/scheduledSessions/scheduledSessionService.test.ts
+++ b/packages/agent-server/src/scheduledSessions/scheduledSessionService.test.ts
@@ -1261,6 +1261,7 @@ describe('ScheduledSessionService', () => {
         input: expect.objectContaining({
           sessionId: 'session-1',
           content: 'Check the issue',
+          turnSource: 'scheduled_wakeup',
           mode: 'sync',
         }),
       }),
@@ -1374,6 +1375,7 @@ describe('ScheduledSessionService', () => {
         input: expect.objectContaining({
           sessionId: 'session-1',
           content: 'Check the issue',
+          turnSource: 'scheduled_wakeup',
         }),
       }),
     );

--- a/packages/agent-server/src/scheduledSessions/scheduledSessionService.ts
+++ b/packages/agent-server/src/scheduledSessions/scheduledSessionService.ts
@@ -1321,6 +1321,7 @@ export class ScheduledSessionService {
         sessionId: wakeup.sessionId,
         content: wakeup.message,
         mode: 'sync',
+        turnSource: 'scheduled_wakeup',
         timeoutSeconds,
       },
       sessionIndex,

--- a/packages/agent-server/src/sessionHub.ts
+++ b/packages/agent-server/src/sessionHub.ts
@@ -83,6 +83,7 @@ export interface LogicalSessionState {
          * Used by that client to admit only its own automatic voice responses.
          */
         turnOriginId?: string;
+        turnSource?: 'scheduled_wakeup';
         responseId: string;
         abortController: AbortController;
         ttsSession?: TtsStreamingSession;

--- a/packages/agent-server/src/sessionMessages.test.ts
+++ b/packages/agent-server/src/sessionMessages.test.ts
@@ -112,7 +112,12 @@ describe('startSessionMessage', () => {
     expect(capturedSignal?.reason).toBe('timeout');
   });
 
-  it('passes scheduled session and search services into agent tool exposure for headless messages', async () => {
+  const turnMetadataCases = [
+    { turnOriginId: 'android-process-1' },
+    { turnSource: 'scheduled_wakeup' as const },
+  ];
+
+  it.each(turnMetadataCases)('passes headless context and metadata %j', async (turnMetadata) => {
     const summary: SessionSummary = {
       sessionId: 'session-1',
       name: 'Session 1',
@@ -176,7 +181,7 @@ describe('startSessionMessage', () => {
         content: 'hello',
         mode: 'sync',
         timeoutSeconds: 1,
-        turnOriginId: 'android-process-1',
+        ...turnMetadata,
       },
       sessionIndex,
       sessionHub,
@@ -210,8 +215,6 @@ describe('startSessionMessage', () => {
     });
 
     expect(resolveAgentToolExposureForHost).toHaveBeenCalledTimes(1);
-    expect(processUserMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ turnOriginId: 'android-process-1' }),
-    );
+    expect(processUserMessage).toHaveBeenCalledWith(expect.objectContaining(turnMetadata));
   });
 });

--- a/packages/agent-server/src/sessionMessages.ts
+++ b/packages/agent-server/src/sessionMessages.ts
@@ -31,6 +31,7 @@ export type SessionMessageInput = {
   inputType?: SessionMessageInputType;
   durationMs?: number;
   turnOriginId?: string;
+  turnSource?: 'scheduled_wakeup';
   webhook?: SessionMessageWebhook;
 };
 
@@ -366,6 +367,7 @@ export async function startSessionMessage(options: {
         state,
         text: content,
         ...(input.turnOriginId ? { turnOriginId: input.turnOriginId } : {}),
+        ...(input.turnSource ? { turnSource: input.turnSource } : {}),
         sessionHub,
         envConfig,
         chatCompletionTools: chatTools,
@@ -448,6 +450,7 @@ export async function startSessionMessage(options: {
         text: content,
         responseId,
         ...(input.turnOriginId ? { turnOriginId: input.turnOriginId } : {}),
+        ...(input.turnSource ? { turnSource: input.turnSource } : {}),
         sessionHub,
         envConfig,
         chatCompletionTools: chatTools,

--- a/packages/agent-server/src/turnSettlement.test.ts
+++ b/packages/agent-server/src/turnSettlement.test.ts
@@ -19,7 +19,12 @@ function createState(overrides: Partial<LogicalSessionState> = {}): LogicalSessi
 }
 
 describe('turn settlement', () => {
-  it('broadcasts a completed tool-only settlement after the run is released', () => {
+  const turnMetadataCases = [
+    { turnOriginId: 'android-process-1' },
+    { turnSource: 'scheduled_wakeup' as const },
+  ];
+
+  it.each(turnMetadataCases)('broadcasts tool-only settlement metadata %j', (turnMetadata) => {
     const broadcast: ServerMessage[] = [];
     const sessionHub = {
       broadcastToSession: (_sessionId: string, message: ServerMessage) => {
@@ -37,7 +42,7 @@ describe('turn settlement', () => {
           responseId: 'response-1',
           status: 'completed',
           hasSpeakableOutput: false,
-          turnOriginId: 'android-process-1',
+          ...turnMetadata,
         },
       }),
     ).toBe(true);
@@ -49,7 +54,7 @@ describe('turn settlement', () => {
         responseId: 'response-1',
         status: 'completed',
         hasSpeakableOutput: false,
-        turnOriginId: 'android-process-1',
+        ...turnMetadata,
       },
     ]);
   });

--- a/packages/agent-server/src/turnSettlement.ts
+++ b/packages/agent-server/src/turnSettlement.ts
@@ -8,6 +8,7 @@ export interface TurnSettlementCandidate {
   status: TurnSettlementStatus;
   hasSpeakableOutput: boolean;
   turnOriginId?: string;
+  turnSource?: 'scheduled_wakeup';
 }
 
 export function hasSpeakableAssistantOutput(events: readonly ChatEvent[]): boolean {
@@ -45,6 +46,7 @@ export function broadcastTurnSettledIfIdle(options: {
     status: candidate.status,
     hasSpeakableOutput: candidate.hasSpeakableOutput,
     ...(candidate.turnOriginId ? { turnOriginId: candidate.turnOriginId } : {}),
+    ...(candidate.turnSource ? { turnSource: candidate.turnSource } : {}),
   };
   sessionHub.broadcastToSession(sessionId, message);
   return true;

--- a/packages/agent-server/src/ws/chatOutputCancelHandling.ts
+++ b/packages/agent-server/src/ws/chatOutputCancelHandling.ts
@@ -136,6 +136,7 @@ export function handleChatOutputCancel(options: HandleChatOutputCancelOptions): 
         text: partialText,
         interrupted: true,
         ...(run.turnOriginId ? { turnOriginId: run.turnOriginId } : {}),
+        ...(run.turnSource ? { turnSource: run.turnSource } : {}),
       },
     });
   }

--- a/packages/mobile-web/README.md
+++ b/packages/mobile-web/README.md
@@ -215,9 +215,9 @@ is still the fastest first pass.
   behind the active local interaction instead of being dropped solely because the runtime was busy.
 - Completed turns also publish an ephemeral `turn_settled` websocket message after the active run
   is released and only when no queued continuation remains. In Response and Manual modes, Android
-  uses a successful local-origin settlement with no final speakable text to start Auto Listen
+  uses a successful local-origin or scheduled wake settlement with no final speakable text to start Auto Listen
   without manufacturing an empty assistant response. A same-request `voice_ask` or
-  `interaction_end`, a server-origin turn, an interrupted/error result, or a subsequent
+  `interaction_end`, a server-origin turn other than a scheduled wake, an interrupted/error result, or a subsequent
   `turn_start` suppresses that automatic listen.
 - Final assistant replies are persisted as one durable `session_attention` item per session, while
   `voice_speak` and `voice_ask` remain append-only notifications with explicit `voiceMode`
@@ -227,8 +227,13 @@ is still the fastest first pass.
   Typed and spoken turns submitted from first-party Android and browser clients carry an ephemeral
   origin identifier. Automatic final-response TTS and Auto Listen run for matching Android-origin
   replies, while replies with another client origin are ignored. Server-initiated replies without
-  an origin, including scheduled wake responses, may play on every eligible Android device but
-  never start recognition afterward. Restarting the app intentionally invalidates in-flight
+  an origin may play on every eligible Android device. One-shot scheduled wake responses respect
+  Auto Listen: Response mode speaks then listens, while Manual mode listens without automatic
+  speech. With Auto Listen off, scheduled wakes do not start recognition. Other originless replies,
+  including recurring cron sessions, never start recognition afterward. Scheduled wakes have no
+  device ownership, so every connected eligible Android device applies its own settings, including
+  the notification-session filter. This behavior requires the updated backend and Android app;
+  no separate wake setting or voice tool is needed. Restarting the app intentionally invalidates in-flight
   ownership. This filter does not affect external notifications, `voice_speak`, `voice_ask`, or
   manual `Play` / microphone actions, and it can be disabled to restore response behavior for turns
   started elsewhere.

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceEventParser.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceEventParser.java
@@ -30,6 +30,7 @@ final class AssistantVoiceEventParser {
                 "",
                 "turn_start",
                 "",
+                "",
                 ""
             );
         }
@@ -44,6 +45,7 @@ final class AssistantVoiceEventParser {
                     requestId,
                     toolCallId,
                     toolName,
+                    "",
                     "",
                     ""
                 );
@@ -64,6 +66,7 @@ final class AssistantVoiceEventParser {
                 toolCallId,
                 toolName,
                 text,
+                "",
                 ""
             );
         }
@@ -81,7 +84,8 @@ final class AssistantVoiceEventParser {
                     responseId,
                     "assistant_response",
                     text,
-                    turnOriginId
+                    turnOriginId,
+                    trim(findStringField(payloadJson, "turnSource", 0))
                 );
             }
         }

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceInteractionRules.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceInteractionRules.java
@@ -37,8 +37,11 @@ final class AssistantVoiceInteractionRules {
         return response.isEmpty() || (!local.isEmpty() && local.equals(response));
     }
 
-    static boolean shouldSuppressAutoListenForAutomaticResponse(String responseTurnOriginId) {
-        return trim(responseTurnOriginId).isEmpty();
+    static boolean shouldSuppressAutoListenForAutomaticResponse(
+        String responseTurnOriginId,
+        String turnSource
+    ) {
+        return trim(responseTurnOriginId).isEmpty() && !"scheduled_wakeup".equals(trim(turnSource));
     }
 
     static boolean shouldAutoListenForSettledTurn(
@@ -55,7 +58,7 @@ final class AssistantVoiceInteractionRules {
             && !event.hasSpeakableOutput
             && !interactionEnded
             && !voiceAskStarted
-            && !shouldSuppressAutoListenForAutomaticResponse(event.turnOriginId)
+            && !shouldSuppressAutoListenForAutomaticResponse(event.turnOriginId, event.turnSource)
             && shouldAdmitAutomaticResponse(
                 localResponseVoiceOnlyEnabled,
                 localTurnOriginId,

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceNotificationEventParser.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceNotificationEventParser.java
@@ -113,7 +113,8 @@ final class AssistantVoiceNotificationEventParser {
             optTrimmedString(object, "ttsText", ""),
             optTrimmedString(object, "sourceEventId", ""),
             sessionActivitySeq,
-            optTrimmedString(object, "turnOriginId", "")
+            optTrimmedString(object, "turnOriginId", ""),
+            optTrimmedString(object, "turnSource", "")
         );
     }
 

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceNotificationRecord.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceNotificationRecord.java
@@ -14,6 +14,7 @@ final class AssistantVoiceNotificationRecord {
     final String sourceEventId;
     final Integer sessionActivitySeq;
     final String turnOriginId;
+    final String turnSource;
 
     AssistantVoiceNotificationRecord(
         String id,
@@ -28,7 +29,8 @@ final class AssistantVoiceNotificationRecord {
         String ttsText,
         String sourceEventId,
         Integer sessionActivitySeq,
-        String turnOriginId
+        String turnOriginId,
+        String turnSource
     ) {
         this.id = trim(id);
         this.kind = trim(kind);
@@ -43,6 +45,7 @@ final class AssistantVoiceNotificationRecord {
         this.sourceEventId = trim(sourceEventId);
         this.sessionActivitySeq = sessionActivitySeq;
         this.turnOriginId = trim(turnOriginId);
+        this.turnSource = trim(turnSource);
     }
 
     boolean isUnread() {

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoicePlugin.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoicePlugin.java
@@ -581,7 +581,8 @@ public final class AssistantVoicePlugin extends Plugin {
             optTrimmedString(notification, "ttsText", null),
             optTrimmedString(notification, "sourceEventId", null),
             sessionActivitySeq,
-            optTrimmedString(notification, "turnOriginId", null)
+            optTrimmedString(notification, "turnOriginId", null),
+            optTrimmedString(notification, "turnSource", null)
         );
     }
 

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoicePromptEvent.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoicePromptEvent.java
@@ -8,6 +8,7 @@ final class AssistantVoicePromptEvent {
     final String toolName;
     final String text;
     final String turnOriginId;
+    final String turnSource;
 
     AssistantVoicePromptEvent(
         String eventId,
@@ -15,9 +16,10 @@ final class AssistantVoicePromptEvent {
         String toolCallId,
         String toolName,
         String text,
-        String turnOriginId
+        String turnOriginId,
+        String turnSource
     ) {
-        this(eventId, sessionId, "", toolCallId, toolName, text, turnOriginId);
+        this(eventId, sessionId, "", toolCallId, toolName, text, turnOriginId, turnSource);
     }
 
     AssistantVoicePromptEvent(
@@ -27,7 +29,8 @@ final class AssistantVoicePromptEvent {
         String toolCallId,
         String toolName,
         String text,
-        String turnOriginId
+        String turnOriginId,
+        String turnSource
     ) {
         this.eventId = eventId;
         this.sessionId = sessionId;
@@ -36,6 +39,7 @@ final class AssistantVoicePromptEvent {
         this.toolName = toolName;
         this.text = text;
         this.turnOriginId = trim(turnOriginId);
+        this.turnSource = trim(turnSource);
     }
 
     boolean isToolPrompt() {

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceRuntimeService.java
@@ -101,6 +101,7 @@ public final class AssistantVoiceRuntimeService extends Service {
     static final String EXTRA_NOTIFICATION_TTS_TEXT = "notificationTtsText";
     static final String EXTRA_NOTIFICATION_SOURCE_EVENT_ID = "notificationSourceEventId";
     static final String EXTRA_NOTIFICATION_SESSION_ACTIVITY_SEQ = "notificationSessionActivitySeq";
+    static final String EXTRA_NOTIFICATION_TURN_SOURCE = "notificationTurnSource";
     static final String EXTRA_NOTIFICATION_TURN_ORIGIN_ID = "notificationTurnOriginId";
 
     static final String BROADCAST_STATE_CHANGED = "com.assistant.mobile.voice.STATE_CHANGED";
@@ -335,6 +336,7 @@ public final class AssistantVoiceRuntimeService extends Service {
         intent.putExtra(EXTRA_NOTIFICATION_TTS_TEXT, notification.ttsText);
         intent.putExtra(EXTRA_NOTIFICATION_SOURCE_EVENT_ID, notification.sourceEventId);
         intent.putExtra(EXTRA_NOTIFICATION_TURN_ORIGIN_ID, notification.turnOriginId);
+        intent.putExtra(EXTRA_NOTIFICATION_TURN_SOURCE, notification.turnSource);
         if (notification.sessionActivitySeq != null) {
             intent.putExtra(EXTRA_NOTIFICATION_SESSION_ACTIVITY_SEQ, notification.sessionActivitySeq);
         }
@@ -2028,7 +2030,8 @@ public final class AssistantVoiceRuntimeService extends Service {
             interactionEnded
                 || voiceAskStarted
                 || AssistantVoiceInteractionRules.shouldSuppressAutoListenForAutomaticResponse(
-                    prompt.turnOriginId
+                    prompt.turnOriginId,
+                    prompt.turnSource
                 );
         boolean admitted = AssistantVoiceInteractionRules.shouldAdmitAutomaticResponse(
             localResponseVoiceOnlyEnabled,
@@ -2273,7 +2276,8 @@ public final class AssistantVoiceRuntimeService extends Service {
             notification != null
                 && notification.isAssistantResponseNotification()
                 && AssistantVoiceInteractionRules.shouldSuppressAutoListenForAutomaticResponse(
-                    notification.turnOriginId
+                    notification.turnOriginId,
+                    notification.turnSource
                 );
         boolean autoListenForNotification = config.autoListenEnabled && !suppressAutoListen;
         boolean shouldAutoplayNotification =
@@ -4128,7 +4132,8 @@ public final class AssistantVoiceRuntimeService extends Service {
             intent.getStringExtra(EXTRA_NOTIFICATION_TTS_TEXT),
             intent.getStringExtra(EXTRA_NOTIFICATION_SOURCE_EVENT_ID),
             sessionActivitySeq,
-            intent.getStringExtra(EXTRA_NOTIFICATION_TURN_ORIGIN_ID)
+            intent.getStringExtra(EXTRA_NOTIFICATION_TURN_ORIGIN_ID),
+            intent.getStringExtra(EXTRA_NOTIFICATION_TURN_SOURCE)
         );
     }
 

--- a/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceTurnSettledEvent.java
+++ b/packages/mobile-web/android/app/src/main/java/com/assistant/mobile/voice/AssistantVoiceTurnSettledEvent.java
@@ -9,6 +9,7 @@ final class AssistantVoiceTurnSettledEvent {
     final String status;
     final boolean hasSpeakableOutput;
     final String turnOriginId;
+    final String turnSource;
 
     AssistantVoiceTurnSettledEvent(
         String sessionId,
@@ -16,7 +17,8 @@ final class AssistantVoiceTurnSettledEvent {
         String responseId,
         String status,
         boolean hasSpeakableOutput,
-        String turnOriginId
+        String turnOriginId,
+        String turnSource
     ) {
         this.sessionId = trim(sessionId);
         this.requestId = trim(requestId);
@@ -24,6 +26,7 @@ final class AssistantVoiceTurnSettledEvent {
         this.status = trim(status);
         this.hasSpeakableOutput = hasSpeakableOutput;
         this.turnOriginId = trim(turnOriginId);
+        this.turnSource = trim(turnSource);
     }
 
     static AssistantVoiceTurnSettledEvent parse(String rawMessage) {
@@ -41,7 +44,8 @@ final class AssistantVoiceTurnSettledEvent {
                 message.optString("responseId"),
                 message.optString("status"),
                 message.optBoolean("hasSpeakableOutput", false),
-                message.optString("turnOriginId")
+                message.optString("turnOriginId"),
+                message.optString("turnSource")
             );
             if (
                 event.sessionId.isEmpty()

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceInteractionRulesTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceInteractionRulesTest.java
@@ -38,16 +38,17 @@ public final class AssistantVoiceInteractionRulesTest {
     }
 
     @Test
-    public void unownedResponsesAlwaysSuppressAutoListen() {
+    public void ordinaryUnownedResponsesSuppressAutoListen() {
         assertTrue(
-            AssistantVoiceInteractionRules.shouldSuppressAutoListenForAutomaticResponse("")
+            AssistantVoiceInteractionRules.shouldSuppressAutoListenForAutomaticResponse("", "")
         );
         assertTrue(
-            AssistantVoiceInteractionRules.shouldSuppressAutoListenForAutomaticResponse("   ")
+            AssistantVoiceInteractionRules.shouldSuppressAutoListenForAutomaticResponse("   ", "")
         );
         assertFalse(
             AssistantVoiceInteractionRules.shouldSuppressAutoListenForAutomaticResponse(
-                "web-process-1"
+                "web-process-1",
+                ""
             )
         );
     }
@@ -60,7 +61,8 @@ public final class AssistantVoiceInteractionRulesTest {
             "response-1",
             "completed",
             false,
-            "android-process-1"
+            "android-process-1",
+            ""
         );
 
         assertTrue(AssistantVoiceInteractionRules.shouldAutoListenForSettledTurn(
@@ -81,7 +83,8 @@ public final class AssistantVoiceInteractionRulesTest {
             "response-1",
             "completed",
             true,
-            "android-process-1"
+            "android-process-1",
+            ""
         );
         AssistantVoiceTurnSettledEvent server = new AssistantVoiceTurnSettledEvent(
             "session-1",
@@ -89,6 +92,7 @@ public final class AssistantVoiceInteractionRulesTest {
             "response-2",
             "completed",
             false,
+            "",
             ""
         );
         AssistantVoiceTurnSettledEvent toolOnly = new AssistantVoiceTurnSettledEvent(
@@ -97,7 +101,8 @@ public final class AssistantVoiceInteractionRulesTest {
             "response-3",
             "completed",
             false,
-            "android-process-1"
+            "android-process-1",
+            ""
         );
 
         assertFalse(AssistantVoiceInteractionRules.shouldAutoListenForSettledTurn(
@@ -130,7 +135,8 @@ public final class AssistantVoiceInteractionRulesTest {
                 "",
                 "event-1",
                 1,
-                "android-process-1"
+                "android-process-1",
+                ""
             );
         AssistantVoiceNotificationRecord externalNotification =
             new AssistantVoiceNotificationRecord(
@@ -146,6 +152,7 @@ public final class AssistantVoiceInteractionRulesTest {
                 "",
                 "",
                 null,
+                "",
                 ""
             );
         AssistantVoiceNotificationRecord toolSessionAttention =
@@ -162,6 +169,7 @@ public final class AssistantVoiceInteractionRulesTest {
                 "",
                 "event-2",
                 2,
+                "",
                 ""
             );
         AssistantVoiceNotificationRecord serverResponseNotification =
@@ -178,6 +186,7 @@ public final class AssistantVoiceInteractionRulesTest {
                 "",
                 "event-3",
                 3,
+                "",
                 ""
             );
 
@@ -219,6 +228,7 @@ public final class AssistantVoiceInteractionRulesTest {
             "call-1",
             "voice_ask",
             "Question?",
+            "",
             ""
         );
         AssistantVoicePromptEvent assistantResponse = new AssistantVoicePromptEvent(
@@ -227,6 +237,7 @@ public final class AssistantVoiceInteractionRulesTest {
             "",
             "assistant_response",
             "Answer",
+            "",
             ""
         );
 
@@ -260,6 +271,7 @@ public final class AssistantVoiceInteractionRulesTest {
             "call-1",
             "voice_ask",
             "Question?",
+            "",
             ""
         );
         AssistantVoicePromptEvent assistantResponse = new AssistantVoicePromptEvent(
@@ -268,6 +280,7 @@ public final class AssistantVoiceInteractionRulesTest {
             "",
             "assistant_response",
             "Answer",
+            "",
             ""
         );
 
@@ -298,6 +311,7 @@ public final class AssistantVoiceInteractionRulesTest {
             "",
             "event-1",
             4,
+            "",
             ""
         );
         AssistantVoiceNotificationRecord toolNotification = new AssistantVoiceNotificationRecord(
@@ -313,6 +327,7 @@ public final class AssistantVoiceInteractionRulesTest {
             "",
             "event-2",
             5,
+            "",
             ""
         );
 
@@ -397,6 +412,7 @@ public final class AssistantVoiceInteractionRulesTest {
             "response-1",
             "assistant_response",
             "Answer",
+            "",
             ""
         );
         AssistantVoicePromptEvent toolPrompt = new AssistantVoicePromptEvent(
@@ -405,6 +421,7 @@ public final class AssistantVoiceInteractionRulesTest {
             "call-1",
             "voice_ask",
             "Question?",
+            "",
             ""
         );
 
@@ -455,6 +472,7 @@ public final class AssistantVoiceInteractionRulesTest {
             "",
             "event-1",
             4,
+            "",
             ""
         );
         AssistantVoiceNotificationRecord readResponseNotification = new AssistantVoiceNotificationRecord(
@@ -470,6 +488,7 @@ public final class AssistantVoiceInteractionRulesTest {
             "",
             "event-2",
             5,
+            "",
             ""
         );
         AssistantVoiceNotificationRecord sessionlessNotification = new AssistantVoiceNotificationRecord(
@@ -485,6 +504,7 @@ public final class AssistantVoiceInteractionRulesTest {
             "",
             "event-3",
             null,
+            "",
             ""
         );
 
@@ -530,6 +550,7 @@ public final class AssistantVoiceInteractionRulesTest {
             "",
             "event-1",
             4,
+            "",
             ""
         );
         AssistantVoiceNotificationRecord toolNotification = new AssistantVoiceNotificationRecord(
@@ -545,6 +566,7 @@ public final class AssistantVoiceInteractionRulesTest {
             "",
             "event-2",
             5,
+            "",
             ""
         );
         AssistantVoiceNotificationRecord readToolNotification = new AssistantVoiceNotificationRecord(
@@ -560,6 +582,7 @@ public final class AssistantVoiceInteractionRulesTest {
             "",
             "event-3",
             6,
+            "",
             ""
         );
 

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceQueueItemTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceQueueItemTest.java
@@ -16,6 +16,7 @@ public final class AssistantVoiceQueueItemTest {
             "call-1",
             "voice_ask",
             "Question?",
+            "",
             ""
         );
 
@@ -41,6 +42,7 @@ public final class AssistantVoiceQueueItemTest {
             "response-2",
             "assistant_response",
             "Answer",
+            "",
             ""
         );
 
@@ -60,7 +62,7 @@ public final class AssistantVoiceQueueItemTest {
     public void fromPromptReturnsNullWithoutSessionOrSpeech() {
         assertNull(
             AssistantVoiceQueueItem.fromPrompt(
-                new AssistantVoicePromptEvent("event-3", "", "", "voice_speak", "Hello", ""),
+                new AssistantVoicePromptEvent("event-3", "", "", "voice_speak", "Hello", "", ""),
                 true,
                 false,
                 ""
@@ -68,7 +70,7 @@ public final class AssistantVoiceQueueItemTest {
         );
         assertNull(
             AssistantVoiceQueueItem.fromPrompt(
-                new AssistantVoicePromptEvent("event-4", "session-4", "", "voice_speak", " ", ""),
+                new AssistantVoicePromptEvent("event-4", "session-4", "", "voice_speak", " ", "", ""),
                 true,
                 false,
                 ""
@@ -84,6 +86,7 @@ public final class AssistantVoiceQueueItemTest {
             "response-5",
             "assistant_response",
             "Answer",
+            "",
             ""
         );
 
@@ -107,6 +110,7 @@ public final class AssistantVoiceQueueItemTest {
             "call-6",
             "voice_ask",
             "Question?",
+            "",
             ""
         );
 
@@ -129,6 +133,7 @@ public final class AssistantVoiceQueueItemTest {
             "response-7",
             "assistant_response",
             "Answer",
+            "",
             ""
         );
 
@@ -158,6 +163,7 @@ public final class AssistantVoiceQueueItemTest {
                 "call-8",
                 "voice_ask",
                 "Question?",
+                "",
                 ""
             ),
             "Session 8"
@@ -173,7 +179,8 @@ public final class AssistantVoiceQueueItemTest {
                 "response-1",
                 "completed",
                 false,
-                "android-process-1"
+                "android-process-1",
+                ""
             ),
             "Session 1"
         );
@@ -194,7 +201,8 @@ public final class AssistantVoiceQueueItemTest {
                 "response-1",
                 "completed",
                 true,
-                "android-process-1"
+                "android-process-1",
+                ""
             ),
             "Session 1"
         ));
@@ -215,6 +223,7 @@ public final class AssistantVoiceQueueItemTest {
             "Reply body",
             "event-1",
             Integer.valueOf(7),
+            "",
             ""
         );
 
@@ -242,6 +251,7 @@ public final class AssistantVoiceQueueItemTest {
             "Reply body",
             "response-auto",
             Integer.valueOf(9),
+            "",
             ""
         );
 
@@ -274,6 +284,7 @@ public final class AssistantVoiceQueueItemTest {
             "Alternate speech",
             "event-tool",
             null,
+            "",
             ""
         );
 
@@ -304,6 +315,7 @@ public final class AssistantVoiceQueueItemTest {
             "Speak me",
             "event-2",
             Integer.valueOf(3),
+            "",
             ""
         );
 

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRuntimeServiceTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceRuntimeServiceTest.java
@@ -37,6 +37,48 @@ import static org.junit.Assert.assertFalse;
 public final class AssistantVoiceRuntimeServiceTest {
     @Test
     @Config(sdk = Build.VERSION_CODES.N)
+    public void scheduledWakeDurableQueueHonorsAudioModeAutoListenAndSessionFilter() throws Exception {
+        for (String mode : new String[] {"response", "manual"}) {
+            for (boolean enabled : new boolean[] {false, true}) {
+                for (boolean preferredSessionOnly : new boolean[] {false, true}) {
+                    AssistantVoiceRuntimeService service = new AssistantVoiceRuntimeService();
+                    setRuntimeConfig(service, createConfig(mode, Collections.emptyMap()).withVoiceSettings(
+                        new org.json.JSONObject()
+                            .put("autoListenEnabled", enabled)
+                            .put("ttsPreferredSessionOnly", preferredSessionOnly)
+                            .put("preferredVoiceSessionId", "other-session")
+                    ));
+                    setPrivateField(service, "adapterSocketConnected", true);
+                    setPrivateField(service, "assistantSocketConnected", true);
+                    // Keep admitted items queued so this test doesn't start actual audio/recognition.
+                    setPrivateField(service, "pendingRecognitionSubmitSessionId", "busy-session");
+                    AssistantVoiceNotificationRecord notification = new AssistantVoiceNotificationRecord(
+                        "wake-1", "session_attention", "system", "Wake", "Time to check in",
+                        "", "session-1", "", "speak_then_listen", "", "response-1",
+                        null, "", "scheduled_wakeup"
+                    );
+                    Method enqueue = AssistantVoiceRuntimeService.class.getDeclaredMethod(
+                        "enqueueAutomaticNotification", AssistantVoiceNotificationRecord.class
+                    );
+                    enqueue.setAccessible(true);
+                    enqueue.invoke(service, notification);
+                    List<AssistantVoiceQueueItem> queue = getQueuedVoiceItems(service);
+                    if (preferredSessionOnly || ("manual".equals(mode) && !enabled)) {
+                        assertTrue(queue.isEmpty());
+                    } else {
+                        assertEquals(1, queue.size());
+                        assertEquals("manual".equals(mode), queue.get(0).isListenOnly());
+                        if ("response".equals(mode)) {
+                            assertEquals(enabled, queue.get(0).startsListeningAfterPlayback());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.N)
     public void foreignResponseConsumesInteractionEndBeforeOriginRejection() {
         AssistantVoiceRequestTracker tracker = new AssistantVoiceRequestTracker(4);
         tracker.remember("session-1", "request-1");
@@ -47,7 +89,8 @@ public final class AssistantVoiceRuntimeServiceTest {
             "response-1",
             "assistant_response",
             "Answer",
-            "other-device"
+            "other-device",
+            ""
         );
 
         AssistantVoiceRuntimeService.AssistantResponseAdmission admission =
@@ -74,6 +117,7 @@ public final class AssistantVoiceRuntimeServiceTest {
             "response-1",
             "assistant_response",
             "Scheduled reminder",
+            "",
             ""
         );
 
@@ -102,7 +146,8 @@ public final class AssistantVoiceRuntimeServiceTest {
             "response-1",
             "assistant_response",
             "Answer",
-            "this-device"
+            "this-device",
+            ""
         );
 
         AssistantVoiceRuntimeService.AssistantResponseAdmission admission =
@@ -129,6 +174,7 @@ public final class AssistantVoiceRuntimeServiceTest {
                 "response-prompt",
                 "assistant_response",
                 "Answer",
+                "",
                 ""
             ),
             "Session 1"
@@ -146,6 +192,7 @@ public final class AssistantVoiceRuntimeServiceTest {
             "Answer",
             "different-source-event",
             Integer.valueOf(7),
+            "",
             ""
         ).toManualAutoListenQueueItem("Session 1");
         AssistantVoiceQueueItem otherSessionItem = AssistantVoiceQueueItem.fromManualAutoListenPrompt(
@@ -155,6 +202,7 @@ public final class AssistantVoiceRuntimeServiceTest {
                 "response-other",
                 "assistant_response",
                 "Answer",
+                "",
                 ""
             ),
             "Session 2"
@@ -172,6 +220,7 @@ public final class AssistantVoiceRuntimeServiceTest {
             "Answer",
             "response-2",
             Integer.valueOf(8),
+            "",
             ""
         ).toManualMicQueueItem();
 
@@ -209,6 +258,7 @@ public final class AssistantVoiceRuntimeServiceTest {
             "Answer",
             "response-1",
             Integer.valueOf(7),
+            "",
             ""
         ).toManualAutoListenQueueItem("Session 1");
 
@@ -531,6 +581,7 @@ public final class AssistantVoiceRuntimeServiceTest {
             "Alternate speech",
             "event-tool",
             null,
+            "",
             ""
         );
 
@@ -578,6 +629,7 @@ public final class AssistantVoiceRuntimeServiceTest {
             "Reply body",
             "event-1",
             Integer.valueOf(4),
+            "",
             ""
         );
 
@@ -617,6 +669,7 @@ public final class AssistantVoiceRuntimeServiceTest {
             "Reply body",
             "event-1",
             Integer.valueOf(4),
+            "",
             ""
         );
 
@@ -648,6 +701,7 @@ public final class AssistantVoiceRuntimeServiceTest {
             "Reply body",
             "event-1",
             Integer.valueOf(4),
+            "",
             ""
         );
 

--- a/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceScheduledWakeTest.java
+++ b/packages/mobile-web/android/app/src/test/java/com/assistant/mobile/voice/AssistantVoiceScheduledWakeTest.java
@@ -1,0 +1,155 @@
+package com.assistant.mobile.voice;
+
+import android.content.Intent;
+import android.os.Build;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = Build.VERSION_CODES.N)
+public final class AssistantVoiceScheduledWakeTest {
+    private AssistantVoicePromptEvent wakePrompt() {
+        return AssistantVoiceSessionSocketProtocol.parsePlaybackMessage(
+            "{\"type\":\"transcript_event\",\"event\":{"
+                + "\"eventId\":\"event-1\",\"sessionId\":\"session-1\","
+                + "\"requestId\":\"request-1\",\"responseId\":\"response-1\","
+                + "\"chatEventType\":\"assistant_done\",\"payload\":{"
+                + "\"phase\":\"final_answer\",\"text\":\"Time to check in\","
+                + "\"turnSource\":\"scheduled_wakeup\"}}}"
+        );
+    }
+
+    private AssistantVoiceNotificationRecord wakeNotification() {
+        return AssistantVoiceNotificationEventParser.parseListResponse(
+            "{\"result\":{\"notifications\":[{"
+                + "\"id\":\"notification-1\",\"sessionId\":\"session-1\","
+                + "\"kind\":\"session_attention\",\"source\":\"system\","
+                + "\"title\":\"Wake\",\"body\":\"Time to check in\","
+                + "\"voiceMode\":\"speak_then_listen\","
+                + "\"turnSource\":\"scheduled_wakeup\"}]}}"
+        ).get(0);
+    }
+
+    @Test
+    public void wakeResponseUsesExistingResponseAndManualAutoListenSettings() {
+        AssistantVoicePromptEvent prompt = wakePrompt();
+        assertNotNull(prompt);
+        assertEquals("scheduled_wakeup", prompt.turnSource);
+        assertEquals("", prompt.turnOriginId);
+        AssistantVoiceRuntimeService.AssistantResponseAdmission admission =
+            AssistantVoiceRuntimeService.evaluateAssistantResponseAdmission(
+                prompt, new AssistantVoiceRequestTracker(4), new AssistantVoiceRequestTracker(4),
+                true, "this-device"
+            );
+        assertTrue(admission.admitted);
+        assertFalse(admission.suppressAutoListen);
+        for (boolean enabled : new boolean[] {false, true}) {
+            boolean autoListen = enabled && !admission.suppressAutoListen;
+            assertTrue(AssistantVoiceInteractionRules.shouldAutoplayEvent(
+                AssistantVoiceConfig.AUDIO_MODE_RESPONSE, prompt, true
+            ));
+            assertEquals(enabled, AssistantVoiceQueueItem.fromPrompt(
+                prompt, autoListen, false, ""
+            ).startsListeningAfterPlayback());
+            assertFalse(AssistantVoiceInteractionRules.shouldAutoplayEvent(
+                AssistantVoiceConfig.AUDIO_MODE_MANUAL, prompt, true
+            ));
+            assertEquals(enabled, AssistantVoiceInteractionRules.shouldAutoListenAfterManualAssistantMessage(
+                AssistantVoiceConfig.AUDIO_MODE_MANUAL, autoListen, prompt, true
+            ));
+        }
+    }
+
+    @Test
+    public void wakeResponseStillHonorsInteractionEndAndVoiceAsk() {
+        for (boolean interactionEnded : new boolean[] {false, true}) {
+            AssistantVoiceRequestTracker interactionEnd = new AssistantVoiceRequestTracker(4);
+            AssistantVoiceRequestTracker voiceAsk = new AssistantVoiceRequestTracker(4);
+            (interactionEnded ? interactionEnd : voiceAsk).remember("session-1", "request-1");
+            assertTrue(AssistantVoiceRuntimeService.evaluateAssistantResponseAdmission(
+                wakePrompt(), interactionEnd, voiceAsk, true, "this-device"
+            ).suppressAutoListen);
+        }
+        assertTrue(AssistantVoiceInteractionRules.shouldSuppressAutoListenForAutomaticResponse("", ""));
+        assertTrue(AssistantVoiceInteractionRules.shouldSuppressAutoListenForAutomaticResponse("", "other"));
+    }
+
+    @Test
+    public void durableWakeNotificationUsesExistingAutoListenSettings() {
+        AssistantVoiceNotificationRecord notification = wakeNotification();
+        assertEquals("scheduled_wakeup", notification.turnSource);
+        assertEquals("", notification.turnOriginId);
+        assertTrue(AssistantVoiceInteractionRules.shouldAdmitAutomaticNotification(
+            true, "this-device", notification
+        ));
+        boolean suppressed = AssistantVoiceInteractionRules.shouldSuppressAutoListenForAutomaticResponse(
+            notification.turnOriginId, notification.turnSource
+        );
+        assertFalse(suppressed);
+        for (boolean enabled : new boolean[] {false, true}) {
+            assertTrue(AssistantVoiceInteractionRules.shouldAutoplayNotification(
+                AssistantVoiceConfig.AUDIO_MODE_RESPONSE, false, notification
+            ));
+            assertEquals(enabled, notification.toAutomaticQueueItem(
+                enabled && !suppressed, false, ""
+            ).startsListeningAfterPlayback());
+            assertFalse(AssistantVoiceInteractionRules.shouldAutoplayNotification(
+                AssistantVoiceConfig.AUDIO_MODE_MANUAL, false, notification
+            ));
+            assertEquals(enabled, AssistantVoiceInteractionRules.shouldAutoListenAfterManualAssistantNotification(
+                AssistantVoiceConfig.AUDIO_MODE_MANUAL, enabled && !suppressed, notification
+            ));
+        }
+    }
+
+    @Test
+    public void notificationActionPreservesWakeSource() throws Exception {
+        Intent intent = AssistantVoiceRuntimeService.notificationDismissIntent(
+            RuntimeEnvironment.getApplication(), wakeNotification()
+        );
+        Method method = AssistantVoiceRuntimeService.class.getDeclaredMethod(
+            "notificationFromIntent", Intent.class
+        );
+        method.setAccessible(true);
+        AssistantVoiceNotificationRecord restored = (AssistantVoiceNotificationRecord) method.invoke(
+            new AssistantVoiceRuntimeService(), intent
+        );
+        assertEquals("scheduled_wakeup", restored.turnSource);
+    }
+
+    @Test
+    public void silentWakeSettlementAutoListensOnlyWhenEnabledAndNotEnded() {
+        AssistantVoiceTurnSettledEvent event = AssistantVoiceTurnSettledEvent.parse(
+            "{\"type\":\"turn_settled\",\"sessionId\":\"session-1\","
+                + "\"requestId\":\"request-1\",\"responseId\":\"response-1\","
+                + "\"status\":\"completed\",\"hasSpeakableOutput\":false,"
+                + "\"turnSource\":\"scheduled_wakeup\"}"
+        );
+        assertNotNull(event);
+        assertEquals("scheduled_wakeup", event.turnSource);
+        assertEquals("", event.turnOriginId);
+        assertTrue(AssistantVoiceInteractionRules.shouldAutoListenForSettledTurn(
+            true, true, "this-device", event, false, false
+        ));
+        assertFalse(AssistantVoiceInteractionRules.shouldAutoListenForSettledTurn(
+            false, true, "this-device", event, false, false
+        ));
+        assertFalse(AssistantVoiceInteractionRules.shouldAutoListenForSettledTurn(
+            true, true, "this-device", event, true, false
+        ));
+        assertFalse(AssistantVoiceInteractionRules.shouldAutoListenForSettledTurn(
+            true, true, "this-device", event, false, true
+        ));
+    }
+}

--- a/packages/plugins/core/notifications/server/service.test.ts
+++ b/packages/plugins/core/notifications/server/service.test.ts
@@ -33,6 +33,7 @@ describe('notifications service', () => {
           ttsText: 'Final answer',
           sourceEventId: 'response-1',
           turnOriginId: 'android-process-1',
+          turnSource: 'scheduled_wakeup',
         },
         source: 'system',
       });
@@ -44,6 +45,7 @@ describe('notifications service', () => {
         sessionId: 'sess-1',
         sourceEventId: 'response-1',
         turnOriginId: 'android-process-1',
+        turnSource: 'scheduled_wakeup',
       });
 
       sourceB.shutdownNotificationsService();

--- a/packages/plugins/core/notifications/server/service.ts
+++ b/packages/plugins/core/notifications/server/service.ts
@@ -201,6 +201,7 @@ export async function createNotificationRecord(options: {
         ...(options.input.sessionActivitySeq !== undefined
           ? { sessionActivitySeq: options.input.sessionActivitySeq }
           : {}),
+        ...(options.input.turnSource ? { turnSource: options.input.turnSource } : {}),
         ...(options.input.turnOriginId !== undefined
           ? { turnOriginId: options.input.turnOriginId }
           : {}),

--- a/packages/plugins/core/notifications/server/store.test.ts
+++ b/packages/plugins/core/notifications/server/store.test.ts
@@ -125,6 +125,32 @@ describe('NotificationsStore', () => {
     });
   });
 
+  it('persists scheduled wake metadata and clears it when an ordinary reply replaces the wake', async () => {
+    const input = { title: 'Wake', body: 'Ready?', sessionId: 'sess-1' };
+    const wake = await store.upsertSessionAttention(
+      { ...input, turnSource: 'scheduled_wakeup' },
+      'system',
+    );
+    const recovered = new NotificationsStore(tempDir);
+    const { notifications } = await recovered.list();
+    expect(notifications[0]).toMatchObject({ id: wake.id, turnSource: 'scheduled_wakeup' });
+
+    const reply = await recovered.upsertSessionAttention(
+      { ...input, body: 'Ordinary reply' },
+      'system',
+    );
+    expect(reply.id).toBe(wake.id);
+    expect(reply.turnSource).toBeUndefined();
+    const reloaded = await new NotificationsStore(tempDir).list();
+    expect(reloaded.notifications[0]?.turnSource).toBeUndefined();
+
+    const nextWake = await recovered.upsertSessionAttention(
+      { ...input, turnSource: 'scheduled_wakeup' },
+      'system',
+    );
+    expect(nextWake).toMatchObject({ id: wake.id, turnSource: 'scheduled_wakeup' });
+  });
+
   it('serializes concurrent session attention upserts for the same session', async () => {
     const [first, second] = await Promise.all([
       store.upsertSessionAttentionWithRevision(

--- a/packages/plugins/core/notifications/server/store.ts
+++ b/packages/plugins/core/notifications/server/store.ts
@@ -88,6 +88,7 @@ function normalizeStoredNotification(value: NotificationRecord): NotificationRec
     sessionActivitySeq: normalizeNullableNumber(
       (value as NotificationRecord & { sessionActivitySeq?: unknown }).sessionActivitySeq,
     ),
+    ...(value.turnSource === 'scheduled_wakeup' ? { turnSource: value.turnSource } : {}),
     turnOriginId: normalizeNullableString(
       (value as NotificationRecord & { turnOriginId?: unknown }).turnOriginId,
     ),
@@ -195,6 +196,7 @@ export class NotificationsStore {
       sourceEventId?: string | null;
       sessionActivitySeq?: number | null;
       turnOriginId?: string | null;
+      turnSource?: 'scheduled_wakeup';
     },
     source: NotificationSource,
   ): Promise<NotificationRecord> {
@@ -215,6 +217,7 @@ export class NotificationsStore {
       sourceEventId?: string | null;
       sessionActivitySeq?: number | null;
       turnOriginId?: string | null;
+      turnSource?: 'scheduled_wakeup';
     },
     source: NotificationSource,
   ): Promise<NotificationMutationResult<NotificationRecord>> {
@@ -238,6 +241,7 @@ export class NotificationsStore {
         sourceEventId: input.sourceEventId ?? null,
         sessionActivitySeq: input.sessionActivitySeq ?? null,
         turnOriginId: input.turnOriginId ?? null,
+        ...(input.turnSource ? { turnSource: input.turnSource } : {}),
       };
 
       this.data.notifications.unshift(record);
@@ -261,6 +265,7 @@ export class NotificationsStore {
       sourceEventId?: string | null;
       sessionActivitySeq?: number | null;
       turnOriginId?: string | null;
+      turnSource?: 'scheduled_wakeup';
     },
     source: NotificationSource,
   ): Promise<NotificationRecord> {
@@ -280,6 +285,7 @@ export class NotificationsStore {
       sourceEventId?: string | null;
       sessionActivitySeq?: number | null;
       turnOriginId?: string | null;
+      turnSource?: 'scheduled_wakeup';
     },
     source: NotificationSource,
   ): Promise<NotificationMutationResult<NotificationRecord>> {
@@ -315,6 +321,7 @@ export class NotificationsStore {
               sourceEventId: input.sourceEventId ?? null,
               sessionActivitySeq: input.sessionActivitySeq ?? null,
               turnOriginId: input.turnOriginId ?? null,
+              ...(input.turnSource ? { turnSource: input.turnSource } : {}),
             }
           : {
               id: crypto.randomUUID(),
@@ -332,7 +339,12 @@ export class NotificationsStore {
               sourceEventId: input.sourceEventId ?? null,
               sessionActivitySeq: input.sessionActivitySeq ?? null,
               turnOriginId: input.turnOriginId ?? null,
+              ...(input.turnSource ? { turnSource: input.turnSource } : {}),
             };
+
+      if (!input.turnSource) {
+        delete record.turnSource;
+      }
 
       if (existingIndex >= 0) {
         this.data.notifications.splice(existingIndex, 1);

--- a/packages/plugins/core/notifications/server/types.ts
+++ b/packages/plugins/core/notifications/server/types.ts
@@ -18,6 +18,7 @@ export interface NotificationRecord {
   sourceEventId: string | null;
   sessionActivitySeq: number | null;
   turnOriginId: string | null;
+  turnSource?: 'scheduled_wakeup';
 }
 
 export interface CreateNotificationInput {
@@ -32,6 +33,7 @@ export interface CreateNotificationInput {
   sourceEventId?: string | null;
   sessionActivitySeq?: number | null;
   turnOriginId?: string | null;
+  turnSource?: 'scheduled_wakeup';
 }
 
 export interface NotificationListOptions {

--- a/packages/plugins/core/notifications/web/index.ts
+++ b/packages/plugins/core/notifications/web/index.ts
@@ -29,6 +29,7 @@ interface NotificationRecord {
   sourceEventId: string | null;
   sessionActivitySeq: number | null;
   turnOriginId: string | null;
+  turnSource?: 'scheduled_wakeup';
 }
 
 type SessionSummary = SessionLabelSummary & {

--- a/packages/shared/src/chatEvents.test.ts
+++ b/packages/shared/src/chatEvents.test.ts
@@ -73,6 +73,7 @@ describe('chat event validation', () => {
         textSignature: '{"v":1,"id":"msg-1","phase":"final_answer"}',
         interrupted: true,
         turnOriginId: 'android-process-1',
+        turnSource: 'scheduled_wakeup',
       },
     };
 
@@ -83,6 +84,7 @@ describe('chat event validation', () => {
       expect(result.data.payload.phase).toBe('final_answer');
       expect(result.data.payload.interrupted).toBe(true);
       expect(result.data.payload.turnOriginId).toBe('android-process-1');
+      expect(result.data.payload.turnSource).toBe('scheduled_wakeup');
     }
   });
 

--- a/packages/shared/src/chatEvents.ts
+++ b/packages/shared/src/chatEvents.ts
@@ -68,6 +68,7 @@ export const AssistantDonePayloadSchema = z.object({
   textSignature: z.string().optional(),
   interrupted: z.boolean().optional(),
   turnOriginId: z.string().trim().min(1).max(128).optional(),
+  turnSource: z.literal('scheduled_wakeup').optional(),
 });
 export type AssistantDonePayload = z.infer<typeof AssistantDonePayloadSchema>;
 

--- a/packages/shared/src/protocol.test.ts
+++ b/packages/shared/src/protocol.test.ts
@@ -313,6 +313,7 @@ describe('server message validation', () => {
       status: 'completed',
       hasSpeakableOutput: false,
       turnOriginId: 'android-process-1',
+      turnSource: 'scheduled_wakeup',
     };
 
     expect(validateServerMessage(message)).toEqual(message);
@@ -419,6 +420,7 @@ describe('server message validation', () => {
         sourceEventId: 'response-1',
         sessionActivitySeq: 12,
         turnOriginId: 'android-process-1',
+        turnSource: 'scheduled_wakeup',
       },
     };
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -746,6 +746,7 @@ export const ServerTurnSettledMessageSchema = z.object({
   status: TurnSettlementStatusSchema,
   hasSpeakableOutput: z.boolean(),
   turnOriginId: z.string().trim().min(1).max(128).optional(),
+  turnSource: z.literal('scheduled_wakeup').optional(),
 });
 
 export const ServerAgentCallbackResultMessageSchema = z.object({
@@ -906,6 +907,7 @@ export const NotificationRecordSchema = z.object({
   sourceEventId: z.string().nullable(),
   sessionActivitySeq: z.number().int().nonnegative().nullable(),
   turnOriginId: z.string().nullable(),
+  turnSource: z.literal('scheduled_wakeup').optional(),
 });
 export type NotificationRecord = z.infer<typeof NotificationRecordSchema>;
 


### PR DESCRIPTION
Scheduled wake replies could play on Android but never rearm recognition, even with Auto-listen enabled. One-shot wakes now carry explicit `turnSource: scheduled_wakeup` metadata through live replies, durable notifications, and turn settlement, allowing Android to apply the existing Auto-listen setting.

Response mode speaks then listens; Manual mode listens without automatic speech. Ordinary originless replies remain suppressed, and session filtering, interaction-end handling, and stale-queue validation still apply. Wakes have no device ownership, so each eligible device applies its own settings. Both the backend and Android app must be updated.

Validation:
- 154 Android voice tests passed, including Response/Manual queue behavior with Auto-listen on/off and session filtering.
- Focused backend/shared and notification persistence tests passed, including queued wakes and clearing wake metadata when an ordinary reply replaces it.
- Full deployment build and staged Android APK build passed; service restart and HTTP health checks passed.
- APK identity, signature, source commit, and HTTP download checksum verified.
- User confirmed scheduled wake auto-rearm works after installing the updated APK.
